### PR TITLE
fix: handle None default in get_safe_redirect_url

### DIFF
--- a/app/security.py
+++ b/app/security.py
@@ -74,7 +74,9 @@ def get_safe_redirect_url(target, default='main.dashboard'):
     """
     if target and is_safe_url(target):
         return target
-    return url_for(default)
+    if default:
+        return url_for(default)
+    return None
 
 
 def validate_password_strength(password):


### PR DESCRIPTION
Fixes #13 - Login results in Internal Server Error

When get_safe_redirect_url is called with default=None, url_for(None) was being called which caused a TypeError. Now we check if default is None before calling url_for, returning None to allow callers to use their own fallback logic.