### PR TITLE
Release v0.8.2 - Fix delete forms, theme toggle, recurring expense bugs

### DIFF
--- a/app/routes/recurring.py
+++ b/app/routes/recurring.py
@@ -103,7 +103,7 @@ def edit(recurring_id):
         recurring.next_due = next_due
         recurring.description = request.form.get('description')
         recurring.auto_create = request.form.get('auto_create') == 'on'
-        recurring.remind_days_before = int(request.form.get('remind_days_before', 7))
+        recurring.notify_before_days = int(request.form.get('remind_days_before', 7))
 
         db.session.commit()
 
@@ -141,11 +141,11 @@ def generate(recurring_id):
         Vehicle.owner_id == current_user.id
     ).first_or_404()
 
-    # Create expense entry
+    # Create expense entry using the recurring expense's due date
     expense = Expense(
         vehicle_id=recurring.vehicle_id,
         user_id=recurring.user_id,
-        date=date.today(),
+        date=recurring.next_due or date.today(),
         category=recurring.category,
         cost=recurring.amount or 0,
         description=f"{recurring.name} (auto-generated)"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -348,8 +348,14 @@
 
     <script>
     function toggleDarkMode() {
-        fetch('/api/toggle-dark-mode', { method: 'POST' })
-            .then(response => response.json())
+        fetch('/api/toggle-dark-mode', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        })
+            .then(response => {
+                if (!response.ok) throw new Error('Toggle failed');
+                return response.json();
+            })
             .then(data => {
                 if (data.dark_mode) {
                     document.documentElement.classList.add('dark');
@@ -358,6 +364,7 @@
                     document.documentElement.classList.remove('dark');
                     localStorage.setItem('may-theme', 'light');
                 }
+                window.location.reload();
             })
             .catch(() => {});
     }

--- a/app/templates/documents/form.html
+++ b/app/templates/documents/form.html
@@ -110,13 +110,9 @@
 
             <div class="flex justify-between pt-4 border-t border-gray-200 dark:border-gray-700">
                 {% if document %}
-                <form method="POST" action="{{ url_for('documents.delete', document_id=document.id) }}"
-                      onsubmit="return confirm('{{ _('Delete this document?') }}');" class="inline">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button type="submit" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
-                        {{ _('Delete') }}
-                    </button>
-                </form>
+                <button type="button" onclick="deleteDocument()" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
+                    {{ _('Delete') }}
+                </button>
                 {% else %}
                 <div></div>
                 {% endif %}
@@ -132,6 +128,19 @@
                 </div>
             </div>
         </form>
+
+        {% if document %}
+        <form id="delete-form" method="POST" action="{{ url_for('documents.delete', document_id=document.id) }}" class="hidden">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        </form>
+        <script>
+        function deleteDocument() {
+            if (confirm('{{ _("Delete this document?") }}')) {
+                document.getElementById('delete-form').submit();
+            }
+        }
+        </script>
+        {% endif %}
     </div>
 </div>
 

--- a/app/templates/maintenance/form.html
+++ b/app/templates/maintenance/form.html
@@ -144,13 +144,9 @@
         <!-- Form Actions -->
         <div class="flex justify-between pt-6 border-t border-gray-200 dark:border-gray-700">
             {% if schedule %}
-            <form method="POST" action="{{ url_for('maintenance.delete', schedule_id=schedule.id) }}"
-                  onsubmit="return confirm('{{ _('Delete this maintenance schedule?') }}');" class="inline">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <button type="submit" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
-                    {{ _('Delete Schedule') }}
-                </button>
-            </form>
+            <button type="button" onclick="deleteSchedule()" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
+                {{ _('Delete Schedule') }}
+            </button>
             {% else %}
             <div></div>
             {% endif %}
@@ -166,5 +162,18 @@
             </div>
         </div>
     </form>
+
+    {% if schedule %}
+    <form id="delete-form" method="POST" action="{{ url_for('maintenance.delete', schedule_id=schedule.id) }}" class="hidden">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    </form>
+    <script>
+    function deleteSchedule() {
+        if (confirm('{{ _("Delete this maintenance schedule?") }}')) {
+            document.getElementById('delete-form').submit();
+        }
+    }
+    </script>
+    {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/recurring/form.html
+++ b/app/templates/recurring/form.html
@@ -109,20 +109,16 @@
             <div>
                 <label for="remind_days_before" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Remind days before') }}</label>
                 <input type="number" name="remind_days_before" id="remind_days_before"
-                       value="{{ recurring.remind_days_before if recurring else 7 }}"
+                       value="{{ recurring.notify_before_days if recurring else 7 }}"
                        min="0" max="90"
                        class="mt-1 block w-24 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
             </div>
 
             <div class="flex justify-between pt-4 border-t border-gray-200 dark:border-gray-700">
                 {% if recurring %}
-                <form method="POST" action="{{ url_for('recurring.delete', recurring_id=recurring.id) }}"
-                      onsubmit="return confirm('{{ _('Delete this recurring expense?') }}');" class="inline">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button type="submit" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
-                        {{ _('Delete') }}
-                    </button>
-                </form>
+                <button type="button" onclick="deleteRecurring()" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
+                    {{ _('Delete') }}
+                </button>
                 {% else %}
                 <div></div>
                 {% endif %}
@@ -138,6 +134,19 @@
                 </div>
             </div>
         </form>
+
+        {% if recurring %}
+        <form id="delete-form" method="POST" action="{{ url_for('recurring.delete', recurring_id=recurring.id) }}" class="hidden">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        </form>
+        <script>
+        function deleteRecurring() {
+            if (confirm('{{ _("Delete this recurring expense?") }}')) {
+                document.getElementById('delete-form').submit();
+            }
+        }
+        </script>
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/app/templates/stations/form.html
+++ b/app/templates/stations/form.html
@@ -89,13 +89,9 @@
 
             <div class="flex justify-between pt-4 border-t border-gray-200 dark:border-gray-700">
                 {% if station %}
-                <form method="POST" action="{{ url_for('stations.delete', station_id=station.id) }}"
-                      onsubmit="return confirm('{{ _('Delete this station?') }}');" class="inline">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button type="submit" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
-                        {{ _('Delete') }}
-                    </button>
-                </form>
+                <button type="button" onclick="deleteStation()" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm">
+                    {{ _('Delete') }}
+                </button>
                 {% else %}
                 <div></div>
                 {% endif %}
@@ -111,6 +107,19 @@
                 </div>
             </div>
         </form>
+
+        {% if station %}
+        <form id="delete-form" method="POST" action="{{ url_for('stations.delete', station_id=station.id) }}" class="hidden">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        </form>
+        <script>
+        function deleteStation() {
+            if (confirm('{{ _("Delete this station?") }}')) {
+                document.getElementById('delete-form').submit();
+            }
+        }
+        </script>
+        {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.8.1'
+APP_VERSION = '0.8.2'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'


### PR DESCRIPTION
## Summary

- **Fix nested delete forms** (#30): Delete buttons in recurring expenses, maintenance schedules, fuel stations, and documents edit pages were nested inside the outer edit form. Since nested `<form>` tags are invalid HTML, browsers ignored the inner form and the delete button would submit the edit form instead, causing Internal Server Errors. Moved delete forms outside the edit forms using JS-based confirmation and separate form submission.
- **Fix theme toggle** (#29): Dark mode toggle now reloads the page after updating the preference, ensuring the server-rendered HTML and Tailwind CSS classes are fully consistent with the new theme setting.
- **Fix recurring expense date** (#31): When generating an expense from a recurring expense, the expense date now uses the recurring expense's due date instead of today's date.
- **Fix recurring expense edit**: The edit handler was setting a non-existent `remind_days_before` attribute instead of the correct `notify_before_days` model field, so editing the notification days had no effect. Also fixed the form template to read the correct field when displaying the current value.
- Version bump to 0.8.2

## Test plan
- [ ] Edit a recurring expense and click Delete - should show confirmation and delete successfully
- [ ] Edit a maintenance schedule and click Delete - should work correctly
- [ ] Edit a fuel station and click Delete - should work correctly
- [ ] Edit a document and click Delete - should work correctly
- [ ] Toggle dark mode in Settings - page should reload and theme should change fully
- [ ] Toggle dark mode back - should persist across navigation
- [ ] Create an expense from a past-due recurring expense - expense date should match the due date, not today
- [ ] Edit a recurring expense's "Remind days before" field and save - value should persist