### PR TITLE
feat: configurable date format preference

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -54,6 +54,9 @@ def _run_schema_migrations(app):
             ('tessie_battery_range', 'FLOAT'),
             ('tessie_last_updated', 'DATETIME'),
         ],
+        'users': [
+            ('date_format', "VARCHAR(20) DEFAULT 'DD/MM/YYYY'"),
+        ],
         'charging_sessions': [
             ('tessie_charge_id', 'VARCHAR(50)'),
         ],
@@ -153,6 +156,49 @@ def create_app(config_class=Config):
             'TAILWIND_CDN_URL': app.config.get('TAILWIND_CDN_URL', 'https://cdn.tailwindcss.com'),
             'HTMX_CDN_URL': app.config.get('HTMX_CDN_URL', 'https://unpkg.com/htmx.org@1.9.10'),
         }
+
+    # Date format filter for templates
+    DATE_FORMATS = {
+        'DD/MM/YYYY': {
+            'default': '%d/%m/%Y',
+            'short': '%d %b',
+            'long': '%d %B %Y',
+            'datetime': '%d/%m/%Y %H:%M',
+            'long_datetime': '%d %B %Y at %H:%M',
+        },
+        'MM/DD/YYYY': {
+            'default': '%m/%d/%Y',
+            'short': '%b %d',
+            'long': '%B %d, %Y',
+            'datetime': '%m/%d/%Y %H:%M',
+            'long_datetime': '%B %d, %Y at %H:%M',
+        },
+        'YYYY-MM-DD': {
+            'default': '%Y-%m-%d',
+            'short': '%b %d',
+            'long': '%Y-%m-%d',
+            'datetime': '%Y-%m-%d %H:%M',
+            'long_datetime': '%Y-%m-%d %H:%M',
+        },
+        'DD.MM.YYYY': {
+            'default': '%d.%m.%Y',
+            'short': '%d %b',
+            'long': '%d %B %Y',
+            'datetime': '%d.%m.%Y %H:%M',
+            'long_datetime': '%d %B %Y at %H:%M',
+        },
+    }
+
+    @app.template_filter('format_date')
+    def format_date_filter(value, style='default'):
+        if value is None:
+            return ''
+        user_format = 'DD/MM/YYYY'
+        if current_user and current_user.is_authenticated:
+            user_format = getattr(current_user, 'date_format', None) or 'DD/MM/YYYY'
+        formats = DATE_FORMATS.get(user_format, DATE_FORMATS['DD/MM/YYYY'])
+        fmt = formats.get(style, formats['default'])
+        return value.strftime(fmt)
 
     from app.routes import main, auth, vehicles, fuel, expenses, api, reminders, maintenance, documents, stations, recurring, homeassistant, calendar, trips, charging
     app.register_blueprint(main.bp)

--- a/app/models.py
+++ b/app/models.py
@@ -56,6 +56,7 @@ class User(UserMixin, db.Model):
     consumption_unit = db.Column(db.String(10), default='L/100km')  # L/100km, mpg, mpg_us
     currency = db.Column(db.String(10), default='USD')
     dark_mode = db.Column(db.Boolean, default=False)  # Dark mode preference
+    date_format = db.Column(db.String(20), default='DD/MM/YYYY')  # DD/MM/YYYY, MM/DD/YYYY, YYYY-MM-DD, DD.MM.YYYY
 
     # Notification preferences
     email_reminders = db.Column(db.Boolean, default=True)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -127,6 +127,7 @@ def settings():
             custom_currency = (request.form.get('custom_currency') or '').strip()
             currency = custom_currency or 'USD'
         current_user.currency = currency[:10]
+        current_user.date_format = request.form.get('date_format', 'DD/MM/YYYY')
 
         # Update password if provided
         new_password = request.form.get('new_password')

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -101,13 +101,24 @@
 
                         <div class="p-6 space-y-6">
                             <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
-                                <div class="sm:col-span-2">
+                                <div>
                                     <label for="language" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Language') }}</label>
                                     <select name="language" id="language"
                                             class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
                                         {% for code, name in LANGUAGES.items() %}
                                         <option value="{{ code }}" {% if current_user.language == code %}selected{% endif %}>{{ name }}</option>
                                         {% endfor %}
+                                    </select>
+                                </div>
+
+                                <div>
+                                    <label for="date_format" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Date Format') }}</label>
+                                    <select name="date_format" id="date_format"
+                                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                                        <option value="DD/MM/YYYY" {% if current_user.date_format == 'DD/MM/YYYY' %}selected{% endif %}>DD/MM/YYYY (15/01/2024)</option>
+                                        <option value="MM/DD/YYYY" {% if current_user.date_format == 'MM/DD/YYYY' %}selected{% endif %}>MM/DD/YYYY (01/15/2024)</option>
+                                        <option value="YYYY-MM-DD" {% if current_user.date_format == 'YYYY-MM-DD' %}selected{% endif %}>YYYY-MM-DD (2024-01-15)</option>
+                                        <option value="DD.MM.YYYY" {% if current_user.date_format == 'DD.MM.YYYY' %}selected{% endif %}>DD.MM.YYYY (15.01.2024)</option>
                                     </select>
                                 </div>
 
@@ -206,7 +217,7 @@
                                 </div>
                                 <div>
                                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Member Since') }}</label>
-                                    <p class="mt-1 text-sm text-gray-900 dark:text-white">{{ current_user.created_at.strftime('%B %d, %Y') }}</p>
+                                    <p class="mt-1 text-sm text-gray-900 dark:text-white">{{ current_user.created_at|format_date('long') }}</p>
                                 </div>
                             </div>
                         </div>
@@ -617,7 +628,7 @@
                                             {{ _('Copy') }}
                                         </button>
                                     </div>
-                                    <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">{{ _('Created') }}: {{ current_user.api_key_created_at.strftime('%B %d, %Y at %H:%M') }}</p>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">{{ _('Created') }}: {{ current_user.api_key_created_at|format_date('long_datetime') }}</p>
                                     <div class="flex gap-3">
                                         <button type="button" onclick="regenerateApiKey()"
                                                 class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 dark:bg-gray-700 hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600">

--- a/app/templates/auth/users.html
+++ b/app/templates/auth/users.html
@@ -34,7 +34,7 @@
                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-600 text-gray-800">No</span>
                     {% endif %}
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.created_at.strftime('%Y-%m-%d') }}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.created_at|format_date }}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     {% if user.id != current_user.id %}
                     <form method="POST" action="{{ url_for('auth.toggle_admin', user_id=user.id) }}" class="inline">

--- a/app/templates/charging/index.html
+++ b/app/templates/charging/index.html
@@ -63,7 +63,7 @@
                 <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
                         <p class="text-sm font-medium text-gray-900 dark:text-white">
-                            {{ session.date.strftime('%b %d, %Y') }}
+                            {{ session.date|format_date }}
                             {% if session.start_time %}
                             <span class="text-gray-500 dark:text-gray-400">{{ session.start_time.strftime('%H:%M') }}</span>
                             {% endif %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -201,7 +201,7 @@
                 <div class="flex justify-between">
                     <div>
                         <p class="text-sm font-medium text-gray-900 dark:text-white">{{ log.vehicle.name }}</p>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">{{ log.date.strftime('%b %d, %Y') }} - {{ "%.1f"|format(log.volume or 0) }} {{ current_user.volume_unit }}</p>
+                        <p class="text-sm text-gray-500 dark:text-gray-400">{{ log.date|format_date }} - {{ "%.1f"|format(log.volume or 0) }} {{ current_user.volume_unit }}</p>
                     </div>
                     <p class="text-sm font-medium text-gray-900 dark:text-white">{{ "%.2f"|format(log.total_cost or 0) }} {{ current_user.currency }}</p>
                 </div>
@@ -225,7 +225,7 @@
                 <div class="flex justify-between">
                     <div>
                         <p class="text-sm font-medium text-gray-900 dark:text-white">{{ expense.description }}</p>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">{{ expense.vehicle.name }} - {{ expense.date.strftime('%b %d, %Y') }}</p>
+                        <p class="text-sm text-gray-500 dark:text-gray-400">{{ expense.vehicle.name }} - {{ expense.date|format_date }}</p>
                     </div>
                     <p class="text-sm font-medium text-gray-900 dark:text-white">{{ "%.2f"|format(expense.cost) }} {{ current_user.currency }}</p>
                 </div>

--- a/app/templates/documents/index.html
+++ b/app/templates/documents/index.html
@@ -73,7 +73,7 @@
                         <div class="text-right">
                             <p class="text-xs text-gray-500 dark:text-gray-400">{{ _('Expires') }}</p>
                             <p class="text-sm {% if doc.is_expired() %}text-red-600{% elif doc.is_expiring_soon() %}text-amber-600{% else %}text-gray-900 dark:text-white{% endif %}">
-                                {{ doc.expiry_date.strftime('%d %b %Y') }}
+                                {{ doc.expiry_date|format_date }}
                             </p>
                         </div>
                         {% endif %}

--- a/app/templates/documents/view.html
+++ b/app/templates/documents/view.html
@@ -77,7 +77,7 @@
                 {% if document.issue_date %}
                 <div>
                     <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Issue Date') }}</dt>
-                    <dd class="mt-1 text-sm text-gray-900 dark:text-white">{{ document.issue_date.strftime('%d %b %Y') }}</dd>
+                    <dd class="mt-1 text-sm text-gray-900 dark:text-white">{{ document.issue_date|format_date }}</dd>
                 </div>
                 {% endif %}
 
@@ -85,7 +85,7 @@
                 <div>
                     <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Expiry Date') }}</dt>
                     <dd class="mt-1 text-sm {% if document.is_expired() %}text-red-600{% elif document.is_expiring_soon() %}text-amber-600{% else %}text-gray-900 dark:text-white{% endif %}">
-                        {{ document.expiry_date.strftime('%d %b %Y') }}
+                        {{ document.expiry_date|format_date }}
                     </dd>
                 </div>
                 {% endif %}

--- a/app/templates/expenses/index.html
+++ b/app/templates/expenses/index.html
@@ -33,7 +33,7 @@
             <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {% for expense in expenses %}
                 <tr class="hover:bg-gray-50 dark:bg-gray-700">
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ expense.date.strftime('%b %d, %Y') }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ expense.date|format_date }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                         <a href="{{ url_for('vehicles.view', vehicle_id=expense.vehicle_id) }}" class="text-primary-600 hover:text-primary-500">
                             {{ expense.vehicle.name }}

--- a/app/templates/fuel/index.html
+++ b/app/templates/fuel/index.html
@@ -34,7 +34,7 @@
             <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {% for log in logs %}
                 <tr class="hover:bg-gray-50 dark:bg-gray-700">
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ log.date.strftime('%b %d, %Y') }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ log.date|format_date }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                         <a href="{{ url_for('vehicles.view', vehicle_id=log.vehicle_id) }}" class="text-primary-600 hover:text-primary-500">
                             {{ log.vehicle.name }}

--- a/app/templates/maintenance/index.html
+++ b/app/templates/maintenance/index.html
@@ -56,7 +56,7 @@
                 <div class="ml-4 flex-shrink-0 text-right">
                     {% if schedule.next_due_date %}
                     <p class="text-sm {% if is_due %}text-red-600 dark:text-red-400{% elif is_due_soon %}text-amber-600 dark:text-amber-400{% else %}text-gray-900 dark:text-white{% endif %}">
-                        {{ schedule.next_due_date.strftime('%d %b %Y') }}
+                        {{ schedule.next_due_date|format_date }}
                     </p>
                     {% endif %}
                     {% if schedule.next_due_odometer %}

--- a/app/templates/recurring/index.html
+++ b/app/templates/recurring/index.html
@@ -63,7 +63,7 @@
                     <div class="text-right">
                         <p class="text-xs text-gray-500 dark:text-gray-400">{{ _('Next due') }}</p>
                         <p class="text-sm {% if item.is_due() %}text-red-600{% elif item.is_due_soon() %}text-amber-600{% else %}text-gray-900 dark:text-white{% endif %}">
-                            {{ item.next_due.strftime('%d %b %Y') }}
+                            {{ item.next_due|format_date }}
                         </p>
                     </div>
                     {% endif %}

--- a/app/templates/reminders/_reminder_row.html
+++ b/app/templates/reminders/_reminder_row.html
@@ -56,7 +56,7 @@
             <!-- Due date -->
             <div class="text-right">
                 <p class="text-sm {% if reminder.is_overdue() %}text-red-600 font-medium{% elif reminder.is_upcoming(7) %}text-amber-600{% else %}text-gray-900 dark:text-white{% endif %}">
-                    {{ reminder.due_date.strftime('%b %d, %Y') }}
+                    {{ reminder.due_date|format_date }}
                 </p>
                 <p class="text-xs text-gray-500 dark:text-gray-400">
                     {% if reminder.is_completed %}

--- a/app/templates/stations/cheapest.html
+++ b/app/templates/stations/cheapest.html
@@ -44,7 +44,7 @@
                             {{ "%.3f"|format(price.price_per_unit) }} {{ current_user.currency }}
                         </p>
                         <p class="text-xs text-gray-500 dark:text-gray-400">
-                            {{ price.date.strftime('%b %d') }}
+                            {{ price.date|format_date('short') }}
                         </p>
                     </div>
                     <a href="{{ url_for('stations.price_history', station_id=price.station_id) }}"

--- a/app/templates/stations/prices.html
+++ b/app/templates/stations/prices.html
@@ -34,7 +34,7 @@
         {% for price in prices %}
         <li class="px-6 py-4 flex items-center justify-between">
             <div>
-                <p class="text-sm font-medium text-gray-900 dark:text-white">{{ price.date.strftime('%b %d, %Y') }}</p>
+                <p class="text-sm font-medium text-gray-900 dark:text-white">{{ price.date|format_date }}</p>
                 <p class="text-sm text-gray-500 dark:text-gray-400 capitalize">{{ price.fuel_type }}</p>
             </div>
             <p class="text-lg font-semibold text-gray-900 dark:text-white">{{ "%.3f"|format(price.price_per_unit) }} {{ current_user.currency }}/{{ current_user.volume_unit }}</p>

--- a/app/templates/timeline/index.html
+++ b/app/templates/timeline/index.html
@@ -69,7 +69,7 @@
                                 {% endif %}
                             </div>
                             <div class="whitespace-nowrap text-right">
-                                <time class="text-sm text-gray-500 dark:text-gray-400">{{ event.date.strftime('%b %d, %Y') }}</time>
+                                <time class="text-sm text-gray-500 dark:text-gray-400">{{ event.date|format_date }}</time>
                                 {% if event.cost %}
                                 <p class="text-sm font-medium text-gray-900 dark:text-white">{{ "%.2f"|format(event.cost) }} {{ current_user.currency }}</p>
                                 {% endif %}

--- a/app/templates/trips/index.html
+++ b/app/templates/trips/index.html
@@ -88,7 +88,7 @@
                 <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
                         <p class="text-sm font-medium text-gray-900 dark:text-white">
-                            {{ trip.date.strftime('%b %d, %Y') }}
+                            {{ trip.date|format_date }}
                         </p>
                         <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
                                      {% if trip.purpose == 'business' %}bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200

--- a/app/templates/trips/report.html
+++ b/app/templates/trips/report.html
@@ -105,7 +105,7 @@
             <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {% for trip in trips %}
                 <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ trip.date.strftime('%b %d') }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ trip.date|format_date('short') }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ trip.vehicle.name }}</td>
                     <td class="px-6 py-4 whitespace-nowrap">
                         <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium

--- a/app/templates/vehicles/report_pdf.html
+++ b/app/templates/vehicles/report_pdf.html
@@ -198,7 +198,7 @@
             {% if vehicle.registration %}&bull; {{ vehicle.registration }}{% endif %}
         </div>
         <div class="meta">
-            Generated on {{ generated_at.strftime('%B %d, %Y at %H:%M UTC') }} for {{ user.username }}
+            Generated on {{ generated_at|format_date('long_datetime') }} for {{ user.username }}
         </div>
     </div>
 
@@ -314,7 +314,7 @@
         </tr>
         {% for log in fuel_logs %}
         <tr>
-            <td>{{ log.date.strftime('%Y-%m-%d') }}</td>
+            <td>{{ log.date|format_date }}</td>
             <td class="text-right">{{ "%.0f"|format(log.odometer) }} {{ user.distance_unit }}</td>
             <td class="text-right">{% if log.volume %}{{ "%.2f"|format(log.volume) }} {{ user.volume_unit }}{% else %}-{% endif %}</td>
             <td class="text-right">{% if log.price_per_unit %}{{ "%.3f"|format(log.price_per_unit) }}{% else %}-{% endif %}</td>
@@ -340,7 +340,7 @@
         </tr>
         {% for expense in expenses %}
         <tr>
-            <td>{{ expense.date.strftime('%Y-%m-%d') }}</td>
+            <td>{{ expense.date|format_date }}</td>
             <td style="text-transform: capitalize;">{{ expense.category }}</td>
             <td>{{ expense.description }}</td>
             <td class="text-right">{{ "%.2f"|format(expense.cost) }} {{ user.currency }}</td>

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -192,7 +192,7 @@
                 <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('MOT Expiry') }}</dt>
                 <dd class="mt-1 text-sm text-gray-900 dark:text-white">
                     {% if vehicle.mot_expiry %}
-                    {{ vehicle.mot_expiry.strftime('%d %b %Y') }}
+                    {{ vehicle.mot_expiry|format_date }}
                     {% else %}
                     -
                     {% endif %}
@@ -220,7 +220,7 @@
                 <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Tax Due') }}</dt>
                 <dd class="mt-1 text-sm text-gray-900 dark:text-white">
                     {% if vehicle.tax_due %}
-                    {{ vehicle.tax_due.strftime('%d %b %Y') }}
+                    {{ vehicle.tax_due|format_date }}
                     {% else %}
                     -
                     {% endif %}
@@ -228,7 +228,7 @@
             </div>
         </div>
         <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
-            {{ _('Last updated') }}: {{ vehicle.dvla_last_updated.strftime('%d %b %Y at %H:%M') }}
+            {{ _('Last updated') }}: {{ vehicle.dvla_last_updated|format_date('long_datetime') }}
         </p>
         {% else %}
         <div class="text-center py-4">
@@ -330,7 +330,7 @@
             </div>
         </div>
         <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
-            {{ _('Last updated') }}: {{ vehicle.tessie_last_updated.strftime('%d %b %Y at %H:%M') }}
+            {{ _('Last updated') }}: {{ vehicle.tessie_last_updated|format_date('long_datetime') }}
         </p>
         {% else %}
         <div class="text-center py-4">
@@ -403,7 +403,7 @@
                 <div class="flex items-center space-x-4">
                     <div class="text-right">
                         <p class="text-sm {% if reminder.is_overdue() %}text-red-600 font-medium{% elif reminder.is_upcoming(7) %}text-amber-600{% else %}text-gray-900 dark:text-white{% endif %}">
-                            {{ reminder.due_date.strftime('%b %d, %Y') }}
+                            {{ reminder.due_date|format_date }}
                         </p>
                         <p class="text-xs text-gray-500 dark:text-gray-400">
                             {% if reminder.is_overdue() %}
@@ -554,7 +554,7 @@
             <li class="px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-700">
                 <div class="flex items-center justify-between">
                     <div>
-                        <p class="text-sm font-medium text-gray-900 dark:text-white">{{ log.date.strftime('%b %d, %Y') }}</p>
+                        <p class="text-sm font-medium text-gray-900 dark:text-white">{{ log.date|format_date }}</p>
                         <p class="text-sm text-gray-500 dark:text-gray-400">
                             {{ "%.0f"|format(log.odometer) }} {{ current_user.distance_unit }} &middot;
                             {{ "%.1f"|format(log.volume or 0) }} {{ current_user.volume_unit }}
@@ -607,7 +607,7 @@
                     <div class="min-w-0 flex-1">
                         <p class="text-sm font-medium text-gray-900 dark:text-white">{{ expense.description }}</p>
                         <p class="text-sm text-gray-500 dark:text-gray-400">
-                            {{ expense.date.strftime('%b %d, %Y') }} &middot;
+                            {{ expense.date|format_date }} &middot;
                             <span class="capitalize">{{ expense.category }}</span>
                         </p>
                     </div>

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.8.2'
+APP_VERSION = '0.9.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'


### PR DESCRIPTION
## Summary

- Adds user-selectable date format preference with 4 options: DD/MM/YYYY (default), MM/DD/YYYY, YYYY-MM-DD, DD.MM.YYYY
- New `format_date` Jinja2 template filter that reads the logged-in user's preference and supports `default`, `short`, `long`, `datetime`, and `long_datetime` styles
- Date format dropdown added to Settings > Units & Values page
- Replaced hardcoded `strftime()` calls across 20 templates with the new filter
- HTML date `<input>` values remain in ISO `%Y-%m-%d` format (unaffected)
- Schema migration automatically adds `date_format` column to existing databases
- Version bumped to 0.9.0

Closes #33

## Test plan

- [ ] Verify settings page shows the new Date Format dropdown
- [ ] Change format to each option and confirm dates update across dashboard, fuel logs, expenses, trips, charging, maintenance, recurring, documents, stations, reminders, timeline, and vehicle view
- [ ] Confirm form date inputs remain in ISO format (YYYY-MM-DD)
- [ ] Confirm new users default to DD/MM/YYYY
- [ ] Test with existing database to verify schema migration works