### PR TITLE
feat: add generic CSV import with column-mapping UI

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -8,13 +8,14 @@ import tempfile
 import zipfile
 from functools import wraps
 from datetime import datetime
-from flask import Blueprint, jsonify, request, send_from_directory, current_app, url_for, render_template, Response, flash, redirect
+from flask import Blueprint, jsonify, request, send_from_directory, current_app, url_for, render_template, Response, flash, redirect, session
 from flask_login import login_required, current_user
 from app import db
 from app.models import (
     User, Vehicle, VehicleSpec, FuelLog, Expense, EXPENSE_CATEGORIES,
     Reminder, MaintenanceSchedule, RecurringExpense, FuelStation,
-    Document, Trip, ChargingSession, VehiclePart, FuelPriceHistory, Attachment
+    Document, Trip, ChargingSession, VehiclePart, FuelPriceHistory, Attachment,
+    TRIP_PURPOSES, CHARGER_TYPES
 )
 from app.services.tessie import TessieService
 from config import APP_VERSION
@@ -2492,5 +2493,463 @@ def import_fuelly():
     except Exception as e:
         db.session.rollback()
         flash(f'Import failed: {str(e)}', 'error')
+
+    return redirect(url_for('auth.settings') + '#integrations')
+
+
+# =============================================================================
+# Generic CSV Import
+# =============================================================================
+
+def get_import_fields(data_type):
+    """Return field definitions for a given data type."""
+    fields = {
+        'fuel_logs': [
+            {'name': 'date', 'label': 'Date', 'required': True, 'type': 'date'},
+            {'name': 'odometer', 'label': 'Odometer', 'required': True, 'type': 'float'},
+            {'name': 'volume', 'label': 'Volume', 'required': False, 'type': 'float'},
+            {'name': 'price_per_unit', 'label': 'Price per Unit', 'required': False, 'type': 'float'},
+            {'name': 'total_cost', 'label': 'Total Cost', 'required': False, 'type': 'float'},
+            {'name': 'is_full_tank', 'label': 'Full Tank', 'required': False, 'type': 'bool'},
+            {'name': 'is_missed', 'label': 'Missed Fill-up', 'required': False, 'type': 'bool'},
+            {'name': 'station', 'label': 'Station', 'required': False, 'type': 'str'},
+            {'name': 'notes', 'label': 'Notes', 'required': False, 'type': 'str'},
+        ],
+        'expenses': [
+            {'name': 'date', 'label': 'Date', 'required': True, 'type': 'date'},
+            {'name': 'category', 'label': 'Category', 'required': True, 'type': 'str'},
+            {'name': 'description', 'label': 'Description', 'required': True, 'type': 'str'},
+            {'name': 'cost', 'label': 'Cost', 'required': True, 'type': 'float'},
+            {'name': 'odometer', 'label': 'Odometer', 'required': False, 'type': 'float'},
+            {'name': 'vendor', 'label': 'Vendor', 'required': False, 'type': 'str'},
+            {'name': 'notes', 'label': 'Notes', 'required': False, 'type': 'str'},
+        ],
+        'trips': [
+            {'name': 'date', 'label': 'Date', 'required': True, 'type': 'date'},
+            {'name': 'start_odometer', 'label': 'Start Odometer', 'required': True, 'type': 'float'},
+            {'name': 'end_odometer', 'label': 'End Odometer', 'required': True, 'type': 'float'},
+            {'name': 'purpose', 'label': 'Purpose', 'required': True, 'type': 'str'},
+            {'name': 'description', 'label': 'Description', 'required': False, 'type': 'str'},
+            {'name': 'start_location', 'label': 'Start Location', 'required': False, 'type': 'str'},
+            {'name': 'end_location', 'label': 'End Location', 'required': False, 'type': 'str'},
+            {'name': 'notes', 'label': 'Notes', 'required': False, 'type': 'str'},
+        ],
+        'charging_sessions': [
+            {'name': 'date', 'label': 'Date', 'required': True, 'type': 'date'},
+            {'name': 'start_time', 'label': 'Start Time', 'required': False, 'type': 'time'},
+            {'name': 'end_time', 'label': 'End Time', 'required': False, 'type': 'time'},
+            {'name': 'odometer', 'label': 'Odometer', 'required': False, 'type': 'float'},
+            {'name': 'kwh_added', 'label': 'kWh Added', 'required': False, 'type': 'float'},
+            {'name': 'start_soc', 'label': 'Start SOC %', 'required': False, 'type': 'int'},
+            {'name': 'end_soc', 'label': 'End SOC %', 'required': False, 'type': 'int'},
+            {'name': 'cost_per_kwh', 'label': 'Cost per kWh', 'required': False, 'type': 'float'},
+            {'name': 'total_cost', 'label': 'Total Cost', 'required': False, 'type': 'float'},
+            {'name': 'charger_type', 'label': 'Charger Type', 'required': False, 'type': 'str'},
+            {'name': 'location', 'label': 'Location', 'required': False, 'type': 'str'},
+            {'name': 'network', 'label': 'Network', 'required': False, 'type': 'str'},
+            {'name': 'notes', 'label': 'Notes', 'required': False, 'type': 'str'},
+        ],
+    }
+    return fields.get(data_type, [])
+
+
+# Common aliases for auto-suggesting column mappings
+_COLUMN_ALIASES = {
+    'date': ['date', 'fuelup date', 'fill date', 'trip date', 'charge date', 'session date', 'expense date'],
+    'odometer': ['odometer', 'odo', 'mileage', 'miles', 'km', 'kilometers', 'distance'],
+    'volume': ['volume', 'litres', 'liters', 'gallons', 'gal', 'fuel', 'qty', 'quantity'],
+    'price_per_unit': ['price per unit', 'unit price', 'price/l', 'price/gal', 'price', 'rate'],
+    'total_cost': ['total cost', 'total', 'cost', 'price paid', 'total price'],
+    'is_full_tank': ['full tank', 'full', 'complete', 'full fill'],
+    'is_missed': ['missed', 'missed fill', 'skipped'],
+    'station': ['station', 'gas station', 'fuel station'],
+    'notes': ['notes', 'note', 'comments', 'comment', 'remarks', 'memo'],
+    'category': ['category', 'type', 'expense type', 'expense category'],
+    'description': ['description', 'desc', 'title', 'name', 'item', 'service'],
+    'cost': ['cost', 'amount', 'total', 'price', 'expense'],
+    'vendor': ['vendor', 'shop', 'store', 'supplier', 'merchant', 'provider'],
+    'start_odometer': ['start odometer', 'start odo', 'start miles', 'start km', 'odometer start'],
+    'end_odometer': ['end odometer', 'end odo', 'end miles', 'end km', 'odometer end'],
+    'purpose': ['purpose', 'trip purpose', 'reason', 'trip type'],
+    'start_location': ['start location', 'from', 'origin', 'departure'],
+    'end_location': ['end location', 'to', 'destination', 'arrival'],
+    'start_time': ['start time', 'time start', 'begin time'],
+    'end_time': ['end time', 'time end', 'finish time'],
+    'kwh_added': ['kwh added', 'kwh', 'energy', 'energy added', 'kilowatt hours'],
+    'start_soc': ['start soc', 'soc start', 'start battery', 'battery start', 'start %'],
+    'end_soc': ['end soc', 'soc end', 'end battery', 'battery end', 'end %'],
+    'cost_per_kwh': ['cost per kwh', 'price per kwh', 'kwh price', 'kwh cost'],
+    'charger_type': ['charger type', 'charger', 'connector', 'plug type'],
+    'location': ['location', 'place', 'charging station', 'site'],
+    'network': ['network', 'provider', 'operator', 'charging network'],
+}
+
+
+def auto_suggest_mappings(csv_columns, target_fields):
+    """Match CSV column names to target fields using normalized name comparison."""
+    field_names = {f['name'] for f in target_fields}
+    suggestions = {}
+    used_fields = set()
+
+    for col in csv_columns:
+        normalized = col.strip().lower().replace('_', ' ').replace('-', ' ')
+        best_match = None
+
+        for field_name, aliases in _COLUMN_ALIASES.items():
+            if field_name not in field_names or field_name in used_fields:
+                continue
+            if normalized in aliases or normalized == field_name.replace('_', ' '):
+                best_match = field_name
+                break
+
+        if best_match:
+            suggestions[col] = best_match
+            used_fields.add(best_match)
+
+    return suggestions
+
+
+def parse_date_value(value, date_format='auto'):
+    """Parse a date string, optionally with a format hint."""
+    if not value or not value.strip():
+        return None
+    value = value.strip()
+
+    if date_format == 'DD/MM/YYYY':
+        formats = ['%d/%m/%Y', '%d-%m-%Y', '%d.%m.%Y', '%d/%m/%y']
+    elif date_format == 'MM/DD/YYYY':
+        formats = ['%m/%d/%Y', '%m-%d-%Y', '%m/%d/%y']
+    elif date_format == 'YYYY-MM-DD':
+        formats = ['%Y-%m-%d', '%Y/%m/%d']
+    else:
+        # Auto-detect: try unambiguous formats first
+        formats = ['%Y-%m-%d', '%Y/%m/%d', '%d/%m/%Y', '%m/%d/%Y', '%d-%m-%Y',
+                   '%m-%d-%Y', '%d.%m.%Y', '%d/%m/%y', '%m/%d/%y', '%Y-%m-%d %H:%M:%S']
+
+    for fmt in formats:
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_time_value(value):
+    """Parse a time string."""
+    if not value or not value.strip():
+        return None
+    value = value.strip()
+    for fmt in ['%H:%M:%S', '%H:%M', '%I:%M %p', '%I:%M:%S %p']:
+        try:
+            return datetime.strptime(value, fmt).time()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_bool_value(value):
+    """Parse a boolean-like value."""
+    if not value:
+        return False
+    return str(value).strip().lower() in ('1', 'yes', 'true', 'y', 'on', 'full')
+
+
+def parse_float_value(value):
+    """Parse a float, stripping currency symbols and commas."""
+    if not value or not str(value).strip():
+        return None
+    cleaned = str(value).strip()
+    for ch in ['$', '\u20ac', '\u00a3', '\u00a5', '\u20b9', ',']:
+        cleaned = cleaned.replace(ch, '')
+    cleaned = cleaned.strip()
+    if not cleaned:
+        return None
+    return float(cleaned)
+
+
+def parse_int_value(value):
+    """Parse an integer value."""
+    f = parse_float_value(value)
+    if f is None:
+        return None
+    return int(round(f))
+
+
+def _cleanup_temp_file(path):
+    """Remove a temp file safely."""
+    try:
+        if path and os.path.exists(path):
+            os.unlink(path)
+    except OSError:
+        pass
+
+
+def create_record(data_type, mapped_row, vehicle_id, user_id, date_format):
+    """Create a model instance from a mapped CSV row."""
+    date_val = parse_date_value(mapped_row.get('date', ''), date_format)
+
+    if data_type == 'fuel_logs':
+        if not date_val:
+            raise ValueError('Missing or invalid date')
+        odometer = parse_float_value(mapped_row.get('odometer'))
+        if odometer is None:
+            raise ValueError('Missing or invalid odometer')
+        return FuelLog(
+            vehicle_id=vehicle_id,
+            user_id=user_id,
+            date=date_val,
+            odometer=odometer,
+            volume=parse_float_value(mapped_row.get('volume')),
+            price_per_unit=parse_float_value(mapped_row.get('price_per_unit')),
+            total_cost=parse_float_value(mapped_row.get('total_cost')),
+            is_full_tank=parse_bool_value(mapped_row.get('is_full_tank')) if mapped_row.get('is_full_tank') else True,
+            is_missed=parse_bool_value(mapped_row.get('is_missed')),
+            station=mapped_row.get('station', '').strip() or None,
+            notes=mapped_row.get('notes', '').strip() or None,
+        )
+
+    elif data_type == 'expenses':
+        if not date_val:
+            raise ValueError('Missing or invalid date')
+        cost = parse_float_value(mapped_row.get('cost'))
+        if cost is None:
+            raise ValueError('Missing or invalid cost')
+        description = mapped_row.get('description', '').strip()
+        if not description:
+            raise ValueError('Missing description')
+        category = mapped_row.get('category', '').strip().lower()
+        valid_categories = [c[0] for c in EXPENSE_CATEGORIES]
+        if category not in valid_categories:
+            category = 'other'
+        return Expense(
+            vehicle_id=vehicle_id,
+            user_id=user_id,
+            date=date_val,
+            category=category,
+            description=description,
+            cost=cost,
+            odometer=parse_float_value(mapped_row.get('odometer')),
+            vendor=mapped_row.get('vendor', '').strip() or None,
+            notes=mapped_row.get('notes', '').strip() or None,
+        )
+
+    elif data_type == 'trips':
+        if not date_val:
+            raise ValueError('Missing or invalid date')
+        start_odo = parse_float_value(mapped_row.get('start_odometer'))
+        end_odo = parse_float_value(mapped_row.get('end_odometer'))
+        if start_odo is None:
+            raise ValueError('Missing or invalid start odometer')
+        if end_odo is None:
+            raise ValueError('Missing or invalid end odometer')
+        purpose = mapped_row.get('purpose', '').strip().lower()
+        valid_purposes = [p[0] for p in TRIP_PURPOSES]
+        if purpose not in valid_purposes:
+            purpose = 'other'
+        return Trip(
+            vehicle_id=vehicle_id,
+            user_id=user_id,
+            date=date_val,
+            start_odometer=start_odo,
+            end_odometer=end_odo,
+            purpose=purpose,
+            description=mapped_row.get('description', '').strip() or None,
+            start_location=mapped_row.get('start_location', '').strip() or None,
+            end_location=mapped_row.get('end_location', '').strip() or None,
+            notes=mapped_row.get('notes', '').strip() or None,
+        )
+
+    elif data_type == 'charging_sessions':
+        if not date_val:
+            raise ValueError('Missing or invalid date')
+        charger_type = mapped_row.get('charger_type', '').strip().lower()
+        valid_charger_types = [c[0] for c in CHARGER_TYPES]
+        if charger_type and charger_type not in valid_charger_types:
+            charger_type = 'other'
+        return ChargingSession(
+            vehicle_id=vehicle_id,
+            user_id=user_id,
+            date=date_val,
+            start_time=parse_time_value(mapped_row.get('start_time')),
+            end_time=parse_time_value(mapped_row.get('end_time')),
+            odometer=parse_float_value(mapped_row.get('odometer')),
+            kwh_added=parse_float_value(mapped_row.get('kwh_added')),
+            start_soc=parse_int_value(mapped_row.get('start_soc')),
+            end_soc=parse_int_value(mapped_row.get('end_soc')),
+            cost_per_kwh=parse_float_value(mapped_row.get('cost_per_kwh')),
+            total_cost=parse_float_value(mapped_row.get('total_cost')),
+            charger_type=charger_type or None,
+            location=mapped_row.get('location', '').strip() or None,
+            network=mapped_row.get('network', '').strip() or None,
+            notes=mapped_row.get('notes', '').strip() or None,
+        )
+
+    raise ValueError(f'Unknown data type: {data_type}')
+
+
+DATA_TYPE_LABELS = {
+    'fuel_logs': 'Fuel Logs',
+    'expenses': 'Expenses',
+    'trips': 'Trips',
+    'charging_sessions': 'Charging Sessions',
+}
+
+
+@bp.route('/import/csv')
+@login_required
+def csv_import_upload():
+    """CSV import - step 1: upload form."""
+    vehicles = current_user.get_all_vehicles()
+    if not vehicles:
+        flash('Please add a vehicle before importing data.', 'warning')
+        return redirect(url_for('auth.settings') + '#integrations')
+    return render_template('import/csv_upload.html', vehicles=vehicles)
+
+
+@bp.route('/import/csv/preview', methods=['POST'])
+@login_required
+def csv_import_preview():
+    """CSV import - step 2: parse CSV and show mapping page."""
+    data_type = request.form.get('data_type')
+    vehicle_id = request.form.get('vehicle_id', type=int)
+
+    if data_type not in DATA_TYPE_LABELS:
+        flash('Invalid data type selected.', 'error')
+        return redirect(url_for('api.csv_import_upload'))
+
+    vehicle = Vehicle.query.get(vehicle_id)
+    if not vehicle:
+        flash('Vehicle not found.', 'error')
+        return redirect(url_for('api.csv_import_upload'))
+
+    if 'file' not in request.files or not request.files['file'].filename:
+        flash('No CSV file uploaded.', 'error')
+        return redirect(url_for('api.csv_import_upload'))
+
+    file = request.files['file']
+
+    try:
+        content = file.read().decode('utf-8-sig', errors='ignore')
+        reader = csv.DictReader(io.StringIO(content))
+        csv_columns = reader.fieldnames
+
+        if not csv_columns:
+            flash('CSV file has no column headers.', 'error')
+            return redirect(url_for('api.csv_import_upload'))
+
+        # Read all rows for counting, keep first 5 for preview
+        all_rows = list(reader)
+        preview_rows = all_rows[:5]
+
+        # Build sample data (first non-empty value per column)
+        sample_data = {}
+        for col in csv_columns:
+            for row in preview_rows:
+                val = row.get(col, '').strip()
+                if val:
+                    sample_data[col] = val
+                    break
+
+        # Save CSV to temp file
+        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False,
+                                          dir=current_app.instance_path if os.path.isdir(current_app.instance_path) else None)
+        tmp.write(content)
+        tmp.close()
+        session['csv_import_temp_file'] = tmp.name
+
+        target_fields = get_import_fields(data_type)
+        suggestions = auto_suggest_mappings(csv_columns, target_fields)
+        required_fields = [f for f in target_fields if f['required']]
+
+        return render_template('import/csv_mapping.html',
+                               data_type=data_type,
+                               data_type_label=DATA_TYPE_LABELS[data_type],
+                               vehicle_id=vehicle_id,
+                               vehicle_name=vehicle.name,
+                               csv_columns=csv_columns,
+                               sample_data=sample_data,
+                               preview_rows=preview_rows,
+                               total_rows=len(all_rows),
+                               target_fields=target_fields,
+                               suggestions=suggestions,
+                               required_fields=required_fields)
+
+    except Exception as e:
+        flash(f'Failed to parse CSV file: {str(e)}', 'error')
+        return redirect(url_for('api.csv_import_upload'))
+
+
+@bp.route('/import/csv/execute', methods=['POST'])
+@login_required
+def csv_import_execute():
+    """CSV import - step 3: apply mapping and create records."""
+    data_type = request.form.get('data_type')
+    vehicle_id = request.form.get('vehicle_id', type=int)
+    date_format = request.form.get('date_format', 'auto')
+    temp_file = session.pop('csv_import_temp_file', None)
+
+    if data_type not in DATA_TYPE_LABELS:
+        flash('Invalid data type.', 'error')
+        return redirect(url_for('auth.settings') + '#integrations')
+
+    vehicle = Vehicle.query.get(vehicle_id)
+    if not vehicle:
+        flash('Vehicle not found.', 'error')
+        return redirect(url_for('auth.settings') + '#integrations')
+
+    if not temp_file or not os.path.exists(temp_file):
+        flash('CSV file expired. Please upload again.', 'error')
+        return redirect(url_for('api.csv_import_upload'))
+
+    try:
+        # Read temp CSV
+        with open(temp_file, 'r', encoding='utf-8-sig', errors='ignore') as f:
+            reader = csv.DictReader(f)
+            csv_columns = reader.fieldnames or []
+
+            # Build column mapping from form: mapping_0, mapping_1, etc.
+            col_mapping = {}
+            for i, col in enumerate(csv_columns):
+                field_name = request.form.get(f'mapping_{i}', '')
+                if field_name:
+                    col_mapping[col] = field_name
+
+            rows = list(reader)
+
+        imported = 0
+        errors = []
+        max_errors = 50
+
+        for row_num, row in enumerate(rows, start=2):  # start=2 because row 1 is header
+            try:
+                mapped_row = {}
+                for csv_col, field_name in col_mapping.items():
+                    mapped_row[field_name] = row.get(csv_col, '')
+
+                record = create_record(data_type, mapped_row, vehicle_id, current_user.id, date_format)
+                db.session.add(record)
+                imported += 1
+            except (ValueError, KeyError) as e:
+                if len(errors) < max_errors:
+                    errors.append(f'Row {row_num}: {str(e)}')
+
+        db.session.commit()
+
+        label = DATA_TYPE_LABELS.get(data_type, data_type)
+        flash(f'CSV import complete: {imported} {label.lower()} imported.', 'success')
+
+        if errors:
+            error_summary = f'{len(errors)} row(s) skipped due to errors.'
+            if len(errors) <= 10:
+                error_summary += ' ' + '; '.join(errors)
+            else:
+                error_summary += ' First 10: ' + '; '.join(errors[:10])
+            flash(error_summary, 'warning')
+
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Import failed: {str(e)}', 'error')
+    finally:
+        _cleanup_temp_file(temp_file)
 
     return redirect(url_for('auth.settings') + '#integrations')

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -530,6 +530,17 @@
 
                             <div class="flex items-center justify-between py-3 border-t border-gray-200 dark:border-gray-700">
                                 <div>
+                                    <h3 class="text-sm font-medium text-gray-900 dark:text-white">CSV Import</h3>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">Import fuel logs, expenses, trips, or charging sessions from any CSV file</p>
+                                </div>
+                                <a href="{{ url_for('api.csv_import_upload') }}"
+                                   class="w-24 text-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 dark:bg-gray-700 hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600">
+                                    Import
+                                </a>
+                            </div>
+
+                            <div class="flex items-center justify-between py-3 border-t border-gray-200 dark:border-gray-700">
+                                <div>
                                     <h3 class="text-sm font-medium text-gray-900 dark:text-white">Drivvo</h3>
                                     <p class="text-sm text-gray-500 dark:text-gray-400">Import from Drivvo backup files</p>
                                 </div>

--- a/app/templates/import/csv_mapping.html
+++ b/app/templates/import/csv_mapping.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+{% block title %}CSV Import - Map Columns{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto">
+    <div class="mb-6">
+        <a href="{{ url_for('api.csv_import_upload') }}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300">&larr; Back to upload</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">Map CSV Columns</h1>
+    </div>
+
+    <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-6">
+        <p class="text-sm text-blue-800 dark:text-blue-200">
+            Importing <strong>{{ data_type_label }}</strong> for <strong>{{ vehicle_name }}</strong> &mdash; {{ total_rows }} row{{ 's' if total_rows != 1 else '' }} found in CSV.
+        </p>
+    </div>
+
+    <form method="POST" action="{{ url_for('api.csv_import_execute') }}" id="mappingForm">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="data_type" value="{{ data_type }}">
+        <input type="hidden" name="vehicle_id" value="{{ vehicle_id }}">
+
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-6">
+            <div class="mb-4">
+                <label for="date_format" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Date Format in CSV</label>
+                <select name="date_format" id="date_format"
+                        class="mt-1 block w-48 rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm">
+                    <option value="auto">Auto-detect</option>
+                    <option value="DD/MM/YYYY">DD/MM/YYYY</option>
+                    <option value="MM/DD/YYYY">MM/DD/YYYY</option>
+                    <option value="YYYY-MM-DD">YYYY-MM-DD</option>
+                </select>
+            </div>
+
+            <h2 class="text-lg font-medium text-gray-900 dark:text-white mb-4">Column Mapping</h2>
+
+            <div id="mappingError" class="hidden mb-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+                <p class="text-sm text-red-800 dark:text-red-200" id="mappingErrorText"></p>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                    <thead class="bg-gray-50 dark:bg-gray-700">
+                        <tr>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">CSV Column</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Sample Data</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Map To</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                        {% for col in csv_columns %}
+                        <tr>
+                            <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white whitespace-nowrap">{{ col }}</td>
+                            <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">{{ sample_data.get(col, '') }}</td>
+                            <td class="px-4 py-3">
+                                <select name="mapping_{{ loop.index0 }}" data-csv-col="{{ col }}" class="column-mapping block w-full rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1.5 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                                    <option value="">-- Skip --</option>
+                                    {% for field in target_fields %}
+                                    <option value="{{ field.name }}" {% if suggestions.get(col) == field.name %}selected{% endif %}>
+                                        {{ field.label }}{% if field.required %} *{% endif %}
+                                    </option>
+                                    {% endfor %}
+                                </select>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        {% if preview_rows %}
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-6">
+            <h2 class="text-lg font-medium text-gray-900 dark:text-white mb-4">Data Preview (first {{ preview_rows|length }} rows)</h2>
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                    <thead class="bg-gray-50 dark:bg-gray-700">
+                        <tr>
+                            {% for col in csv_columns %}
+                            <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider whitespace-nowrap">{{ col }}</th>
+                            {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                        {% for row in preview_rows %}
+                        <tr>
+                            {% for col in csv_columns %}
+                            <td class="px-3 py-2 text-gray-700 dark:text-gray-300 whitespace-nowrap max-w-xs truncate">{{ row.get(col, '') }}</td>
+                            {% endfor %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="flex justify-between items-center">
+            <a href="{{ url_for('api.csv_import_upload') }}"
+               class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
+                Cancel
+            </a>
+            <button type="submit" id="importBtn"
+                    class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+                Import {{ total_rows }} Row{{ 's' if total_rows != 1 else '' }}
+            </button>
+        </div>
+    </form>
+</div>
+
+<script>
+(function() {
+    const selects = document.querySelectorAll('.column-mapping');
+    const requiredFields = {{ required_fields | tojson }};
+    const errorDiv = document.getElementById('mappingError');
+    const errorText = document.getElementById('mappingErrorText');
+    const form = document.getElementById('mappingForm');
+
+    function getUsedValues() {
+        const used = new Set();
+        selects.forEach(function(s) {
+            if (s.value) used.add(s.value);
+        });
+        return used;
+    }
+
+    function updateDropdowns() {
+        const used = getUsedValues();
+        selects.forEach(function(sel) {
+            var currentVal = sel.value;
+            var options = sel.querySelectorAll('option');
+            options.forEach(function(opt) {
+                if (opt.value && opt.value !== currentVal) {
+                    opt.disabled = used.has(opt.value);
+                } else {
+                    opt.disabled = false;
+                }
+            });
+        });
+    }
+
+    function validateRequired() {
+        var mapped = getUsedValues();
+        var missing = [];
+        requiredFields.forEach(function(f) {
+            if (!mapped.has(f.name)) {
+                missing.push(f.label);
+            }
+        });
+        if (missing.length > 0) {
+            errorText.textContent = 'Required fields not mapped: ' + missing.join(', ');
+            errorDiv.classList.remove('hidden');
+            return false;
+        }
+        errorDiv.classList.add('hidden');
+        return true;
+    }
+
+    selects.forEach(function(s) {
+        s.addEventListener('change', function() {
+            updateDropdowns();
+            validateRequired();
+        });
+    });
+
+    form.addEventListener('submit', function(e) {
+        if (!validateRequired()) {
+            e.preventDefault();
+        }
+    });
+
+    updateDropdowns();
+})();
+</script>
+{% endblock %}

--- a/app/templates/import/csv_upload.html
+++ b/app/templates/import/csv_upload.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block title %}CSV Import{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+    <div class="mb-6">
+        <a href="{{ url_for('auth.settings') }}#integrations" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300">&larr; Back to settings</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">Import from CSV</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Import fuel logs, expenses, trips, or charging sessions from any CSV file.</p>
+    </div>
+
+    <form method="POST" action="{{ url_for('api.csv_import_preview') }}" enctype="multipart/form-data" class="space-y-6">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <div class="grid grid-cols-1 gap-6">
+                <div>
+                    <label for="data_type" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Data Type *</label>
+                    <select name="data_type" id="data_type" required
+                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                        <option value="fuel_logs">Fuel Logs</option>
+                        <option value="expenses">Expenses</option>
+                        <option value="trips">Trips</option>
+                        <option value="charging_sessions">Charging Sessions</option>
+                    </select>
+                </div>
+
+                <div>
+                    <label for="vehicle_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Vehicle *</label>
+                    <select name="vehicle_id" id="vehicle_id" required
+                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                        {% for vehicle in vehicles %}
+                        <option value="{{ vehicle.id }}">{{ vehicle.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div>
+                    <label for="file" class="block text-sm font-medium text-gray-700 dark:text-gray-300">CSV File *</label>
+                    <input type="file" name="file" id="file" accept=".csv" required
+                           class="mt-1 block w-full text-sm text-gray-500 dark:text-gray-400 file:mr-2 file:py-1.5 file:px-3 file:rounded file:border-0 file:text-sm file:bg-gray-100 dark:file:bg-gray-600 file:text-gray-700 dark:file:text-gray-200 hover:file:bg-gray-200 dark:hover:file:bg-gray-500">
+                </div>
+            </div>
+        </div>
+
+        <div class="flex justify-end">
+            <button type="submit"
+                    class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+                Next: Map Columns
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds a generic CSV importer accessible from Settings > Import Data, supporting fuel logs, expenses, trips, and charging sessions
- Two-step flow: upload CSV with data type/vehicle selection, then map CSV columns to May fields via dropdowns with auto-suggested mappings
- Per-row error handling with partial import support — invalid rows are skipped and reported via flash messages

## Changes
- **`app/routes/api.py`** — 3 new routes (`/api/import/csv`, `/api/import/csv/preview`, `/api/import/csv/execute`) and 9 helper functions for field definitions, column auto-matching, value parsing, and record creation
- **`app/templates/import/csv_upload.html`** — New upload form (step 1: data type, vehicle, file)
- **`app/templates/import/csv_mapping.html`** — New mapping page (step 2: column mapping table, data preview, date format selector, client-side validation)
- **`app/templates/auth/settings.html`** — Added CSV Import entry in the Import Data section

## Test plan
- [ ] Upload a CSV with fuel log data, verify column auto-suggestions work, import, check fuel logs page
- [ ] Upload with bad rows (missing date, non-numeric odometer), verify per-row errors and partial import
- [ ] Test each data type (expenses, trips, charging sessions) with sample CSVs
- [ ] Verify existing importers (Hammond, Clarkson, Fuelly) still work unchanged
- [ ] Test with Excel-exported CSV (BOM encoding) and various date formats (DD/MM/YYYY, MM/DD/YYYY, YYYY-MM-DD)

Closes #39