### PR TITLE
Fix: Registration toggle not showing active color (#52)

### DIFF
--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -280,7 +280,7 @@
                                         <input type="checkbox" id="registration_enabled" class="sr-only peer"
                                                {% if registration_enabled %}checked{% endif %}
                                                onchange="toggleRegistration(this.checked)">
-                                        <div class="w-11 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 dark:after:border-gray-600 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-600"></div>
+                                        <div class="w-11 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 dark:after:border-gray-600 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-600 dark:peer-checked:bg-primary-600"></div>
                                     </label>
                                 </div>
                                 <script>


### PR DESCRIPTION
## Summary
Fixes the "Allow Registration" toggle switch not visually changing color when enabled.

## Problem
The toggle was not showing the primary color when checked because `dark:bg-gray-600` was overriding `peer-checked:bg-primary-600` in Tailwind CSS specificity.

## Fix
Added `dark:peer-checked:bg-primary-600` to ensure the toggle shows the correct active color in both light and dark modes.

Fixes #52