### PR TITLE
Fix: Logo not showing on login page (#53)

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -215,9 +215,8 @@ def test_smtp():
 # =============================================================================
 
 @bp.route('/uploads/<filename>')
-@login_required
 def uploaded_file(filename):
-    """Serve uploaded files"""
+    """Serve uploaded files (public for branding assets like logo)"""
     return send_from_directory(current_app.config['UPLOAD_FOLDER'], filename)
 
 


### PR DESCRIPTION
## Summary
Fixes the logo not displaying on the login page.

## Problem
The `/api/uploads/<filename>` endpoint had `@login_required` decorator, which meant the logo image could not be loaded on the login page since the user is not yet authenticated.

## Fix
Removed `@login_required` from the `uploaded_file` endpoint so branding assets (logo, favicon) can be served to unauthenticated users.

Fixes #53