### PR TITLE
Fix: Make fuel stations system-wide (#57)

### DIFF
--- a/app/routes/stations.py
+++ b/app/routes/stations.py
@@ -11,8 +11,8 @@ bp = Blueprint('stations', __name__, url_prefix='/stations')
 @bp.route('/')
 @login_required
 def index():
-    """List all fuel stations"""
-    stations = FuelStation.query.filter_by(user_id=current_user.id).order_by(
+    """List all fuel stations (system-wide, visible to all users)"""
+    stations = FuelStation.query.order_by(
         FuelStation.is_favorite.desc(),
         FuelStation.times_used.desc()
     ).all()
@@ -57,10 +57,6 @@ def edit(station_id):
     """Edit a fuel station"""
     station = FuelStation.query.get_or_404(station_id)
 
-    if station.user_id != current_user.id:
-        flash('Access denied', 'error')
-        return redirect(url_for('stations.index'))
-
     if request.method == 'POST':
         station.name = request.form.get('name')
         station.brand = request.form.get('brand')
@@ -92,9 +88,6 @@ def toggle_favorite(station_id):
     """Toggle favorite status"""
     station = FuelStation.query.get_or_404(station_id)
 
-    if station.user_id != current_user.id:
-        return jsonify({'success': False, 'error': 'Access denied'}), 403
-
     station.is_favorite = not station.is_favorite
     db.session.commit()
 
@@ -106,10 +99,6 @@ def toggle_favorite(station_id):
 def delete(station_id):
     """Delete a fuel station"""
     station = FuelStation.query.get_or_404(station_id)
-
-    if station.user_id != current_user.id:
-        flash('Access denied', 'error')
-        return redirect(url_for('stations.index'))
 
     name = station.name
     db.session.delete(station)
@@ -123,7 +112,7 @@ def delete(station_id):
 @login_required
 def api_list():
     """Get list of stations for autocomplete/selection"""
-    stations = FuelStation.query.filter_by(user_id=current_user.id).order_by(
+    stations = FuelStation.query.order_by(
         FuelStation.is_favorite.desc(),
         FuelStation.times_used.desc()
     ).all()
@@ -143,10 +132,6 @@ def price_history(station_id):
     """View price history for a station"""
     station = FuelStation.query.get_or_404(station_id)
 
-    if station.user_id != current_user.id:
-        flash('Access denied', 'error')
-        return redirect(url_for('stations.index'))
-
     # Get price history ordered by date
     prices = FuelPriceHistory.query.filter_by(station_id=station_id).order_by(
         FuelPriceHistory.date.desc()
@@ -163,8 +148,6 @@ def cheapest():
     subquery = db.session.query(
         FuelPriceHistory.station_id,
         func.max(FuelPriceHistory.date).label('max_date')
-    ).filter(
-        FuelPriceHistory.user_id == current_user.id
     ).group_by(FuelPriceHistory.station_id).subquery()
 
     latest_prices = db.session.query(FuelPriceHistory).join(


### PR DESCRIPTION
## Summary
Fuel stations are now shared across all users in the system.

## Problem
Fuel stations were scoped per-user (`user_id` filter), so stations added by one user (e.g., admin) were invisible to other users (e.g., steve) even when they share vehicles.

## Fix
Removed `user_id` filtering from all station queries. Stations are physical locations and should be shared system-wide. Any authenticated user can now view, edit, and use all stations.

Fixes #57