### PR TITLE
fix: show all fuel stations in dropdown for shared vehicle users

### DIFF
--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -136,8 +136,8 @@ def new():
     # Pre-select vehicle if provided
     selected_vehicle_id = request.args.get('vehicle_id', type=int)
 
-    # Get user's fuel stations for dropdown
-    stations = FuelStation.query.filter_by(user_id=current_user.id).order_by(
+    # Get all fuel stations for dropdown (stations are system-wide)
+    stations = FuelStation.query.order_by(
         FuelStation.is_favorite.desc(),
         FuelStation.times_used.desc()
     ).all()
@@ -195,8 +195,8 @@ def edit(log_id):
         flash(_('Fuel log updated successfully'), 'success')
         return redirect(url_for('vehicles.view', vehicle_id=log.vehicle_id))
 
-    # Get user's fuel stations for dropdown
-    stations = FuelStation.query.filter_by(user_id=current_user.id).order_by(
+    # Get all fuel stations for dropdown (stations are system-wide)
+    stations = FuelStation.query.order_by(
         FuelStation.is_favorite.desc(),
         FuelStation.times_used.desc()
     ).all()
@@ -245,8 +245,8 @@ def quick():
         flash(_('Please add a vehicle first'), 'info')
         return redirect(url_for('vehicles.new'))
 
-    # Get user's fuel stations for dropdown
-    stations = FuelStation.query.filter_by(user_id=current_user.id).order_by(
+    # Get all fuel stations for dropdown (stations are system-wide)
+    stations = FuelStation.query.order_by(
         FuelStation.is_favorite.desc(),
         FuelStation.times_used.desc()
     ).limit(10).all()


### PR DESCRIPTION
## Summary
- Fixed fuel station dropdown being empty for users with shared vehicles
- Removed `user_id` filter from fuel station queries in new, edit, and quick log routes to match the system-wide behavior already used on the Fuel Stations page

## Details
Fuel stations were made system-wide on the Fuel Stations page (`stations.py`), but the fuel log form routes in `fuel.py` still filtered by `user_id=current_user.id`. When a shared vehicle user tried to add a fuel log, the station dropdown showed no options because they hadn't created any stations themselves.

Fixes #72

## Test plan
- [ ] Log in as admin, create a vehicle and fuel stations
- [ ] Share the vehicle with another user
- [ ] Log in as the shared user
- [ ] Verify fuel stations appear in the dropdown when adding a new fuel log
- [ ] Verify fuel stations appear in the dropdown when editing a fuel log
- [ ] Verify fuel stations appear in the quick log form