### PR TITLE
Fix cheapest fuel not showing for shared station users

### DIFF
--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -101,7 +101,7 @@ def new():
         station_id = request.form.get('station_id', type=int)
         if station_id and log.price_per_unit:
             station = FuelStation.query.get(station_id)
-            if station and station.user_id == current_user.id:
+            if station:
                 # Save price history
                 price_history = FuelPriceHistory(
                     station_id=station_id,

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -109,8 +109,6 @@ def dashboard():
         subquery = db.session.query(
             FuelPriceHistory.station_id,
             func.max(FuelPriceHistory.date).label('max_date')
-        ).filter(
-            FuelPriceHistory.user_id == current_user.id
         ).group_by(FuelPriceHistory.station_id).subquery()
 
         cheapest_stations = db.session.query(FuelPriceHistory).join(


### PR DESCRIPTION
## Summary
- Fixes fuel price history not being recorded when logging fuel at shared stations (station owned by another user)
- Fixes dashboard "Cheapest Fuel" section showing empty for users who don't own the stations
- Fixes "View All" cheapest fuel page showing "No price data available" despite fuel being logged

## Root Cause
When fuel stations were made system-wide in #57, two places still had user-scoped checks:
1. **`app/routes/fuel.py:104`** — Price history was only saved when `station.user_id == current_user.id`, so shared station users never had prices recorded
2. **`app/routes/main.py:113`** — Dashboard query filtered `FuelPriceHistory.user_id == current_user.id`, hiding prices recorded by other users

## Changes
- Removed ownership check in fuel logging — price history is now saved for any valid station
- Removed user_id filter from dashboard cheapest fuel query — all price data is now visible

Fixes #75

## Test plan
- [ ] Log fuel at a station created by another user — verify price history is recorded
- [ ] Check dashboard "Cheapest Fuel" section shows data for shared station prices
- [ ] Click "View All" — verify prices appear for all stations
- [ ] Verify existing single-user setups still work correctly