### PR TITLE
Fix: Cast LazyString to str before DB commit

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -4,6 +4,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import UserMixin
 from flask_babel import lazy_gettext as _l
 from app import db
+from sqlalchemy.orm import validates
 
 # Currency symbols for display in UI
 CURRENCY_SYMBOLS = {
@@ -505,6 +506,12 @@ class VehicleSpec(db.Model):
     label = db.Column(db.String(100), nullable=False)  # display label
     value = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    @validates('label')
+    def force_string(self, _, value):
+            if value is None:
+                return value
+            return str(value)
 
 
 class Reminder(db.Model):


### PR DESCRIPTION
Added force_string validator to ensure label is string before DB commit.

## Summary

Fixed a 500 Internal Server Error occurring when adding vehicle specifications during new vehicle creation and adding to existing vehicle. 
LazyStrings were being passed directly to SQLite resulting in crash.

## Changelog

- Added: A @validates decorator in models.py to automatically cast specification labels to standard strings before they reach the database.

- Fixed: sqlalchemy.exc.ProgrammingError when saving predefined vehicle spec types during new vehicle creation and after.


## Testing

How were these changes tested?

- [X] Tested locally
- [X] Tested with Docker image
