### PR TITLE
v0.16.0 - Bug fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -46,10 +46,10 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -68,7 +68,7 @@ jobs:
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/app/models.py
+++ b/app/models.py
@@ -270,11 +270,12 @@ class Vehicle(db.Model):
             return 0
         return logs[-1].odometer - logs[0].odometer
 
-    def get_average_consumption(self, consumption_unit=None):
+    def get_average_consumption(self, consumption_unit=None, volume_unit='L'):
         """Calculate average fuel consumption.
 
         Args:
             consumption_unit: 'L/100km', 'mpg', or 'mpg_us'. If None, returns L/100km.
+            volume_unit: 'L', 'gal' (UK), or 'us_gal'. Used to convert volume for MPG.
         """
         logs = self.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.odometer).all()
         if len(logs) < 2:
@@ -284,9 +285,14 @@ class Vehicle(db.Model):
         total_distance = logs[-1].odometer - logs[0].odometer
 
         if total_distance > 0 and total_fuel > 0:
-            if consumption_unit in ('mpg', 'mpg_us'):
-                return total_distance / total_fuel
-            return (total_fuel / total_distance) * 100  # L/100km
+            if consumption_unit == 'mpg':
+                gallons = _to_uk_gallons(total_fuel, volume_unit)
+                return total_distance / gallons if gallons > 0 else None
+            if consumption_unit == 'mpg_us':
+                gallons = _to_us_gallons(total_fuel, volume_unit)
+                return total_distance / gallons if gallons > 0 else None
+            litres = _to_litres(total_fuel, volume_unit)
+            return (litres / total_distance) * 100  # L/100km
         return None
 
     def uses_tessie_odometer(self):
@@ -371,6 +377,30 @@ class Vehicle(db.Model):
         }
 
 
+def _to_litres(volume, volume_unit):
+    if volume_unit == 'gal':
+        return volume * 4.54609
+    if volume_unit == 'us_gal':
+        return volume * 3.78541
+    return volume  # already litres
+
+
+def _to_uk_gallons(volume, volume_unit):
+    if volume_unit == 'gal':
+        return volume
+    if volume_unit == 'us_gal':
+        return volume * 3.78541 / 4.54609
+    return volume / 4.54609  # litres to UK gallons
+
+
+def _to_us_gallons(volume, volume_unit):
+    if volume_unit == 'us_gal':
+        return volume
+    if volume_unit == 'gal':
+        return volume * 4.54609 / 3.78541
+    return volume / 3.78541  # litres to US gallons
+
+
 class FuelLog(db.Model):
     __tablename__ = 'fuel_logs'
 
@@ -396,11 +426,12 @@ class FuelLog(db.Model):
     attachments = db.relationship('Attachment', backref='fuel_log', lazy='dynamic',
                                   cascade='all, delete-orphan')
 
-    def get_consumption(self, consumption_unit=None):
+    def get_consumption(self, consumption_unit=None, volume_unit='L'):
         """Calculate consumption for this fill-up.
 
         Args:
             consumption_unit: 'L/100km', 'mpg', or 'mpg_us'. If None, returns L/100km.
+            volume_unit: 'L', 'gal' (UK), or 'us_gal'. Used to convert volume for MPG.
         """
         if not self.is_full_tank or not self.volume:
             return None
@@ -414,14 +445,19 @@ class FuelLog(db.Model):
         if prev_log:
             distance = self.odometer - prev_log.odometer
             if distance > 0 and self.volume > 0:
-                if consumption_unit in ('mpg', 'mpg_us'):
-                    return distance / self.volume
-                return (self.volume / distance) * 100  # L/100km
+                if consumption_unit == 'mpg':
+                    gallons = _to_uk_gallons(self.volume, volume_unit)
+                    return distance / gallons if gallons > 0 else None
+                if consumption_unit == 'mpg_us':
+                    gallons = _to_us_gallons(self.volume, volume_unit)
+                    return distance / gallons if gallons > 0 else None
+                litres = _to_litres(self.volume, volume_unit)
+                return (litres / distance) * 100  # L/100km
         return None
 
-    def to_dict(self, consumption_unit=None):
+    def to_dict(self, consumption_unit=None, volume_unit='L'):
         """Serialize fuel log to dictionary for API"""
-        consumption = self.get_consumption(consumption_unit)
+        consumption = self.get_consumption(consumption_unit, volume_unit)
         return {
             'id': self.id,
             'vehicle_id': self.vehicle_id,

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -274,7 +274,7 @@ def vehicle_stats(vehicle_id):
     logs = vehicle.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.date).all()
     consumption_data = []
     for log in logs:
-        consumption = log.get_consumption(current_user.consumption_unit)
+        consumption = log.get_consumption(current_user.consumption_unit, current_user.volume_unit)
         if consumption:
             consumption_data.append({
                 'date': log.date.isoformat(),
@@ -296,7 +296,7 @@ def vehicle_stats(vehicle_id):
         'total_fuel_cost': vehicle.get_total_fuel_cost(),
         'total_expense_cost': vehicle.get_total_expense_cost(),
         'total_distance': vehicle.get_total_distance(vehicle.get_effective_odometer_unit()),
-        'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit)
+        'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit, current_user.volume_unit)
     })
 
 
@@ -2771,15 +2771,17 @@ def parse_date_value(value, date_format='auto'):
     value = value.strip()
 
     if date_format == 'DD/MM/YYYY':
-        formats = ['%d/%m/%Y', '%d-%m-%Y', '%d.%m.%Y', '%d/%m/%y']
+        formats = ['%d/%m/%Y %H:%M:%S', '%d/%m/%Y %H:%M', '%d/%m/%Y', '%d-%m-%Y', '%d.%m.%Y', '%d/%m/%y']
     elif date_format == 'MM/DD/YYYY':
-        formats = ['%m/%d/%Y', '%m-%d-%Y', '%m/%d/%y']
+        formats = ['%m/%d/%Y %H:%M:%S', '%m/%d/%Y %H:%M', '%m/%d/%Y', '%m-%d-%Y', '%m/%d/%y']
     elif date_format == 'YYYY-MM-DD':
-        formats = ['%Y-%m-%d', '%Y/%m/%d']
+        formats = ['%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M', '%Y-%m-%d', '%Y/%m/%d']
     else:
         # Auto-detect: try unambiguous formats first
-        formats = ['%Y-%m-%d', '%Y/%m/%d', '%d/%m/%Y', '%m/%d/%Y', '%d-%m-%Y',
-                   '%m-%d-%Y', '%d.%m.%Y', '%d/%m/%y', '%m/%d/%y', '%Y-%m-%d %H:%M:%S']
+        formats = ['%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M', '%Y-%m-%d', '%Y/%m/%d',
+                   '%d/%m/%Y %H:%M:%S', '%d/%m/%Y %H:%M', '%d/%m/%Y',
+                   '%m/%d/%Y %H:%M:%S', '%m/%d/%Y %H:%M', '%m/%d/%Y',
+                   '%d-%m-%Y', '%m-%d-%Y', '%d.%m.%Y', '%d/%m/%y', '%m/%d/%y']
 
     for fmt in formats:
         try:

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -478,10 +478,19 @@ def users():
 @admin_required
 def toggle_admin(user_id):
     user = User.query.get_or_404(user_id)
-    if user.id != current_user.id:
-        user.is_admin = not user.is_admin
-        db.session.commit()
-        flash(_('Admin status updated for %(username)s') % {'username': user.username}, 'success')
+    if user.id == current_user.id:
+        return redirect(url_for('auth.users'))
+
+    # Prevent removing admin from the last admin account
+    if user.is_admin:
+        admin_count = User.query.filter_by(is_admin=True).count()
+        if admin_count <= 1:
+            flash(_('Cannot remove admin status from the last administrator.'), 'error')
+            return redirect(url_for('auth.users'))
+
+    user.is_admin = not user.is_admin
+    db.session.commit()
+    flash(_('Admin status updated for %(username)s') % {'username': user.username}, 'success')
 
     return redirect(url_for('auth.users'))
 

--- a/app/routes/calendar.py
+++ b/app/routes/calendar.py
@@ -193,7 +193,7 @@ def calendar_feed(user):
                 summary=summary,
                 description=description,
                 dtstart=item.next_due,
-                alarm_days=item.remind_days_before or 7
+                alarm_days=item.notify_before_days or 7
             ))
 
     # Document expiry dates
@@ -235,7 +235,7 @@ def calendar_feed(user):
             vehicle_name = vehicle.name if vehicle else 'Vehicle'
 
             summary = f"⏰ {reminder.title} - {vehicle_name}"
-            description = reminder.notes or f"Reminder for {vehicle_name}"
+            description = reminder.description or f"Reminder for {vehicle_name}"
 
             events.append(create_vevent(
                 uid=generate_uid('remind', reminder.id, user.id),

--- a/app/routes/expenses.py
+++ b/app/routes/expenses.py
@@ -166,3 +166,28 @@ def delete(expense_id):
     db.session.commit()
     flash(_('Expense deleted successfully'), 'success')
     return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+
+@bp.route('/<int:expense_id>/attachments/<int:attachment_id>/delete', methods=['POST'])
+@login_required
+def delete_attachment(expense_id, attachment_id):
+    expense = Expense.query.get_or_404(expense_id)
+    vehicles = current_user.get_all_vehicles()
+
+    if expense.vehicle not in vehicles:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('expenses.index'))
+
+    attachment = Attachment.query.get_or_404(attachment_id)
+    if attachment.expense_id != expense_id:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('expenses.edit', expense_id=expense_id))
+
+    file_path = os.path.join(current_app.config['UPLOAD_FOLDER'], attachment.filename)
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+    db.session.delete(attachment)
+    db.session.commit()
+    flash(_('Attachment deleted'), 'success')
+    return redirect(url_for('expenses.edit', expense_id=expense_id))

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -241,6 +241,31 @@ def delete(log_id):
     return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
 
 
+@bp.route('/<int:log_id>/attachments/<int:attachment_id>/delete', methods=['POST'])
+@login_required
+def delete_attachment(log_id, attachment_id):
+    log = FuelLog.query.get_or_404(log_id)
+    vehicles = current_user.get_all_vehicles()
+
+    if log.vehicle not in vehicles:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('fuel.index'))
+
+    attachment = Attachment.query.get_or_404(attachment_id)
+    if attachment.fuel_log_id != log_id:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('fuel.edit', log_id=log_id))
+
+    file_path = os.path.join(current_app.config['UPLOAD_FOLDER'], attachment.filename)
+    if os.path.exists(file_path):
+        os.remove(file_path)
+
+    db.session.delete(attachment)
+    db.session.commit()
+    flash(_('Attachment deleted'), 'success')
+    return redirect(url_for('fuel.edit', log_id=log_id))
+
+
 @bp.route('/quick', methods=['GET', 'POST'])
 @login_required
 def quick():

--- a/app/routes/homeassistant.py
+++ b/app/routes/homeassistant.py
@@ -193,7 +193,7 @@ def vehicle_stats(vehicle_id, user):
         avg_consumption = 0
 
     # Calculate expense totals
-    total_expenses = expense_query.with_entities(func.sum(Expense.amount)).scalar() or 0
+    total_expenses = expense_query.with_entities(func.sum(Expense.cost)).scalar() or 0
 
     # Get last fill date
     last_fill = FuelLog.query.filter_by(vehicle_id=vehicle.id).order_by(
@@ -340,7 +340,7 @@ def summary(user):
 
         # Get expense totals
         expenses = Expense.query.filter_by(vehicle_id=vehicle.id).with_entities(
-            func.sum(Expense.amount)
+            func.sum(Expense.cost)
         ).scalar() or 0
         total_expenses += float(expenses)
 

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -138,13 +138,18 @@ def get_monthly_spending(vehicle_ids):
     fuel_costs = []
     expense_costs = []
 
+    now = datetime.now()
     for i in range(5, -1, -1):
-        date = datetime.now() - timedelta(days=i * 30)
-        month_start = date.replace(day=1)
-        if date.month == 12:
-            month_end = date.replace(year=date.year + 1, month=1, day=1)
+        month = now.month - i
+        year = now.year
+        while month <= 0:
+            month += 12
+            year -= 1
+        month_start = now.replace(year=year, month=month, day=1, hour=0, minute=0, second=0, microsecond=0)
+        if month == 12:
+            month_end = month_start.replace(year=year + 1, month=1, day=1)
         else:
-            month_end = date.replace(month=date.month + 1, day=1)
+            month_end = month_start.replace(month=month + 1, day=1)
 
         months.append(month_start.strftime('%b'))
 

--- a/app/routes/vehicles.py
+++ b/app/routes/vehicles.py
@@ -124,7 +124,7 @@ def view(vehicle_id):
         'total_expense_cost': vehicle.get_total_expense_cost(),
         'total_cost': vehicle.get_total_cost(),
         'total_distance': vehicle.get_total_distance(vehicle.get_effective_odometer_unit()),
-        'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit),
+        'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit, current_user.volume_unit),
         'fuel_logs_count': vehicle.fuel_logs.count(),
         'expenses_count': vehicle.expenses.count()
     }
@@ -365,7 +365,7 @@ def report(vehicle_id):
         'total_expense_cost': vehicle.get_total_expense_cost(),
         'total_cost': vehicle.get_total_cost(),
         'total_distance': vehicle.get_total_distance(vehicle.get_effective_odometer_unit()),
-        'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit),
+        'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit, current_user.volume_unit),
         'fuel_logs_count': len(fuel_logs),
         'expenses_count': len(expenses)
     }

--- a/app/routes/vehicles.py
+++ b/app/routes/vehicles.py
@@ -76,7 +76,7 @@ def new():
 
         for i, spec_type in enumerate(spec_types):
             if spec_values[i].strip():  # Only add if value is not empty
-                label = spec_labels[i] if spec_type == 'custom' else dict(VEHICLE_SPEC_TYPES).get(spec_type, spec_labels[i])
+                label = spec_labels[i] if spec_type == 'custom' else str(dict(VEHICLE_SPEC_TYPES).get(spec_type, spec_labels[i]))
                 spec = VehicleSpec(
                     vehicle_id=vehicle.id,
                     spec_type=spec_type,
@@ -207,7 +207,7 @@ def edit(vehicle_id):
 
         for i, spec_type in enumerate(spec_types):
             if spec_values[i].strip():  # Only add if value is not empty
-                label = spec_labels[i] if spec_type == 'custom' else dict(VEHICLE_SPEC_TYPES).get(spec_type, spec_labels[i])
+                label = spec_labels[i] if spec_type == 'custom' else str(dict(VEHICLE_SPEC_TYPES).get(spec_type, spec_labels[i]))
                 spec = VehicleSpec(
                     vehicle_id=vehicle.id,
                     spec_type=spec_type,

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -2104,7 +2104,7 @@ function checkForUpdates() {
     const releaseLinkEl = document.getElementById('release-link');
 
     // Show loading state
-    statusEl.textContent = '{{ _("Checking...") }}';
+    statusEl.textContent = {{ _("Checking...") | tojson }};
     spinnerEl.classList.add('animate-spin');
     updateAvailableEl.classList.add('hidden');
     upToDateEl.classList.add('hidden');
@@ -2116,21 +2116,21 @@ function checkForUpdates() {
 
             if (data.success) {
                 if (data.update_available) {
-                    statusEl.textContent = '{{ _("A newer version is available") }}';
+                    statusEl.textContent = {{ _("A newer version is available") | tojson }};
                     latestVersionEl.textContent = 'v' + data.latest_version;
                     releaseLinkEl.href = data.release_url;
                     updateAvailableEl.classList.remove('hidden');
                 } else {
-                    statusEl.textContent = '{{ _("Last checked just now") }}';
+                    statusEl.textContent = {{ _("Last checked just now") | tojson }};
                     upToDateEl.classList.remove('hidden');
                 }
             } else {
-                statusEl.textContent = '{{ _("Could not check for updates") }}';
+                statusEl.textContent = {{ _("Could not check for updates") | tojson }};
             }
         })
         .catch(err => {
             spinnerEl.classList.remove('animate-spin');
-            statusEl.textContent = '{{ _("Error checking for updates") }}';
+            statusEl.textContent = {{ _("Error checking for updates") | tojson }};
             console.error(err);
         });
 }

--- a/app/templates/expenses/form.html
+++ b/app/templates/expenses/form.html
@@ -83,8 +83,12 @@
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Receipt / Attachment</label>
                     {% if expense %}
                     {% for attachment in expense.attachments.all() %}
-                    <div class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-                        Current: <a href="{{ url_for('api.uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-primary-600 hover:text-primary-500">{{ attachment.original_filename }}</a>
+                    <div class="mt-2 flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                        <a href="{{ url_for('api.uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-primary-600 hover:text-primary-500">{{ attachment.original_filename }}</a>
+                        <form method="POST" action="{{ url_for('expenses.delete_attachment', expense_id=expense.id, attachment_id=attachment.id) }}" onsubmit="return confirm('Delete this attachment?')">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="text-red-600 hover:text-red-800 text-xs">Delete</button>
+                        </form>
                     </div>
                     {% endfor %}
                     {% endif %}

--- a/app/templates/expenses/form.html
+++ b/app/templates/expenses/form.html
@@ -18,6 +18,7 @@
                             class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
                         {% for vehicle in vehicles %}
                         <option value="{{ vehicle.id }}"
+                                data-odometer-unit="{{ vehicle.get_effective_odometer_unit() }}"
                                 {% if (expense and expense.vehicle_id == vehicle.id) or (selected_vehicle_id == vehicle.id) %}selected{% endif %}>
                             {{ vehicle.name }}
                         </option>
@@ -58,7 +59,7 @@
                 </div>
 
                 <div>
-                    <label for="odometer" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Odometer ({{ current_user.distance_unit }})</label>
+                    <label for="odometer" id="odometer-label" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Odometer ({{ current_user.distance_unit }})</label>
                     <input type="number" name="odometer" id="odometer" step="0.1"
                            value="{{ expense.odometer if expense else '' }}"
                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
@@ -106,4 +107,24 @@
     </form>
 </div>
 
+{% endblock %}
+
+{% block scripts %}
+<script>
+    (function() {
+        const vehicleSelect = document.getElementById('vehicle_id');
+        const odometerLabel = document.getElementById('odometer-label');
+
+        function updateOdometerUnit() {
+            const selected = vehicleSelect.options[vehicleSelect.selectedIndex];
+            const unit = selected ? selected.dataset.odometerUnit : '{{ current_user.distance_unit }}';
+            if (unit) {
+                odometerLabel.textContent = odometerLabel.textContent.replace(/\([^)]*\)/, '(' + unit + ')');
+            }
+        }
+
+        vehicleSelect.addEventListener('change', updateOdometerUnit);
+        updateOdometerUnit();
+    })();
+</script>
 {% endblock %}

--- a/app/templates/fuel/form.html
+++ b/app/templates/fuel/form.html
@@ -130,8 +130,12 @@
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Receipt / Attachment</label>
                     {% if log %}
                     {% for attachment in log.attachments.all() %}
-                    <div class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-                        Current: <a href="{{ url_for('api.uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-primary-600 hover:text-primary-500">{{ attachment.original_filename }}</a>
+                    <div class="mt-2 flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                        <a href="{{ url_for('api.uploaded_file', filename=attachment.filename) }}" target="_blank" class="text-primary-600 hover:text-primary-500">{{ attachment.original_filename }}</a>
+                        <form method="POST" action="{{ url_for('fuel.delete_attachment', log_id=log.id, attachment_id=attachment.id) }}" onsubmit="return confirm('Delete this attachment?')">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="text-red-600 hover:text-red-800 text-xs">Delete</button>
+                        </form>
                     </div>
                     {% endfor %}
                     {% endif %}

--- a/app/templates/fuel/index.html
+++ b/app/templates/fuel/index.html
@@ -52,7 +52,7 @@
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ "%.2f"|format(log.total_cost or 0) }} {{ current_user.currency }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                        {% set consumption = log.get_consumption(current_user.consumption_unit) %}
+                        {% set consumption = log.get_consumption(current_user.consumption_unit, current_user.volume_unit) %}
                         {% if consumption %}{{ "%.1f"|format(consumption) }} {{ current_user.consumption_unit }}{% else %}-{% endif %}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -564,7 +564,7 @@
                     <div class="flex items-center gap-3">
                         <div class="text-right">
                             <p class="text-sm font-medium text-gray-900 dark:text-white">{{ "%.2f"|format(log.total_cost or 0) }} {{ current_user.currency }}</p>
-                            {% set consumption = log.get_consumption(current_user.consumption_unit) %}
+                            {% set consumption = log.get_consumption(current_user.consumption_unit, current_user.volume_unit) %}
                             {% if consumption %}
                             <p class="text-sm text-gray-500 dark:text-gray-400">{{ "%.1f"|format(consumption) }} {{ current_user.consumption_unit }}</p>
                             {% endif %}

--- a/app/translations/de/LC_MESSAGES/messages.po
+++ b/app/translations/de/LC_MESSAGES/messages.po
@@ -19,70 +19,63 @@ msgstr ""
 
 #: app/models.py:624
 msgid "Front Tire Size"
-msgstr ""
+msgstr "Reifengröße vorn"
 
 #: app/models.py:625
-#, fuzzy
 msgid "Rear Tire Size"
-msgstr "Benutzer erstellen"
+msgstr "Reifengröße hinten"
 
 #: app/models.py:626
 msgid "Wheel Size"
-msgstr ""
+msgstr "Reifengröße"
 
 #: app/models.py:627
-#, fuzzy
 msgid "Engine Oil Type"
-msgstr "Ungültiger Dateityp"
+msgstr "Motoröltyp"
 
 #: app/models.py:628
 msgid "Oil Capacity"
-msgstr ""
+msgstr "Max. Ölmenge"
 
 #: app/models.py:629
-#, fuzzy
 msgid "Coolant Type"
-msgstr "Ladetyp"
+msgstr "Kühltyp"
 
 #: app/models.py:630
 msgid "Front Wiper Size"
-msgstr ""
+msgstr "Wischblättergröße vorn"
 
 #: app/models.py:631
 msgid "Rear Wiper Size"
-msgstr ""
+msgstr "Wischblattgröße hinten"
 
 #: app/models.py:632
-#, fuzzy
 msgid "Battery Type"
-msgstr "Batteriestand"
+msgstr "Batterietyp"
 
 #: app/models.py:633
-#, fuzzy
 msgid "Spark Plug Type"
-msgstr "Ladetyp"
+msgstr "Zündkerzentyp"
 
 #: app/models.py:634
-#, fuzzy
 msgid "Air Filter Part #"
-msgstr "Tankstelle hinzufügen"
+msgstr "Luftfiltertyp #"
 
 #: app/models.py:635
-#, fuzzy
 msgid "Cabin Filter Part #"
-msgstr "Tankstelle hinzufügen"
+msgstr "Innenraumfiltertyp"
 
 #: app/models.py:636
 msgid "Front Brake Pads"
-msgstr ""
+msgstr "Vordere Bremsbeläge"
 
 #: app/models.py:637
 msgid "Rear Brake Pads"
-msgstr ""
+msgstr "Hintere Bremsbeläge"
 
 #: app/models.py:638 app/models.py:1127
 msgid "Transmission Fluid"
-msgstr ""
+msgstr "Getriebeöl"
 
 #: app/models.py:639 app/models.py:706 app/models.py:757
 #: app/templates/auth/settings.html:176
@@ -96,141 +89,125 @@ msgid "Maintenance"
 msgstr "Wartung"
 
 #: app/models.py:645
-#, fuzzy
 msgid "Repairs"
-msgstr "Teile"
+msgstr "Reparaturen"
 
 #: app/models.py:646
-#, fuzzy
 msgid "Insurance"
-msgstr "Entfernung"
+msgstr "Versicherung"
 
 #: app/models.py:647 app/models.py:701
 msgid "Road Tax"
-msgstr ""
+msgstr "KfZ-Steuer"
 
 #: app/models.py:648 app/templates/vehicles/view.html:59
-#, fuzzy
 msgid "Registration"
-msgstr "Registrierung erlauben"
+msgstr "Registrierung"
 
 #: app/models.py:649
-#, fuzzy
 msgid "Parking"
-msgstr "Laden"
+msgstr "Parken"
 
 #: app/models.py:650
-#, fuzzy
 msgid "Tolls"
-msgstr "Gesamt"
+msgstr "Maut"
 
 #: app/models.py:651
-#, fuzzy
 msgid "Cleaning"
-msgstr "Laden"
+msgstr "Reinigung"
 
 #: app/models.py:652
-#, fuzzy
 msgid "Accessories"
-msgstr "Zugriff verweigert"
+msgstr "Zubehör"
 
 #: app/models.py:653 app/models.py:667 app/models.py:693 app/models.py:725
 #: app/models.py:735 app/models.py:769 app/models.py:1133
-#, fuzzy
 msgid "Other"
-msgstr "Kilometerstand"
+msgstr "andere"
 
 #: app/models.py:658
-#, fuzzy
 msgid "Car"
-msgstr "Zurücksetzen"
+msgstr "Auto"
 
 #: app/models.py:659
-#, fuzzy
 msgid "Van"
-msgstr "FIN"
+msgstr "Van"
 
 #: app/models.py:660
-#, fuzzy
 msgid "Motorbike"
-msgstr "Mehr"
+msgstr "Motorrad"
 
 #: app/models.py:661
-#, fuzzy
 msgid "Scooter"
-msgstr "Kilometerstand"
+msgstr "Scooter"
 
 #: app/models.py:662
 msgid "Truck"
-msgstr ""
+msgstr "Lastkraftwagen"
 
 #: app/models.py:663
 msgid "SUV"
-msgstr ""
+msgstr "SUV"
 
 #: app/models.py:664
-#, fuzzy
 msgid "Tractor"
-msgstr "Administrator"
+msgstr "Traktor"
 
 #: app/models.py:665
 msgid "ATV/UTV"
-msgstr ""
+msgstr "ATV/UTV"
 
 #: app/models.py:666
-#, fuzzy
 msgid "Boat"
-msgstr "Über"
+msgstr "Boot/Schiff"
 
 #: app/models.py:672
 msgid "Mileage (km/mi)"
-msgstr ""
+msgstr "Verbrauch (km/mi)"
 
 #: app/models.py:673
-#, fuzzy
 msgid "Hours"
-msgstr "Benutzer"
+msgstr "Stunden"
 
 #: app/models.py:678
 msgid "Kilometres (km)"
-msgstr ""
+msgstr "Kilometer (km)"
 
 #: app/models.py:679
-#, fuzzy
 msgid "Miles (mi)"
-msgstr "E-Mail (SMTP)"
+msgstr "Milen (mi)"
 
 #: app/models.py:684
 msgid "Petrol/Gasoline"
-msgstr ""
+msgstr "Benzin"
 
 #: app/models.py:685
 msgid "Diesel"
-msgstr ""
+msgstr "Diesel"
 
 #: app/models.py:686
 msgid "Electric"
-msgstr ""
+msgstr "Elektrisch"
 
 #: app/models.py:687
 msgid "Hybrid"
-msgstr ""
+msgstr "Hybrid"
 
 #: app/models.py:688
 msgid "Plug-in Hybrid"
-msgstr ""
+msgstr "Plug-in Hybrid"
 
 #: app/models.py:689
 msgid "LPG"
-msgstr ""
+msgstr "LPG"
 
 #: app/models.py:690
 msgid "CNG"
-msgstr ""
+msgstr "Erdgas"
 
 #: app/models.py:691
 msgid "Hydrogen"
-msgstr ""
+msgstr "Wasserstoff"
 
 #: app/models.py:692
 msgid "E85/Flex Fuel"
@@ -238,7 +215,7 @@ msgstr ""
 
 #: app/models.py:698
 msgid "MOT/Inspection"
-msgstr ""
+msgstr "Inspektion"
 
 #: app/models.py:699
 #, fuzzy
@@ -247,242 +224,216 @@ msgstr "Service-Verlauf"
 
 #: app/models.py:700
 msgid "Insurance Renewal"
-msgstr ""
+msgstr "Versicherung verlängern"
 
 #: app/models.py:702
-#, fuzzy
 msgid "Registration Renewal"
-msgstr "Registrierung erlauben"
+msgstr "Registrierung erneuern"
 
 #: app/models.py:703
-#, fuzzy
 msgid "Warranty Expiry"
-msgstr "MOT-Ablauf"
+msgstr "Garantieablauf"
 
 #: app/models.py:704
-#, fuzzy
 msgid "Tire Change"
-msgstr "Änderungen speichern"
+msgstr "Reifenwechsel"
 
 #: app/models.py:705 app/models.py:740
-#, fuzzy
 msgid "Oil Change"
-msgstr "z.B. Ölwechsel"
+msgstr "Ölwechsel"
 
 #: app/models.py:711
 msgid "No Repeat"
-msgstr ""
+msgstr "kene Wiederholung"
 
 #: app/models.py:712 app/templates/recurring/form.html:57
 msgid "Monthly"
 msgstr "Monatlich"
 
 #: app/models.py:713
-#, fuzzy
 msgid "Quarterly (3 months)"
 msgstr "Vierteljährlich (alle 3 Monate)"
 
 #: app/models.py:714
-#, fuzzy
 msgid "Every 6 months"
-msgstr "Alle (Monate)"
+msgstr "Alle 6 Monate"
 
 #: app/models.py:715 app/templates/recurring/form.html:60
 msgid "Yearly"
 msgstr "Jährlich"
 
 #: app/models.py:720
-#, fuzzy
 msgid "Business"
-msgstr "SSL verwenden"
+msgstr "Geschäftlich"
 
 #: app/models.py:721
-#, fuzzy
 msgid "Personal"
-msgstr "Version"
+msgstr "Privat"
 
 #: app/models.py:722
 #, fuzzy
 msgid "Commute"
-msgstr "Erledigen"
+msgstr "Pendeln"
 
 #: app/models.py:723
 msgid "Medical"
-msgstr ""
+msgstr "medizinisch"
 
 #: app/models.py:724
-#, fuzzy
 msgid "Charity"
-msgstr "Stadt"
+msgstr "Wohltätigkeit"
 
 #: app/models.py:730
-#, fuzzy
 msgid "Home Charging"
-msgstr "Elektro-Laden"
+msgstr "Elektroladung zu Hause"
 
 #: app/models.py:731
 msgid "Level 1"
-msgstr ""
+msgstr "Level 1"
 
 #: app/models.py:732
 msgid "Level 2"
-msgstr ""
+msgstr "Level 2"
 
 #: app/models.py:733
-#, fuzzy
 msgid "DC Fast Charge"
-msgstr "Ersten Ladevorgang erfassen"
+msgstr "Schnelladung"
 
 #: app/models.py:734
 msgid "Tesla Supercharger"
-msgstr ""
+msgstr "esla Supercharger"
 
 #: app/models.py:741 app/models.py:1119
-#, fuzzy
 msgid "Oil Filter"
-msgstr "Filtern"
+msgstr "Ölfilter"
 
 #: app/models.py:742 app/models.py:1120
-#, fuzzy
 msgid "Air Filter"
-msgstr "Filtern"
+msgstr "Luftfilter"
 
 #: app/models.py:743
 msgid "Cabin/Pollen Filter"
-msgstr ""
+msgstr "Pollenfilter"
 
 #: app/models.py:744 app/models.py:1121
-#, fuzzy
 msgid "Fuel Filter"
-msgstr "Filtern"
+msgstr "Kraftstofffilter"
 
 #: app/models.py:745
 msgid "Spark Plugs"
-msgstr ""
+msgstr "Zündkerzen"
 
 #: app/models.py:746
-#, fuzzy
 msgid "Brake Pads"
-msgstr "Zurück zu Fahrten"
+msgstr "Bremsklötze"
 
 #: app/models.py:747 app/models.py:1125
 msgid "Brake Fluid"
-msgstr ""
+msgstr "Bremsflüssigkeit"
 
 #: app/models.py:748
 msgid "Coolant Flush"
-msgstr ""
+msgstr "Kühlflüssigkeit"
 
 #: app/models.py:749
-#, fuzzy
 msgid "Transmission Service"
-msgstr "Benachrichtigungsdienste"
+msgstr "Überführungskosten"
 
 #: app/models.py:750
 msgid "Timing Belt"
-msgstr ""
+msgstr "Zahnriemen"
 
 #: app/models.py:751
 msgid "Serpentine Belt"
-msgstr ""
+msgstr "Keilriemen"
 
 #: app/models.py:752
-#, fuzzy
 msgid "Tire Rotation"
-msgstr "Tessie-Integration"
+msgstr "Radwechsel"
 
 #: app/models.py:753
 msgid "Wheel Alignment"
-msgstr ""
+msgstr "Achsvermessung"
 
 #: app/models.py:754
 msgid "Battery Check/Replace"
-msgstr ""
+msgstr "Batterieprüfung/-austausch"
 
 #: app/models.py:755
 msgid "Wiper Blades"
-msgstr ""
+msgstr "Wischblätter"
 
 #: app/models.py:756
 msgid "Full Service"
-msgstr ""
+msgstr "Voller Service"
 
 #: app/models.py:762
-#, fuzzy
 msgid "Insurance Policy"
-msgstr "z.B. Versicherungspolice 2024"
+msgstr "Versicherungspolice"
 
 #: app/models.py:763
-#, fuzzy
 msgid "Registration/V5C"
-msgstr "Registrierung erlauben"
+msgstr "Kraftfahrzeugbrief"
 
 #: app/models.py:764
 msgid "MOT Certificate"
-msgstr ""
+msgstr "TÜV-Bericht"
 
 #: app/models.py:765
-#, fuzzy
 msgid "Service Record"
-msgstr "Wartungsintervall"
+msgstr "Servicebericht"
 
 #: app/models.py:766
 msgid "Purchase Invoice"
-msgstr ""
+msgstr "Rechnung Kauf"
 
 #: app/models.py:767
-#, fuzzy
 msgid "Warranty Document"
-msgstr "Keine Dokumente"
+msgstr "Garantieurkunde"
 
 #: app/models.py:768
 msgid "Owner's Manual"
-msgstr ""
+msgstr "Betriebsanleitung"
 
 #: app/models.py:1118
 msgid "Engine Oil"
-msgstr ""
+msgstr "Motoröl"
 
 #: app/models.py:1122
-#, fuzzy
 msgid "Cabin Filter"
-msgstr "Filtern"
+msgstr "Pollenfilter"
 
 #: app/models.py:1123
-#, fuzzy
 msgid "Spark Plug"
-msgstr "Startseite"
+msgstr "Zündkerze"
 
 #: app/models.py:1124
 msgid "Brake Pad"
-msgstr ""
+msgstr "Bremsklötze"
 
 #: app/models.py:1126
 msgid "Coolant"
-msgstr ""
+msgstr "Kühlflüssigkeit"
 
 #: app/models.py:1128
-#, fuzzy
 msgid "Battery"
-msgstr "Batteriestand"
+msgstr "Batterie"
 
 #: app/models.py:1129
-#, fuzzy
 msgid "Tire"
-msgstr "Titel"
+msgstr "Reifen"
 
 #: app/models.py:1130
-#, fuzzy
 msgid "Belt"
-msgstr "Löschen"
+msgstr "Gurt"
 
 #: app/models.py:1131
 msgid "Wiper Blade"
-msgstr ""
+msgstr "Wischblätter"
 
 #: app/models.py:1132
 msgid "Light Bulb"
-msgstr ""
+msgstr "Glühlampe"
 
 #: app/routes/api.py:2141 app/routes/api.py:2354 app/routes/api.py:2527
 msgid "No file uploaded"

--- a/app/translations/es/LC_MESSAGES/messages.po
+++ b/app/translations/es/LC_MESSAGES/messages.po
@@ -20,43 +20,43 @@ msgstr ""
 
 #: app/models.py:624
 msgid "Front Tire Size"
-msgstr ""
+msgstr "Tamaño neumático delantero"
 
 #: app/models.py:625
 #, fuzzy
 msgid "Rear Tire Size"
-msgstr "Crear usuario"
+msgstr "Tamaño neumático trasero"
 
 #: app/models.py:626
 msgid "Wheel Size"
-msgstr ""
+msgstr "Tamaño Neumático"
 
 #: app/models.py:627
 #, fuzzy
 msgid "Engine Oil Type"
-msgstr "Tipo de archivo no válido"
+msgstr "Tipo de Aceite Motor"
 
 #: app/models.py:628
 msgid "Oil Capacity"
-msgstr ""
+msgstr "Capacidad Aceite"
 
 #: app/models.py:629
 #, fuzzy
 msgid "Coolant Type"
-msgstr "Tipo de cargador"
+msgstr "Tipo de refrigerante"
 
 #: app/models.py:630
 msgid "Front Wiper Size"
-msgstr ""
+msgstr "Tamaño del limpiaparabrisas delantero"
 
 #: app/models.py:631
 msgid "Rear Wiper Size"
-msgstr ""
+msgstr "Tamaño del limpiaparabrisas trasero"
 
 #: app/models.py:632
 #, fuzzy
 msgid "Battery Type"
-msgstr "Nivel de batería"
+msgstr "Tipo de batería"
 
 #: app/models.py:633
 #, fuzzy
@@ -66,24 +66,24 @@ msgstr "Tipo de cargador"
 #: app/models.py:634
 #, fuzzy
 msgid "Air Filter Part #"
-msgstr "Agregar gasolinera"
+msgstr "Filtro Aire Part #"
 
 #: app/models.py:635
 #, fuzzy
 msgid "Cabin Filter Part #"
-msgstr "Agregar gasolinera"
+msgstr "Filtro habitáculo Part #"
 
 #: app/models.py:636
 msgid "Front Brake Pads"
-msgstr ""
+msgstr "Pastillas freno delanteras"
 
 #: app/models.py:637
 msgid "Rear Brake Pads"
-msgstr ""
+msgstr "Pastillas freno traseras"
 
 #: app/models.py:638 app/models.py:1127
 msgid "Transmission Fluid"
-msgstr ""
+msgstr "Líquido transmisión"
 
 #: app/models.py:639 app/models.py:706 app/models.py:757
 #: app/templates/auth/settings.html:176
@@ -99,52 +99,52 @@ msgstr "Mantenimiento"
 #: app/models.py:645
 #, fuzzy
 msgid "Repairs"
-msgstr "Piezas"
+msgstr "Repuestos"
 
 #: app/models.py:646
 #, fuzzy
 msgid "Insurance"
-msgstr "Distancia"
+msgstr "Seguro"
 
 #: app/models.py:647 app/models.py:701
 msgid "Road Tax"
-msgstr ""
+msgstr "Impuesto circulación"
 
 #: app/models.py:648 app/templates/vehicles/view.html:59
 #, fuzzy
 msgid "Registration"
-msgstr "Permitir registro"
+msgstr "Registro"
 
 #: app/models.py:649
 #, fuzzy
 msgid "Parking"
-msgstr "Carga"
+msgstr "Aparcamiento"
 
 #: app/models.py:650
 #, fuzzy
 msgid "Tolls"
-msgstr "Total"
+msgstr "Peaje"
 
 #: app/models.py:651
 #, fuzzy
 msgid "Cleaning"
-msgstr "Carga"
+msgstr "Limpieza"
 
 #: app/models.py:652
 #, fuzzy
 msgid "Accessories"
-msgstr "Acceso denegado"
+msgstr "Accesorios"
 
 #: app/models.py:653 app/models.py:667 app/models.py:693 app/models.py:725
 #: app/models.py:735 app/models.py:769 app/models.py:1133
 #, fuzzy
 msgid "Other"
-msgstr "Odómetro"
+msgstr "Otro"
 
 #: app/models.py:658
 #, fuzzy
 msgid "Car"
-msgstr "Limpiar"
+msgstr "Coche"
 
 #: app/models.py:659
 #, fuzzy
@@ -154,84 +154,84 @@ msgstr "VIN"
 #: app/models.py:660
 #, fuzzy
 msgid "Motorbike"
-msgstr "Más"
+msgstr "Moto"
 
 #: app/models.py:661
 #, fuzzy
 msgid "Scooter"
-msgstr "Odómetro"
+msgstr "Scooter"
 
 #: app/models.py:662
 msgid "Truck"
-msgstr ""
+msgstr "Camión"
 
 #: app/models.py:663
 msgid "SUV"
-msgstr ""
+msgstr "SUV"
 
 #: app/models.py:664
 #, fuzzy
 msgid "Tractor"
-msgstr "Administrador"
+msgstr "Tractor"
 
 #: app/models.py:665
 msgid "ATV/UTV"
-msgstr ""
+msgstr "ATV/UTV"
 
 #: app/models.py:666
 #, fuzzy
 msgid "Boat"
-msgstr "Acerca de"
+msgstr "Barco"
 
 #: app/models.py:672
 msgid "Mileage (km/mi)"
-msgstr ""
+msgstr "Kilometraje (km/mi)"
 
 #: app/models.py:673
 #, fuzzy
 msgid "Hours"
-msgstr "Usuarios"
+msgstr "Horas"
 
 #: app/models.py:678
 msgid "Kilometres (km)"
-msgstr ""
+msgstr "Kilómetros (km)"
 
 #: app/models.py:679
 #, fuzzy
 msgid "Miles (mi)"
-msgstr "Correo electrónico (SMTP)"
+msgstr "Millas"
 
 #: app/models.py:684
 msgid "Petrol/Gasoline"
-msgstr ""
+msgstr "Gasolina"
 
 #: app/models.py:685
 msgid "Diesel"
-msgstr ""
+msgstr "Diesel"
 
 #: app/models.py:686
 msgid "Electric"
-msgstr ""
+msgstr "Eléctrico"
 
 #: app/models.py:687
 msgid "Hybrid"
-msgstr ""
+msgstr "Híbrido"
 
 #: app/models.py:688
 msgid "Plug-in Hybrid"
-msgstr ""
+msgstr "Híbrido Enchufable"
 
 #: app/models.py:689
 msgid "LPG"
-msgstr ""
+msgstr "GLP"
 
 #: app/models.py:690
 msgid "CNG"
-msgstr ""
+msgstr "GNC"
 
 #: app/models.py:691
 msgid "Hydrogen"
-msgstr ""
+msgstr "Hidrógeno"
 
 #: app/models.py:692
 msgid "E85/Flex Fuel"
@@ -248,31 +248,31 @@ msgstr "Línea de tiempo de servicio"
 
 #: app/models.py:700
 msgid "Insurance Renewal"
-msgstr ""
+msgstr "Renovación seguro"
 
 #: app/models.py:702
 #, fuzzy
 msgid "Registration Renewal"
-msgstr "Permitir registro"
+msgstr "Renovar registro"
 
 #: app/models.py:703
 #, fuzzy
 msgid "Warranty Expiry"
-msgstr "Vencimiento de MOT"
+msgstr "Fin garantía"
 
 #: app/models.py:704
 #, fuzzy
 msgid "Tire Change"
-msgstr "Guardar cambios"
+msgstr "Cambiar neumáticos"
 
 #: app/models.py:705 app/models.py:740
 #, fuzzy
 msgid "Oil Change"
-msgstr "ej., Cambio de aceite"
+msgstr "Cambio de aceite"
 
 #: app/models.py:711
 msgid "No Repeat"
-msgstr ""
+msgstr "No repetir"
 
 #: app/models.py:712 app/templates/recurring/form.html:57
 msgid "Monthly"
@@ -286,7 +286,7 @@ msgstr "Trimestral (cada 3 meses)"
 #: app/models.py:714
 #, fuzzy
 msgid "Every 6 months"
-msgstr "Cada (meses)"
+msgstr "Semestral"
 
 #: app/models.py:715 app/templates/recurring/form.html:60
 msgid "Yearly"
@@ -295,17 +295,17 @@ msgstr "Anual"
 #: app/models.py:720
 #, fuzzy
 msgid "Business"
-msgstr "Usar SSL"
+msgstr "Trabajo"
 
 #: app/models.py:721
 #, fuzzy
 msgid "Personal"
-msgstr "Versión"
+msgstr "Personal"
 
 #: app/models.py:722
 #, fuzzy
 msgid "Commute"
-msgstr "Completar"
+msgstr "Desplazamiento"
 
 #: app/models.py:723
 msgid "Medical"
@@ -314,7 +314,7 @@ msgstr ""
 #: app/models.py:724
 #, fuzzy
 msgid "Charity"
-msgstr "Ciudad"
+msgstr "Caridad"
 
 #: app/models.py:730
 #, fuzzy
@@ -323,167 +323,167 @@ msgstr "Carga EV"
 
 #: app/models.py:731
 msgid "Level 1"
-msgstr ""
+msgstr "Nivel 1"
 
 #: app/models.py:732
 msgid "Level 2"
-msgstr ""
+msgstr "Nivel 2"
 
 #: app/models.py:733
 #, fuzzy
 msgid "DC Fast Charge"
-msgstr "Registre su primera carga"
+msgstr "Carga Rápida"
 
 #: app/models.py:734
 msgid "Tesla Supercharger"
-msgstr ""
+msgstr "Supercargador Tesla"
 
 #: app/models.py:741 app/models.py:1119
 #, fuzzy
 msgid "Oil Filter"
-msgstr "Filtrar"
+msgstr "Filtro de aceite"
 
 #: app/models.py:742 app/models.py:1120
 #, fuzzy
 msgid "Air Filter"
-msgstr "Filtrar"
+msgstr "Filtro de aire"
 
 #: app/models.py:743
 msgid "Cabin/Pollen Filter"
-msgstr ""
+msgstr "Filtro habitáculo"
 
 #: app/models.py:744 app/models.py:1121
 #, fuzzy
 msgid "Fuel Filter"
-msgstr "Filtrar"
+msgstr "Filtro combustible"
 
 #: app/models.py:745
 msgid "Spark Plugs"
-msgstr ""
+msgstr "Bujías"
 
 #: app/models.py:746
 #, fuzzy
 msgid "Brake Pads"
-msgstr "Volver a viajes"
+msgstr "Pastillas de freno"
 
 #: app/models.py:747 app/models.py:1125
 msgid "Brake Fluid"
-msgstr ""
+msgstr "Líquido de frenos"
 
 #: app/models.py:748
 msgid "Coolant Flush"
-msgstr ""
+msgstr "Renovar líquido refrigerante"
 
 #: app/models.py:749
 #, fuzzy
 msgid "Transmission Service"
-msgstr "Servicios de notificación"
+msgstr "Caja de cambios"
 
 #: app/models.py:750
 msgid "Timing Belt"
-msgstr ""
+msgstr "Correa de distribución"
 
 #: app/models.py:751
 msgid "Serpentine Belt"
-msgstr ""
+msgstr "Correa de distribución"
 
 #: app/models.py:752
 #, fuzzy
 msgid "Tire Rotation"
-msgstr "Integración con Tessie"
+msgstr "Equilibrado de neumáticos"
 
 #: app/models.py:753
 msgid "Wheel Alignment"
-msgstr ""
+msgstr "Paralelo"
 
 #: app/models.py:754
 msgid "Battery Check/Replace"
-msgstr ""
+msgstr "Comprobación/Reemplazo batería"
 
 #: app/models.py:755
 msgid "Wiper Blades"
-msgstr ""
+msgstr "Gomas limpiaparabrisas"
 
 #: app/models.py:756
 msgid "Full Service"
-msgstr ""
+msgstr "Servicio completo"
 
 #: app/models.py:762
 #, fuzzy
 msgid "Insurance Policy"
-msgstr "ej., Póliza de seguro 2024"
+msgstr "Póliza de seguro"
 
 #: app/models.py:763
 #, fuzzy
 msgid "Registration/V5C"
-msgstr "Permitir registro"
+msgstr "Alta de vehículo"
 
 #: app/models.py:764
 msgid "MOT Certificate"
-msgstr ""
+msgstr "Certificado ITV"
 
 #: app/models.py:765
 #, fuzzy
 msgid "Service Record"
-msgstr "Intervalo de servicio"
+msgstr "Registro de servicio"
 
 #: app/models.py:766
 msgid "Purchase Invoice"
-msgstr ""
+msgstr "Factura de compra"
 
 #: app/models.py:767
 #, fuzzy
 msgid "Warranty Document"
-msgstr "No hay documentos"
+msgstr "Documento de garantía"
 
 #: app/models.py:768
 msgid "Owner's Manual"
-msgstr ""
+msgstr "Manual de propietario"
 
 #: app/models.py:1118
 msgid "Engine Oil"
-msgstr ""
+msgstr "Aceite Motor"
 
 #: app/models.py:1122
 #, fuzzy
 msgid "Cabin Filter"
-msgstr "Filtrar"
+msgstr "Filtro Habitáculo"
 
 #: app/models.py:1123
 #, fuzzy
 msgid "Spark Plug"
-msgstr "Página de inicio"
+msgstr "Bujía"
 
 #: app/models.py:1124
 msgid "Brake Pad"
-msgstr ""
+msgstr "Pastilla de freno"
 
 #: app/models.py:1126
 msgid "Coolant"
-msgstr ""
+msgstr "Refrigerante"
 
 #: app/models.py:1128
 #, fuzzy
 msgid "Battery"
-msgstr "Nivel de batería"
+msgstr "Batería"
 
 #: app/models.py:1129
 #, fuzzy
 msgid "Tire"
-msgstr "Título"
+msgstr "Neumático"
 
 #: app/models.py:1130
 #, fuzzy
 msgid "Belt"
-msgstr "Eliminar"
+msgstr "Correa"
 
 #: app/models.py:1131
 msgid "Wiper Blade"
-msgstr ""
+msgstr "Goma limpiaparabrisas"
 
 #: app/models.py:1132
 msgid "Light Bulb"
-msgstr ""
+msgstr "Bombilla de faro"
 
 #: app/routes/api.py:2141 app/routes/api.py:2354 app/routes/api.py:2527
 msgid "No file uploaded"
@@ -597,14 +597,12 @@ msgstr "Nombre de usuario o contraseña no válidos"
 
 #: app/routes/auth.py:62
 msgid "Password reset by email is not available. Please contact an administrator."
-msgstr ""
-"El restablecimiento de contraseña por correo no está disponible. Contacte"
+msgstr "El restablecimiento de contraseña por correo no está disponible. Contacte"
 " a un administrador."
 
 #: app/routes/auth.py:91
 msgid "If an account with that email exists, a password reset link has been sent."
-msgstr ""
-"Si existe una cuenta con ese correo electrónico, se ha enviado un enlace "
+msgstr "Si existe una cuenta con ese correo electrónico, se ha enviado un enlace "
 "de restablecimiento."
 
 #: app/routes/auth.py:104
@@ -618,7 +616,7 @@ msgstr "Las contraseñas no coinciden"
 
 #: app/routes/auth.py:124
 msgid "Your password has been reset. Please log in."
-msgstr "Su contraseña ha sido restablecida. Inicie sesión."
+msgstr "Su contraseña ha sido reestablecida. Inicie sesión."
 
 #: app/routes/auth.py:158
 msgid "New account registration is currently disabled."
@@ -2254,16 +2252,16 @@ msgstr "SOC final"
 
 #: app/templates/charging/form.html:125
 msgid "Cost"
-msgstr "Costo"
+msgstr "Coste"
 
 #: app/templates/charging/form.html:128
 msgid "Cost per kWh"
-msgstr "Costo por kWh"
+msgstr "Coste por kWh"
 
 #: app/templates/charging/form.html:135 app/templates/charging/index.html:26
 #: app/templates/fuel/quick.html:64
 msgid "Total Cost"
-msgstr "Costo total"
+msgstr "Coste total"
 
 #: app/templates/charging/form.html:144 app/templates/stations/form.html:74
 #: app/templates/trips/form.html:100 app/templates/vehicles/form.html:183
@@ -2283,11 +2281,11 @@ msgstr "Cancelar"
 
 #: app/templates/charging/index.html:7
 msgid "Charging Sessions"
-msgstr "Sesiones de carga"
+msgstr "Sesiones de recarga"
 
 #: app/templates/charging/index.html:8
 msgid "Track your EV charging sessions"
-msgstr "Registre sus sesiones de carga de vehículos eléctricos"
+msgstr "Registre sus sesiones de recarga de vehículos eléctricos"
 
 #: app/templates/charging/index.html:15
 msgid "Log Charge"
@@ -2318,7 +2316,7 @@ msgstr "No hay sesiones de carga"
 msgid "Start tracking your EV charging to monitor energy usage and costs."
 msgstr ""
 "Comience a registrar sus cargas de vehículo eléctrico para monitorear el "
-"uso de energía y costos."
+"uso de energía y costes."
 
 #: app/templates/charging/index.html:147
 msgid "Log Your First Charge"

--- a/app/translations/fr/LC_MESSAGES/messages.po
+++ b/app/translations/fr/LC_MESSAGES/messages.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2026-02-27 11:00+0000\n"
-"PO-Revision-Date: 2026-02-17 20:56+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2026-03-14 20:56+0000\n"
+"Last-Translator: ewilly\n"
 "Language: fr\n"
 "Language-Team: fr <LL@li.org>\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
@@ -20,70 +20,63 @@ msgstr ""
 
 #: app/models.py:624
 msgid "Front Tire Size"
-msgstr ""
+msgstr "Taille du pneu avant"
 
 #: app/models.py:625
-#, fuzzy
 msgid "Rear Tire Size"
-msgstr "Créer un utilisateur"
+msgstr "Taille du pneu arrière"
 
 #: app/models.py:626
 msgid "Wheel Size"
-msgstr ""
+msgstr "Taille de la jante"
 
 #: app/models.py:627
-#, fuzzy
 msgid "Engine Oil Type"
-msgstr "Type de fichier non valide"
+msgstr "Type d'huile moteur"
 
 #: app/models.py:628
 msgid "Oil Capacity"
-msgstr ""
+msgstr "Capacité en huile"
 
 #: app/models.py:629
-#, fuzzy
 msgid "Coolant Type"
-msgstr "Type de chargeur"
+msgstr "Type de liquide de refroidissement"
 
 #: app/models.py:630
 msgid "Front Wiper Size"
-msgstr ""
+msgstr "Taille de l'essuie-glace avant"
 
 #: app/models.py:631
 msgid "Rear Wiper Size"
-msgstr ""
+msgstr "Taille de l'essuie-glace arrière"
 
 #: app/models.py:632
-#, fuzzy
 msgid "Battery Type"
-msgstr "Niveau de batterie"
+msgstr "Type de batterie"
 
 #: app/models.py:633
-#, fuzzy
 msgid "Spark Plug Type"
-msgstr "Type de chargeur"
+msgstr "Type de bougie d'allumage"
 
 #: app/models.py:634
-#, fuzzy
 msgid "Air Filter Part #"
-msgstr "Ajouter une station"
+msgstr "Référence du filtre à air"
 
 #: app/models.py:635
-#, fuzzy
 msgid "Cabin Filter Part #"
-msgstr "Ajouter une station"
+msgstr "Référence du filtre d'habitacle"
 
 #: app/models.py:636
 msgid "Front Brake Pads"
-msgstr ""
+msgstr "Plaquettes de frein avant"
 
 #: app/models.py:637
 msgid "Rear Brake Pads"
-msgstr ""
+msgstr "Plaquettes de frein arrière"
 
 #: app/models.py:638 app/models.py:1127
 msgid "Transmission Fluid"
-msgstr ""
+msgstr "Huile de transmission"
 
 #: app/models.py:639 app/models.py:706 app/models.py:757
 #: app/templates/auth/settings.html:176
@@ -97,393 +90,349 @@ msgid "Maintenance"
 msgstr "Entretien"
 
 #: app/models.py:645
-#, fuzzy
 msgid "Repairs"
-msgstr "Pièces"
+msgstr "Réparations"
 
 #: app/models.py:646
-#, fuzzy
 msgid "Insurance"
-msgstr "Distance"
+msgstr "Assurance"
 
 #: app/models.py:647 app/models.py:701
 msgid "Road Tax"
-msgstr ""
+msgstr "Taxe de circulation"
 
 #: app/models.py:648 app/templates/vehicles/view.html:59
-#, fuzzy
 msgid "Registration"
-msgstr "Autoriser l'inscription"
+msgstr "Immatriculation"
 
 #: app/models.py:649
-#, fuzzy
 msgid "Parking"
-msgstr "Recharge"
+msgstr "Stationnement"
 
 #: app/models.py:650
-#, fuzzy
 msgid "Tolls"
-msgstr "Total"
+msgstr "Péages"
 
 #: app/models.py:651
-#, fuzzy
 msgid "Cleaning"
-msgstr "Recharge"
+msgstr "Nettoyage"
 
 #: app/models.py:652
-#, fuzzy
 msgid "Accessories"
-msgstr "Accès refusé"
+msgstr "Accessoires"
 
 #: app/models.py:653 app/models.py:667 app/models.py:693 app/models.py:725
 #: app/models.py:735 app/models.py:769 app/models.py:1133
-#, fuzzy
 msgid "Other"
-msgstr "Odomètre"
+msgstr "Autre"
 
 #: app/models.py:658
-#, fuzzy
 msgid "Car"
-msgstr "Effacer"
+msgstr "Voiture"
 
 #: app/models.py:659
-#, fuzzy
 msgid "Van"
-msgstr "VIN"
+msgstr "Fourgon"
 
 #: app/models.py:660
-#, fuzzy
 msgid "Motorbike"
-msgstr "Plus"
+msgstr "Moto"
 
 #: app/models.py:661
-#, fuzzy
 msgid "Scooter"
-msgstr "Odomètre"
+msgstr "Scooter"
 
 #: app/models.py:662
 msgid "Truck"
-msgstr ""
+msgstr "Camion"
 
 #: app/models.py:663
 msgid "SUV"
-msgstr ""
+msgstr "SUV"
 
 #: app/models.py:664
-#, fuzzy
 msgid "Tractor"
-msgstr "Administrateur"
+msgstr "Tracteur"
 
 #: app/models.py:665
 msgid "ATV/UTV"
-msgstr ""
+msgstr "Quad/SSV"
 
 #: app/models.py:666
-#, fuzzy
 msgid "Boat"
-msgstr "À propos"
+msgstr "Bateau"
 
 #: app/models.py:672
 msgid "Mileage (km/mi)"
-msgstr ""
+msgstr "Kilométrage (km/mi)"
 
 #: app/models.py:673
-#, fuzzy
 msgid "Hours"
-msgstr "Utilisateurs"
+msgstr "Heures"
 
 #: app/models.py:678
 msgid "Kilometres (km)"
-msgstr ""
+msgstr "Kilomètres (km)"
 
 #: app/models.py:679
-#, fuzzy
 msgid "Miles (mi)"
-msgstr "E-mail (SMTP)"
+msgstr "Miles (mi)"
 
 #: app/models.py:684
 msgid "Petrol/Gasoline"
-msgstr ""
+msgstr "Essence"
 
 #: app/models.py:685
 msgid "Diesel"
-msgstr ""
+msgstr "Diesel"
 
 #: app/models.py:686
 msgid "Electric"
-msgstr ""
+msgstr "Électrique"
 
 #: app/models.py:687
 msgid "Hybrid"
-msgstr ""
+msgstr "Hybride"
 
 #: app/models.py:688
 msgid "Plug-in Hybrid"
-msgstr ""
+msgstr "Hybride rechargeable"
 
 #: app/models.py:689
 msgid "LPG"
-msgstr ""
+msgstr "GPL"
 
 #: app/models.py:690
 msgid "CNG"
-msgstr ""
+msgstr "GNC"
 
 #: app/models.py:691
 msgid "Hydrogen"
-msgstr ""
+msgstr "Hydrogène"
 
 #: app/models.py:692
 msgid "E85/Flex Fuel"
-msgstr ""
+msgstr "E85 / Flex Fuel"
 
 #: app/models.py:698
 msgid "MOT/Inspection"
-msgstr ""
+msgstr "MOT/Contrôle technique"
 
 #: app/models.py:699
-#, fuzzy
 msgid "Service Due"
-msgstr "Chronologie d'entretien"
+msgstr "Entretien à effectuer"
 
 #: app/models.py:700
 msgid "Insurance Renewal"
-msgstr ""
+msgstr "Renouvellement d'assurance"
 
 #: app/models.py:702
-#, fuzzy
 msgid "Registration Renewal"
-msgstr "Autoriser l'inscription"
+msgstr "Renouvellement d'immatriculation"
 
 #: app/models.py:703
-#, fuzzy
 msgid "Warranty Expiry"
-msgstr "Expiration du MOT"
+msgstr "Expiration de la garantie"
 
 #: app/models.py:704
-#, fuzzy
 msgid "Tire Change"
-msgstr "Enregistrer les modifications"
+msgstr "Changement de pneus"
 
 #: app/models.py:705 app/models.py:740
-#, fuzzy
 msgid "Oil Change"
-msgstr "ex., Vidange"
+msgstr "Vidange"
 
 #: app/models.py:711
 msgid "No Repeat"
-msgstr ""
+msgstr "Ne pas répéter"
 
 #: app/models.py:712 app/templates/recurring/form.html:57
 msgid "Monthly"
 msgstr "Mensuel"
 
 #: app/models.py:713
-#, fuzzy
 msgid "Quarterly (3 months)"
 msgstr "Trimestriel (tous les 3 mois)"
 
 #: app/models.py:714
-#, fuzzy
 msgid "Every 6 months"
-msgstr "Tous les (mois)"
+msgstr "Tous les 6 mois"
 
 #: app/models.py:715 app/templates/recurring/form.html:60
 msgid "Yearly"
 msgstr "Annuel"
 
 #: app/models.py:720
-#, fuzzy
 msgid "Business"
-msgstr "Utiliser SSL"
+msgstr "Professionnel"
 
 #: app/models.py:721
-#, fuzzy
 msgid "Personal"
-msgstr "Version"
+msgstr "Personnel"
 
 #: app/models.py:722
-#, fuzzy
 msgid "Commute"
-msgstr "Terminer"
+msgstr "Domicile-travail"
 
 #: app/models.py:723
 msgid "Medical"
-msgstr ""
+msgstr "Médical"
 
 #: app/models.py:724
-#, fuzzy
 msgid "Charity"
-msgstr "Ville"
+msgstr "Caritatif"
 
 #: app/models.py:730
-#, fuzzy
 msgid "Home Charging"
-msgstr "Recharge VE"
+msgstr "Recharge à domicile"
 
 #: app/models.py:731
 msgid "Level 1"
-msgstr ""
+msgstr "Niveau 1"
 
 #: app/models.py:732
 msgid "Level 2"
-msgstr ""
+msgstr "Niveau 2"
 
 #: app/models.py:733
-#, fuzzy
 msgid "DC Fast Charge"
-msgstr "Enregistrez votre première recharge"
+msgstr "Recharge rapide CC"
 
 #: app/models.py:734
 msgid "Tesla Supercharger"
-msgstr ""
+msgstr "Tesla Supercharger"
 
 #: app/models.py:741 app/models.py:1119
-#, fuzzy
 msgid "Oil Filter"
-msgstr "Filtrer"
+msgstr "Filtre à huile"
 
 #: app/models.py:742 app/models.py:1120
-#, fuzzy
 msgid "Air Filter"
-msgstr "Filtrer"
+msgstr "Filtre à air"
 
 #: app/models.py:743
 msgid "Cabin/Pollen Filter"
-msgstr ""
+msgstr "Filtre d'habitacle/pollen"
 
 #: app/models.py:744 app/models.py:1121
-#, fuzzy
 msgid "Fuel Filter"
-msgstr "Filtrer"
+msgstr "Filtre à carburant"
 
 #: app/models.py:745
 msgid "Spark Plugs"
-msgstr ""
+msgstr "Bougies d'allumage"
 
 #: app/models.py:746
-#, fuzzy
 msgid "Brake Pads"
-msgstr "Retour aux trajets"
+msgstr "Plaquettes de frein"
 
 #: app/models.py:747 app/models.py:1125
 msgid "Brake Fluid"
-msgstr ""
+msgstr "Liquide de frein"
 
 #: app/models.py:748
 msgid "Coolant Flush"
-msgstr ""
+msgstr "Remplacement du liquide de refroidissement"
 
 #: app/models.py:749
-#, fuzzy
 msgid "Transmission Service"
-msgstr "Services de notification"
+msgstr "Entretien de la transmission"
 
 #: app/models.py:750
 msgid "Timing Belt"
-msgstr ""
+msgstr "Courroie de distribution"
 
 #: app/models.py:751
 msgid "Serpentine Belt"
-msgstr ""
+msgstr "Courroie d'accessoires"
 
 #: app/models.py:752
-#, fuzzy
 msgid "Tire Rotation"
-msgstr "Intégration Tessie"
+msgstr "Permutation des pneus"
 
 #: app/models.py:753
 msgid "Wheel Alignment"
-msgstr ""
+msgstr "Parallélisme"
 
 #: app/models.py:754
 msgid "Battery Check/Replace"
-msgstr ""
+msgstr "Contrôle/Remplacement de la batterie"
 
 #: app/models.py:755
 msgid "Wiper Blades"
-msgstr ""
+msgstr "Balais d'essuie-glace"
 
 #: app/models.py:756
 msgid "Full Service"
-msgstr ""
+msgstr "Révision complète"
 
 #: app/models.py:762
-#, fuzzy
 msgid "Insurance Policy"
-msgstr "ex., Police d'assurance 2024"
+msgstr "Police d'assurance"
 
 #: app/models.py:763
-#, fuzzy
 msgid "Registration/V5C"
-msgstr "Autoriser l'inscription"
+msgstr "Immatriculation/V5C"
 
 #: app/models.py:764
 msgid "MOT Certificate"
-msgstr ""
+msgstr "Certificat MOT"
 
 #: app/models.py:765
-#, fuzzy
 msgid "Service Record"
-msgstr "Intervalle d'entretien"
+msgstr "Carnet d'entretien"
 
 #: app/models.py:766
 msgid "Purchase Invoice"
-msgstr ""
+msgstr "Facture d'achat"
 
 #: app/models.py:767
-#, fuzzy
 msgid "Warranty Document"
-msgstr "Aucun document"
+msgstr "Document de garantie"
 
 #: app/models.py:768
 msgid "Owner's Manual"
-msgstr ""
+msgstr "Manuel du propriétaire"
 
 #: app/models.py:1118
 msgid "Engine Oil"
-msgstr ""
+msgstr "Huile moteur"
 
 #: app/models.py:1122
-#, fuzzy
 msgid "Cabin Filter"
-msgstr "Filtrer"
+msgstr "Filtre d'habitacle"
 
 #: app/models.py:1123
-#, fuzzy
 msgid "Spark Plug"
-msgstr "Page d'accueil"
+msgstr "Bougie d'allumage"
 
 #: app/models.py:1124
 msgid "Brake Pad"
-msgstr ""
+msgstr "Plaquette de frein"
 
 #: app/models.py:1126
 msgid "Coolant"
-msgstr ""
+msgstr "Liquide de refroidissement"
 
 #: app/models.py:1128
-#, fuzzy
 msgid "Battery"
-msgstr "Niveau de batterie"
+msgstr "Batterie"
 
 #: app/models.py:1129
-#, fuzzy
 msgid "Tire"
-msgstr "Titre"
+msgstr "Pneu"
 
 #: app/models.py:1130
-#, fuzzy
 msgid "Belt"
-msgstr "Supprimer"
+msgstr "Courroie"
 
 #: app/models.py:1131
 msgid "Wiper Blade"
-msgstr ""
+msgstr "Balai d'essuie-glace"
 
 #: app/models.py:1132
 msgid "Light Bulb"
-msgstr ""
+msgstr "Ampoule"
 
 #: app/routes/api.py:2141 app/routes/api.py:2354 app/routes/api.py:2527
 msgid "No file uploaded"
@@ -499,40 +448,23 @@ msgid "The uploaded file is not a valid SQLite database."
 msgstr "Le fichier envoyé n'est pas une base de données SQLite valide."
 
 #: app/routes/api.py:2173
-msgid ""
-"This does not appear to be a Hammond database — no vehicles, fillups, or "
-"expenses tables found."
-msgstr ""
-"Ce fichier ne semble pas être une base de données Hammond — aucune table "
-"de véhicules, pleins ou dépenses trouvée."
+msgid "This does not appear to be a Hammond database — no vehicles, fillups, or expenses tables found."
+msgstr "Ce fichier ne semble pas être une base de données Hammond — aucune table de véhicules, pleins ou dépenses trouvée."
 
 #: app/routes/api.py:2322
 #, python-format
-msgid ""
-"Hammond import complete: %(vehicles)s vehicles, %(fuel_logs)s fuel logs, "
-"%(expenses)s expenses imported."
-msgstr ""
-"Importation Hammond terminée : %(vehicles)s véhicules, %(fuel_logs)s "
-"registres de carburant, %(expenses)s dépenses importés."
+msgid "Hammond import complete: %(vehicles)s vehicles, %(fuel_logs)s fuel logs, %(expenses)s expenses imported."
+msgstr "Importation Hammond terminée : %(vehicles)s véhicules, %(fuel_logs)s registres de carburant, %(expenses)s dépenses importés."
 
 #: app/routes/api.py:2324
 #, python-format
-msgid ""
-"(%(total_skipped)s records skipped due to errors — check server logs for "
-"details.)"
-msgstr ""
-"(%(total_skipped)s enregistrements ignorés en raison d'erreurs — "
-"consultez les journaux du serveur pour plus de détails.)"
+msgid "(%(total_skipped)s records skipped due to errors — check server logs for details.)"
+msgstr "(%(total_skipped)s enregistrements ignorés en raison d'erreurs — consultez les journaux du serveur pour plus de détails.)"
 
 #: app/routes/api.py:2331
 #, python-format
-msgid ""
-"Import failed due to a database error. Check that the file is a valid "
-"Hammond database. Error: %(error)s"
-msgstr ""
-"L'importation a échoué en raison d'une erreur de base de données. "
-"Vérifiez que le fichier est une base de données Hammond valide. Erreur : "
-"%(error)s"
+msgid "Import failed due to a database error. Check that the file is a valid Hammond database. Error: %(error)s"
+msgstr "L'importation a échoué en raison d'une erreur de base de données. Vérifiez que le fichier est une base de données Hammond valide. Erreur : %(error)s"
 
 #: app/routes/api.py:2336 app/routes/api.py:2478 app/routes/api.py:2650
 #: app/routes/api.py:3106
@@ -543,16 +475,12 @@ msgstr "L'importation a échoué : %(error)s"
 #: app/routes/api.py:2474
 #, python-format
 msgid "Clarkson import complete: %(vehicles)s vehicles, %(fuel_logs)s fuel logs"
-msgstr ""
-"Importation Clarkson terminée : %(vehicles)s véhicules, %(fuel_logs)s "
-"registres de carburant"
+msgstr "Importation Clarkson terminée : %(vehicles)s véhicules, %(fuel_logs)s registres de carburant"
 
 #: app/routes/api.py:2646
 #, python-format
 msgid "Fuelly import complete: %(vehicles)s new vehicles, %(fuel_logs)s fuel logs"
-msgstr ""
-"Importation Fuelly terminée : %(vehicles)s nouveaux véhicules, "
-"%(fuel_logs)s registres de carburant"
+msgstr "Importation Fuelly terminée : %(vehicles)s nouveaux véhicules, %(fuel_logs)s registres de carburant"
 
 #: app/routes/api.py:2959
 msgid "Please add a vehicle before importing data."
@@ -598,21 +526,15 @@ msgstr "Nom d'utilisateur ou mot de passe non valide"
 
 #: app/routes/auth.py:62
 msgid "Password reset by email is not available. Please contact an administrator."
-msgstr ""
-"La réinitialisation du mot de passe par e-mail n'est pas disponible. "
-"Veuillez contacter un administrateur."
+msgstr "La réinitialisation du mot de passe par e-mail n'est pas disponible. Veuillez contacter un administrateur."
 
 #: app/routes/auth.py:91
 msgid "If an account with that email exists, a password reset link has been sent."
-msgstr ""
-"Si un compte avec cette adresse e-mail existe, un lien de "
-"réinitialisation a été envoyé."
+msgstr "Si un compte avec cette adresse e-mail existe, un lien de réinitialisation a été envoyé."
 
 #: app/routes/auth.py:104
 msgid "Invalid or expired reset link. Please request a new one."
-msgstr ""
-"Lien de réinitialisation non valide ou expiré. Veuillez en demander un "
-"nouveau."
+msgstr "Lien de réinitialisation non valide ou expiré. Veuillez en demander un nouveau."
 
 #: app/routes/auth.py:112 app/routes/auth.py:168 app/routes/auth.py:234
 #: app/routes/auth.py:522 app/routes/auth.py:558
@@ -718,9 +640,7 @@ msgstr "Utilisateur %(username)s créé avec succès"
 
 #: app/routes/charging.py:54
 msgid "No electric vehicles found. Add an EV or hybrid vehicle first."
-msgstr ""
-"Aucun véhicule électrique trouvé. Ajoutez d'abord un véhicule électrique "
-"ou hybride."
+msgstr "Aucun véhicule électrique trouvé. Ajoutez d'abord un véhicule électrique ou hybride."
 
 #: app/routes/charging.py:62 app/routes/charging.py:122
 #: app/routes/charging.py:172 app/routes/documents.py:130
@@ -1093,9 +1013,7 @@ msgstr "Tout voir"
 
 #: app/templates/dashboard.html:147
 msgid "No price data yet. Add fuel stations and log fuel to track prices."
-msgstr ""
-"Aucune donnée de prix pour le moment. Ajoutez des stations-service et "
-"enregistrez du carburant pour suivre les prix."
+msgstr "Aucune donnée de prix pour le moment. Ajoutez des stations-service et enregistrez du carburant pour suivre les prix."
 
 #: app/templates/dashboard.html:156
 msgid "Your Vehicles"
@@ -1382,9 +1300,7 @@ msgstr "Bouton de saisie rapide"
 
 #: app/templates/auth/settings.html:421
 msgid "Show a quick fuel entry button in the navigation bar for rapid logging"
-msgstr ""
-"Afficher un bouton de saisie rapide de carburant dans la barre de "
-"navigation"
+msgstr "Afficher un bouton de saisie rapide de carburant dans la barre de navigation"
 
 #: app/templates/auth/settings.html:432
 msgid "Show Menu Items"
@@ -1419,12 +1335,8 @@ msgid "Export as CSV"
 msgstr "Exporter en CSV"
 
 #: app/templates/auth/settings.html:594
-msgid ""
-"Download all your vehicles, fuel logs, and expenses as CSV files (ZIP "
-"archive)"
-msgstr ""
-"Téléchargez tous vos véhicules, registres de carburant et dépenses en "
-"fichiers CSV (archive ZIP)"
+msgid "Download all your vehicles, fuel logs, and expenses as CSV files (ZIP archive)"
+msgstr "Téléchargez tous vos véhicules, registres de carburant et dépenses en fichiers CSV (archive ZIP)"
 
 #: app/templates/auth/settings.html:598
 msgid "Download CSV"
@@ -1447,12 +1359,8 @@ msgid "Full Backup"
 msgstr "Sauvegarde complète"
 
 #: app/templates/auth/settings.html:616
-msgid ""
-"Download all data and files (images, documents, attachments) as a ZIP "
-"archive"
-msgstr ""
-"Téléchargez toutes les données et fichiers (images, documents, pièces "
-"jointes) sous forme d'archive ZIP"
+msgid "Download all data and files (images, documents, attachments) as a ZIP archive"
+msgstr "Téléchargez toutes les données et fichiers (images, documents, pièces jointes) sous forme d'archive ZIP"
 
 #: app/templates/auth/settings.html:620
 msgid "Download ZIP"
@@ -1496,13 +1404,8 @@ msgid "API Key"
 msgstr "Clé API"
 
 #: app/templates/auth/settings.html:686
-msgid ""
-"Generate an API key to access May programmatically. You can use it to "
-"integrate with other applications or build your own tools."
-msgstr ""
-"Générez une clé API pour accéder à May de manière programmatique. Vous "
-"pouvez l'utiliser pour intégrer d'autres applications ou créer vos "
-"propres outils."
+msgid "Generate an API key to access May programmatically. You can use it to integrate with other applications or build your own tools."
+msgstr "Générez une clé API pour accéder à May de manière programmatique. Vous pouvez l'utiliser pour intégrer d'autres applications ou créer vos propres outils."
 
 #: app/templates/auth/settings.html:689
 msgid "Generate API Key"
@@ -1514,9 +1417,7 @@ msgstr "Clé API générée"
 
 #: app/templates/auth/settings.html:699
 msgid "Copy your API key now. For security, it won't be shown in full again."
-msgstr ""
-"Copiez votre clé API maintenant. Par sécurité, elle ne sera plus affichée"
-" en intégralité."
+msgstr "Copiez votre clé API maintenant. Par sécurité, elle ne sera plus affichée en intégralité."
 
 #: app/templates/auth/settings.html:710
 msgid "Done"
@@ -1593,12 +1494,8 @@ msgid "Subscribe to your reminders in any calendar app"
 msgstr "Abonnez-vous à vos rappels dans n'importe quelle application de calendrier"
 
 #: app/templates/auth/settings.html:847
-msgid ""
-"Add this calendar to Apple Calendar, Google Calendar, Outlook, or any "
-"other calendar app that supports iCal subscriptions."
-msgstr ""
-"Ajoutez ce calendrier à Apple Calendar, Google Calendar, Outlook ou toute"
-" autre application de calendrier prenant en charge les abonnements iCal."
+msgid "Add this calendar to Apple Calendar, Google Calendar, Outlook, or any other calendar app that supports iCal subscriptions."
+msgstr "Ajoutez ce calendrier à Apple Calendar, Google Calendar, Outlook ou toute autre application de calendrier prenant en charge les abonnements iCal."
 
 #: app/templates/auth/settings.html:850
 msgid "Webcal URL"
@@ -1606,9 +1503,7 @@ msgstr "URL Webcal"
 
 #: app/templates/auth/settings.html:851
 msgid "Use this URL for most calendar apps (Apple Calendar, Outlook, etc.)"
-msgstr ""
-"Utilisez cette URL pour la plupart des applications de calendrier (Apple "
-"Calendar, Outlook, etc.)"
+msgstr "Utilisez cette URL pour la plupart des applications de calendrier (Apple Calendar, Outlook, etc.)"
 
 #: app/templates/auth/settings.html:864
 msgid "HTTPS URL"
@@ -1644,21 +1539,15 @@ msgstr "Clé API requise"
 
 #: app/templates/auth/settings.html:893
 msgid "Generate an API key in the API section to enable calendar integration."
-msgstr ""
-"Générez une clé API dans la section API pour activer l'intégration du "
-"calendrier."
+msgstr "Générez une clé API dans la section API pour activer l'intégration du calendrier."
 
 #: app/templates/auth/settings.html:896 app/templates/auth/settings.html:990
 msgid "Go to API Settings"
 msgstr "Accéder aux paramètres API"
 
 #: app/templates/auth/settings.html:933
-msgid ""
-"Add the following configuration to your Home Assistant configuration.yaml"
-" to create vehicle sensors."
-msgstr ""
-"Ajoutez la configuration suivante à votre fichier configuration.yaml de "
-"Home Assistant pour créer des capteurs de véhicules."
+msgid "Add the following configuration to your Home Assistant configuration.yaml to create vehicle sensors."
+msgstr "Ajoutez la configuration suivante à votre fichier configuration.yaml de Home Assistant pour créer des capteurs de véhicules."
 
 #: app/templates/auth/settings.html:936
 msgid "REST Sensor Configuration"
@@ -1693,27 +1582,16 @@ msgid "Combined summary"
 msgstr "Résumé combiné"
 
 #: app/templates/auth/settings.html:987
-msgid ""
-"Generate an API key in the API section to enable Home Assistant "
-"integration."
-msgstr ""
-"Générez une clé API dans la section API pour activer l'intégration Home "
-"Assistant."
+msgid "Generate an API key in the API section to enable Home Assistant integration."
+msgstr "Générez une clé API dans la section API pour activer l'intégration Home Assistant."
 
 #: app/templates/auth/settings.html:1019
 msgid "DVLA Vehicle Lookup"
 msgstr "Recherche de véhicule DVLA"
 
 #: app/templates/auth/settings.html:1028
-msgid ""
-"The DVLA Vehicle Enquiry Service allows you to look up MOT status, tax "
-"status, and vehicle details for UK registered vehicles. This enables "
-"automatic population of vehicle information when adding new vehicles."
-msgstr ""
-"Le service de consultation des véhicules DVLA vous permet de consulter le"
-" statut MOT, le statut fiscal et les détails des véhicules immatriculés "
-"au Royaume-Uni. Cela permet de remplir automatiquement les informations "
-"du véhicule lors de l'ajout de nouveaux véhicules."
+msgid "The DVLA Vehicle Enquiry Service allows you to look up MOT status, tax status, and vehicle details for UK registered vehicles. This enables automatic population of vehicle information when adding new vehicles."
+msgstr "Le service de consultation des véhicules DVLA vous permet de consulter le statut MOT, le statut fiscal et les détails des véhicules immatriculés au Royaume-Uni. Cela permet de remplir automatiquement les informations du véhicule lors de l'ajout de nouveaux véhicules."
 
 #: app/templates/auth/settings.html:1032
 msgid "How to get an API key"
@@ -1761,15 +1639,8 @@ msgid "Sync Tesla vehicle data via Tessie"
 msgstr "Synchroniser les données du véhicule Tesla via Tessie"
 
 #: app/templates/auth/settings.html:1099
-msgid ""
-"Tessie allows you to automatically sync odometer readings, battery level,"
-" and range from your Tesla vehicles. When enabled for a vehicle, odometer"
-" tracking becomes automatic."
-msgstr ""
-"Tessie vous permet de synchroniser automatiquement les relevés "
-"d'odomètre, le niveau de batterie et l'autonomie de vos véhicules Tesla. "
-"Lorsqu'il est activé pour un véhicule, le suivi de l'odomètre devient "
-"automatique."
+msgid "Tessie allows you to automatically sync odometer readings, battery level, and range from your Tesla vehicles. When enabled for a vehicle, odometer tracking becomes automatic."
+msgstr "Tessie vous permet de synchroniser automatiquement les relevés d'odomètre, le niveau de batterie et l'autonomie de vos véhicules Tesla. Lorsqu'il est activé pour un véhicule, le suivi de l'odomètre devient automatique."
 
 #: app/templates/auth/settings.html:1103
 msgid "Important"
@@ -1821,9 +1692,7 @@ msgstr "Préférences de notification"
 
 #: app/templates/auth/settings.html:1161
 msgid "Configure how you receive reminders about your vehicles"
-msgstr ""
-"Configurez la manière dont vous recevez les rappels concernant vos "
-"véhicules"
+msgstr "Configurez la manière dont vous recevez les rappels concernant vos véhicules"
 
 #: app/templates/auth/settings.html:1168
 msgid "Enable Reminders"
@@ -1895,33 +1764,23 @@ msgstr "Les notifications seront envoyées à"
 
 #: app/templates/auth/settings.html:1225
 msgid "Email not configured. Ask an administrator to configure SMTP settings."
-msgstr ""
-"E-mail non configuré. Demandez à un administrateur de configurer les "
-"paramètres SMTP."
+msgstr "E-mail non configuré. Demandez à un administrateur de configurer les paramètres SMTP."
 
 #: app/templates/auth/settings.html:1234
 msgid "is a simple pub-sub notification service. Enter your topic below."
-msgstr ""
-"est un service de notification pub-sub simple. Entrez votre sujet ci-"
-"dessous."
+msgstr "est un service de notification pub-sub simple. Entrez votre sujet ci-dessous."
 
 #: app/templates/auth/settings.html:1237
 msgid "ntfy Topic or Server URL"
 msgstr "Sujet ntfy ou URL du serveur"
 
 #: app/templates/auth/settings.html:1242
-msgid ""
-"For ntfy.sh, just enter your topic name. For self-hosted, enter the full "
-"URL."
-msgstr ""
-"Pour ntfy.sh, entrez simplement le nom de votre sujet. Pour l'auto-"
-"hébergé, entrez l'URL complète."
+msgid "For ntfy.sh, just enter your topic name. For self-hosted, enter the full URL."
+msgstr "Pour ntfy.sh, entrez simplement le nom de votre sujet. Pour l'auto-hébergé, entrez l'URL complète."
 
 #: app/templates/auth/settings.html:1250
 msgid "sends notifications to your devices. Enter your User Key below."
-msgstr ""
-"envoie des notifications à vos appareils. Entrez votre clé utilisateur "
-"ci-dessous."
+msgstr "envoie des notifications à vos appareils. Entrez votre clé utilisateur ci-dessous."
 
 #: app/templates/auth/settings.html:1253
 msgid "Pushover User Key"
@@ -1933,9 +1792,7 @@ msgstr "Trouvez votre clé utilisateur sur votre tableau de bord Pushover."
 
 #: app/templates/auth/settings.html:1265
 msgid "Notifications will be sent as JSON POST requests to your webhook URL."
-msgstr ""
-"Les notifications seront envoyées sous forme de requêtes JSON POST à "
-"votre URL de webhook."
+msgstr "Les notifications seront envoyées sous forme de requêtes JSON POST à votre URL de webhook."
 
 #: app/templates/auth/settings.html:1268
 msgid "Webhook URL"
@@ -1956,9 +1813,7 @@ msgstr "Services de notification"
 
 #: app/templates/auth/settings.html:1311
 msgid "Configure notification services available to all users"
-msgstr ""
-"Configurer les services de notification disponibles pour tous les "
-"utilisateurs"
+msgstr "Configurer les services de notification disponibles pour tous les utilisateurs"
 
 #: app/templates/auth/settings.html:1324
 msgid "Email (SMTP)"
@@ -2017,25 +1872,16 @@ msgid "Always available"
 msgstr "Toujours disponible"
 
 #: app/templates/auth/settings.html:1441
-msgid ""
-"is a free, open-source notification service that requires no admin "
-"configuration. Users can set their own topic."
-msgstr ""
-"est un service de notification gratuit et open source qui ne nécessite "
-"aucune configuration administrateur. Les utilisateurs peuvent définir "
-"leur propre sujet."
+msgid "is a free, open-source notification service that requires no admin configuration. Users can set their own topic."
+msgstr "est un service de notification gratuit et open source qui ne nécessite aucune configuration administrateur. Les utilisateurs peuvent définir leur propre sujet."
 
 #: app/templates/auth/settings.html:1451
 msgid "Webhook"
 msgstr "Webhook"
 
 #: app/templates/auth/settings.html:1455
-msgid ""
-"Webhooks allow users to integrate with any service that accepts HTTP POST"
-" requests (Home Assistant, Discord, Slack, etc.)"
-msgstr ""
-"Les webhooks permettent aux utilisateurs de s'intégrer à tout service "
-"acceptant les requêtes HTTP POST (Home Assistant, Discord, Slack, etc.)"
+msgid "Webhooks allow users to integrate with any service that accepts HTTP POST requests (Home Assistant, Discord, Slack, etc.)"
+msgstr "Les webhooks permettent aux utilisateurs de s'intégrer à tout service acceptant les requêtes HTTP POST (Home Assistant, Discord, Slack, etc.)"
 
 #: app/templates/auth/settings.html:1462
 msgid "Save Notification Settings"
@@ -2323,9 +2169,7 @@ msgstr "Aucune session de recharge"
 
 #: app/templates/charging/index.html:140
 msgid "Start tracking your EV charging to monitor energy usage and costs."
-msgstr ""
-"Commencez à suivre vos recharges de véhicule électrique pour surveiller "
-"la consommation d'énergie et les coûts."
+msgstr "Commencez à suivre vos recharges de véhicule électrique pour surveiller la consommation d'énergie et les coûts."
 
 #: app/templates/charging/index.html:147
 msgid "Log Your First Charge"
@@ -2426,9 +2270,7 @@ msgstr "Aucun document"
 
 #: app/templates/documents/index.html:101
 msgid "Store your vehicle documents, insurance policies, and MOT certificates."
-msgstr ""
-"Stockez les documents de vos véhicules, polices d'assurance et "
-"certificats MOT."
+msgstr "Stockez les documents de vos véhicules, polices d'assurance et certificats MOT."
 
 #: app/templates/documents/view.html:30 app/templates/maintenance/index.html:83
 #: app/templates/stations/index.html:65 app/templates/vehicles/view.html:40
@@ -2527,12 +2369,8 @@ msgid "Service Interval"
 msgstr "Intervalle d'entretien"
 
 #: app/templates/maintenance/form.html:66
-msgid ""
-"Set how often this maintenance should be performed. You can set distance,"
-" time, or both."
-msgstr ""
-"Définissez la fréquence de cet entretien. Vous pouvez définir la "
-"distance, le temps ou les deux."
+msgid "Set how often this maintenance should be performed. You can set distance, time, or both."
+msgstr "Définissez la fréquence de cet entretien. Vous pouvez définir la distance, le temps ou les deux."
 
 #: app/templates/maintenance/form.html:70
 msgid "Every (km)"
@@ -2564,9 +2402,7 @@ msgstr "Dernière réalisation"
 
 #: app/templates/maintenance/form.html:96
 msgid "When was this maintenance last done? Leave blank if never."
-msgstr ""
-"Quand cet entretien a-t-il été effectué pour la dernière fois ? Laissez "
-"vide si jamais."
+msgstr "Quand cet entretien a-t-il été effectué pour la dernière fois ? Laissez vide si jamais."
 
 #: app/templates/maintenance/form.html:109
 msgid "e.g., 50000"
@@ -2750,9 +2586,7 @@ msgstr "Aucune dépense récurrente"
 
 #: app/templates/recurring/index.html:119
 msgid "Set up recurring expenses like insurance, road tax, or parking permits."
-msgstr ""
-"Configurez des dépenses récurrentes comme l'assurance, la taxe de "
-"circulation ou les permis de stationnement."
+msgstr "Configurez des dépenses récurrentes comme l'assurance, la taxe de circulation ou les permis de stationnement."
 
 #: app/templates/stations/cheapest.html:6 app/templates/stations/prices.html:11
 msgid "Back to stations"
@@ -2777,9 +2611,7 @@ msgstr "Aucune donnée de prix disponible"
 
 #: app/templates/stations/cheapest.html:69
 msgid "Prices are automatically tracked when you log fuel at saved stations."
-msgstr ""
-"Les prix sont automatiquement suivis lorsque vous enregistrez du "
-"carburant dans les stations enregistrées."
+msgstr "Les prix sont automatiquement suivis lorsque vous enregistrez du carburant dans les stations enregistrées."
 
 #: app/templates/stations/cheapest.html:76
 msgid "Add a Station"
@@ -2860,9 +2692,7 @@ msgstr "Aucune station-service"
 
 #: app/templates/stations/index.html:83
 msgid "Save your favorite stations for quick access when logging fuel."
-msgstr ""
-"Enregistrez vos stations favorites pour un accès rapide lors de la saisie"
-" de carburant."
+msgstr "Enregistrez vos stations favorites pour un accès rapide lors de la saisie de carburant."
 
 #: app/templates/stations/prices.html:46
 msgid "No price history available for this station."
@@ -2870,9 +2700,7 @@ msgstr "Aucun historique de prix disponible pour cette station."
 
 #: app/templates/stations/prices.html:47
 msgid "Prices are automatically recorded when you log fuel at this station."
-msgstr ""
-"Les prix sont automatiquement enregistrés lorsque vous saisissez du "
-"carburant dans cette station."
+msgstr "Les prix sont automatiquement enregistrés lorsque vous saisissez du carburant dans cette station."
 
 #: app/templates/stations/prices.html:69
 msgid "Price per"
@@ -2986,9 +2814,7 @@ msgstr "Aucun trajet enregistré"
 
 #: app/templates/trips/index.html:145
 msgid "Start logging your trips for mileage tracking and tax deductions."
-msgstr ""
-"Commencez à enregistrer vos trajets pour le suivi du kilométrage et les "
-"déductions fiscales."
+msgstr "Commencez à enregistrer vos trajets pour le suivi du kilométrage et les déductions fiscales."
 
 #: app/templates/trips/index.html:152
 msgid "Log Your First Trip"
@@ -3039,363 +2865,311 @@ msgid "No trips logged for"
 msgstr "Aucun trajet enregistré pour"
 
 #: app/templates/vehicles/form.html:2 app/templates/vehicles/form.html:8
-#, fuzzy
 msgid "Edit Vehicle"
-msgstr "Véhicule"
+msgstr "Modifier le véhicule"
 
 #: app/templates/vehicles/form.html:2 app/templates/vehicles/form.html:269
 #: app/templates/vehicles/index.html:32 app/templates/vehicles/index.html:108
-#, fuzzy
 msgid "Add Vehicle"
-msgstr "Tous les véhicules"
+msgstr "Ajouter un véhicule"
 
 #: app/templates/vehicles/form.html:7 app/templates/vehicles/view.html:11
-#, fuzzy
 msgid "Back to vehicles"
-msgstr "Tous les véhicules"
+msgstr "Retour aux véhicules"
 
 #: app/templates/vehicles/form.html:8
-#, fuzzy
 msgid "Add New Vehicle"
-msgstr "Tous les véhicules"
+msgstr "Ajouter un nouveau véhicule"
 
 #: app/templates/vehicles/form.html:14
-#, fuzzy
 msgid "Basic Information"
-msgstr "Informations du compte"
+msgstr "Informations de base"
 
 #: app/templates/vehicles/form.html:36
 msgid "Tracking Unit"
-msgstr ""
+msgstr "Unité de suivi"
 
 #: app/templates/vehicles/form.html:43
 msgid "Use \"Hours\" for tractors, ATVs, boats, etc."
-msgstr ""
+msgstr "Utilisez \"Heures\" pour les tracteurs, quads, bateaux, etc."
 
 #: app/templates/vehicles/form.html:47
-#, fuzzy
 msgid "Odometer Unit"
-msgstr "Odomètre"
+msgstr "Unité d'odomètre"
 
 #: app/templates/vehicles/form.html:50
-#, fuzzy
 msgid "Use account default"
-msgstr "Détails de votre compte"
+msgstr "Utiliser la valeur par défaut du compte"
 
 #: app/templates/vehicles/form.html:55
-msgid ""
-"Override the odometer unit for this vehicle. Useful when you have "
-"vehicles with different odometer units."
-msgstr ""
+msgid "Override the odometer unit for this vehicle. Useful when you have vehicles with different odometer units."
+msgstr "Remplacer l'unité d'odomètre pour ce véhicule. Utile si vous avez des véhicules avec des unités d'odomètre différentes."
 
 #: app/templates/vehicles/form.html:59
-#, fuzzy
 msgid "Fuel Type"
-msgstr "Type"
+msgstr "Type de carburant"
 
 #: app/templates/vehicles/form.html:69
 msgid "Make"
-msgstr ""
+msgstr "Marque"
 
 #: app/templates/vehicles/form.html:77
-#, fuzzy
 msgid "Model"
-msgstr "Plus"
+msgstr "Modèle"
 
 #: app/templates/vehicles/form.html:94
 msgid "Tank Capacity (L)"
-msgstr ""
+msgstr "Capacité du réservoir (L)"
 
 #: app/templates/vehicles/form.html:104
-#, fuzzy
 msgid "Identification"
-msgstr "Notifications"
+msgstr "Identification"
 
 #: app/templates/vehicles/form.html:108
-#, fuzzy
 msgid "Registration / License Plate"
-msgstr "Paramètres d'inscription mis à jour"
+msgstr "Immatriculation / Plaque d'immatriculation"
 
 #: app/templates/vehicles/form.html:116 app/templates/vehicles/view.html:328
 msgid "VIN"
 msgstr "VIN"
 
 #: app/templates/vehicles/form.html:126
-#, fuzzy
 msgid "Photo"
-msgstr "Code postal"
+msgstr "Photo"
 
 #: app/templates/vehicles/form.html:129
-#, fuzzy
 msgid "Vehicle Image"
-msgstr "Véhicule"
+msgstr "Image du véhicule"
 
 #: app/templates/vehicles/form.html:143 app/templates/vehicles/view.html:447
-#, fuzzy
 msgid "Specifications"
-msgstr "Notifications"
+msgstr "Spécifications"
 
 #: app/templates/vehicles/form.html:144
 msgid "Add technical details like tire sizes, oil type, wiper sizes, etc."
-msgstr ""
+msgstr "Ajoutez des détails techniques comme les tailles de pneus, le type d'huile, les tailles d'essuie-glaces, etc."
 
 #: app/templates/vehicles/form.html:178
-#, fuzzy
 msgid "Add Specification"
-msgstr "Ajouter une station"
+msgstr "Ajouter une spécification"
 
 #: app/templates/vehicles/form.html:186
-#, fuzzy
 msgid "General Notes"
-msgstr "Notes optionnelles"
+msgstr "Notes générales"
 
 #: app/templates/vehicles/form.html:195
-#, fuzzy
 msgid "Status"
-msgstr "Statut fiscal"
+msgstr "Statut"
 
 #: app/templates/vehicles/form.html:200
 msgid "Active (show in lists and calculations)"
-msgstr ""
+msgstr "Actif (affiché dans les listes et les calculs)"
 
 #: app/templates/vehicles/form.html:216
-msgid ""
-"Link this vehicle to Tessie for automatic odometer and battery tracking. "
-"When enabled, manual odometer entry will be disabled."
-msgstr ""
+msgid "Link this vehicle to Tessie for automatic odometer and battery tracking. When enabled, manual odometer entry will be disabled."
+msgstr "Liez ce véhicule à Tessie pour un suivi automatique de l'odomètre et de la batterie. Lorsqu'activé, la saisie manuelle de l'odomètre sera désactivée."
 
 #: app/templates/vehicles/form.html:220
-#, fuzzy
 msgid "Tessie VIN"
-msgstr "Tessie"
+msgstr "VIN Tessie"
 
 #: app/templates/vehicles/form.html:232
-#, fuzzy
 msgid "Lookup"
-msgstr "Déconnexion"
+msgstr "Rechercher"
 
 #: app/templates/vehicles/form.html:243
 msgid "Enable Tessie tracking (disables manual odometer entry)"
-msgstr ""
+msgstr "Activer le suivi Tessie (désactive la saisie manuelle de l'odomètre)"
 
 #: app/templates/vehicles/form.html:253
-#, fuzzy
 msgid "Tessie tracking is active for this vehicle"
-msgstr "Aucune donnée Tessie disponible pour ce véhicule pour le moment."
+msgstr "Le suivi Tessie est actif pour ce véhicule"
 
 #: app/templates/vehicles/index.html:7
-#, fuzzy
 msgid "Archived Vehicles"
-msgstr "Tous les véhicules"
+msgstr "Véhicules archivés"
 
 #: app/templates/vehicles/index.html:8
 msgid "Manage your cars, vans, motorbikes, and scooters"
-msgstr ""
+msgstr "Manage your cars, vans, motorbikes, and scooters"
 
 #: app/templates/vehicles/index.html:18
-#, fuzzy
 msgid "Active Vehicles"
-msgstr "Tous les véhicules"
+msgstr "Véhicules actifs"
 
 #: app/templates/vehicles/index.html:23
-#, fuzzy
 msgid "Archived"
-msgstr "Activer"
+msgstr "Archivé"
 
 #: app/templates/vehicles/index.html:83
-#, fuzzy
 msgid "Inactive"
-msgstr "Activer"
+msgstr "Inactif"
 
 #: app/templates/vehicles/index.html:100
-#, fuzzy
 msgid "No vehicles"
-msgstr "Véhicules"
+msgstr "Aucun véhicule"
 
 #: app/templates/vehicles/index.html:101
 msgid "Get started by adding your first vehicle."
-msgstr ""
+msgstr "Commencez par ajouter votre premier véhicule."
 
 #: app/templates/vehicles/part_form.html:2
 #: app/templates/vehicles/part_form.html:8
-#, fuzzy
 msgid "Edit Part"
-msgstr "Modifier le trajet"
+msgstr "Modifier la pièce"
 
 #: app/templates/vehicles/part_form.html:2
 #: app/templates/vehicles/part_form.html:8
 #: app/templates/vehicles/part_form.html:102
 #: app/templates/vehicles/parts.html:19 app/templates/vehicles/view.html:530
-#, fuzzy
 msgid "Add Part"
-msgstr "Pièces"
+msgstr "Ajouter une pièce"
 
 #: app/templates/vehicles/part_form.html:7
-#, fuzzy
 msgid "Back to parts"
-msgstr "Retour aux trajets"
+msgstr "Retour aux pièces"
 
 #: app/templates/vehicles/part_form.html:15
-#, fuzzy
 msgid "Part Details"
-msgstr "Détails du compte"
+msgstr "Détails de la pièce"
 
 #: app/templates/vehicles/part_form.html:19
-#, fuzzy
 msgid "Part Type"
-msgstr "Type de chargeur"
+msgstr "Type de pièce"
 
 #: app/templates/vehicles/part_form.html:37
-#, fuzzy
 msgid "Specification"
-msgstr "Notifications"
+msgstr "Spécification"
 
 #: app/templates/vehicles/part_form.html:42
 msgid "Oil viscosity, filter model, tire size, etc."
-msgstr ""
+msgstr "Viscosité d'huile, modèle de filtre, taille de pneu, etc."
 
 #: app/templates/vehicles/part_form.html:46
 msgid "Quantity"
-msgstr ""
+msgstr "Quantité"
 
 #: app/templates/vehicles/part_form.html:54
-#, fuzzy
 msgid "Unit"
-msgstr "Montant"
+msgstr "Unité"
 
 #: app/templates/vehicles/part_form.html:57
-#, fuzzy
 msgid "Select unit..."
-msgstr "Sélectionner le type..."
+msgstr "Sélectionner l'unité..."
 
 #: app/templates/vehicles/part_form.html:58
 msgid "Liters (L)"
-msgstr ""
+msgstr "Litres (L)"
 
 #: app/templates/vehicles/part_form.html:59
 msgid "Milliliters (ml)"
-msgstr ""
+msgstr "Millilitres (ml)"
 
 #: app/templates/vehicles/part_form.html:60
 msgid "Gallons (gal)"
-msgstr ""
+msgstr "Gallons (gal)"
 
 #: app/templates/vehicles/part_form.html:61
 msgid "Quarts (qt)"
-msgstr ""
+msgstr "Quarts (qt)"
 
 #: app/templates/vehicles/part_form.html:62
-#, fuzzy
 msgid "Units"
-msgstr "Notes"
+msgstr "Unités"
 
 #: app/templates/vehicles/part_form.html:63
-#, fuzzy
 msgid "Pieces"
-msgstr "Accès API"
+msgstr "Pièces"
 
 #: app/templates/vehicles/part_form.html:64
-#, fuzzy
 msgid "Set"
-msgstr "Utiliser TLS"
+msgstr "Jeu"
 
 #: app/templates/vehicles/part_form.html:65
-#, fuzzy
 msgid "Pair"
-msgstr "Pièces"
+msgstr "Paire"
 
 #: app/templates/vehicles/part_form.html:70
 msgid "Part Number"
-msgstr ""
+msgstr "Référence"
 
 #: app/templates/vehicles/part_form.html:78
 msgid "Supplier URL"
-msgstr ""
+msgstr "URL du fournisseur"
 
 #: app/templates/vehicles/part_form.html:83
 msgid "Link to purchase this part"
-msgstr ""
+msgstr "Lien pour acheter cette pièce"
 
 #: app/templates/vehicles/parts.html:2 app/templates/vehicles/parts.html:11
 #: app/templates/vehicles/view.html:480
 msgid "Parts & Consumables"
-msgstr ""
+msgstr "Pièces et consommables"
 
 #: app/templates/vehicles/parts.html:47
 msgid "Qty:"
-msgstr ""
+msgstr "Qté :"
 
 #: app/templates/vehicles/parts.html:94
-#, fuzzy
 msgid "No parts added"
-msgstr "Énergie ajoutée"
+msgstr "Aucune pièce ajoutée"
 
 #: app/templates/vehicles/parts.html:95
 msgid "Track the parts and consumables needed for servicing this vehicle."
-msgstr ""
+msgstr "Suivez les pièces et consommables nécessaires à l'entretien de ce véhicule."
 
 #: app/templates/vehicles/parts.html:102
-#, fuzzy
 msgid "Add First Part"
-msgstr "Ajouter une station"
+msgstr "Ajouter la première pièce"
 
 #: app/templates/vehicles/share.html:2 app/templates/vehicles/share.html:20
 #: app/templates/vehicles/view.html:44
-#, fuzzy
 msgid "Share"
-msgstr "Enregistrer"
+msgstr "Partager"
 
 #: app/templates/vehicles/share.html:8
-#, fuzzy
 msgid "Share Vehicle"
-msgstr "Tous les véhicules"
+msgstr "Partager le véhicule"
 
 #: app/templates/vehicles/share.html:9
 msgid "Allow other users to view and add logs to this vehicle"
-msgstr ""
+msgstr "Autoriser d'autres utilisateurs à voir et ajouter des entrées pour ce véhicule"
 
 #: app/templates/vehicles/share.html:13
-#, fuzzy
 msgid "Add User"
-msgstr "Créer un utilisateur"
+msgstr "Ajouter un utilisateur"
 
 #: app/templates/vehicles/share.html:16
-#, fuzzy
 msgid "Enter username"
-msgstr "Nom d'utilisateur SMTP"
+msgstr "Saisir le nom d'utilisateur"
 
 #: app/templates/vehicles/share.html:27
 msgid "Shared With"
-msgstr ""
+msgstr "Partagé avec"
 
 #: app/templates/vehicles/share.html:39
-#, fuzzy
 msgid "Remove"
-msgstr "Supprimer le logo"
+msgstr "Supprimer"
 
 #: app/templates/vehicles/share.html:45
 msgid "This vehicle is not shared with anyone yet."
-msgstr ""
+msgstr "Ce véhicule n'est pas encore partagé avec qui que ce soit."
 
 #: app/templates/vehicles/view.html:32
-#, fuzzy
 msgid "Download PDF Report"
-msgstr "Télécharger ZIP"
+msgstr "Télécharger le rapport PDF"
 
 #: app/templates/vehicles/view.html:56 app/templates/vehicles/view.html:60
-#, fuzzy
 msgid "Not set"
-msgstr "Notes"
+msgstr "Non défini"
 
 #: app/templates/vehicles/view.html:63
-#, fuzzy
 msgid "Last Odometer"
-msgstr "Dernier odomètre"
+msgstr "Last Odometer"
 
 #: app/templates/vehicles/view.html:89
-#, fuzzy
 msgid "Avg. Consumption"
-msgstr "Consommation de carburant"
+msgstr "Conso. moyenne"
 
 #: app/templates/vehicles/view.html:103
 msgid "Add Fuel Log"
@@ -3486,126 +3260,100 @@ msgid "Fetch from Tessie"
 msgstr "Récupérer depuis Tessie"
 
 #: app/templates/vehicles/view.html:358
-msgid ""
-"This vehicle is archived. It won't appear in regular lists or "
-"calculations."
-msgstr ""
+msgid "This vehicle is archived. It won't appear in regular lists or calculations."
+msgstr "Ce véhicule est archivé. Il n'apparaîtra pas dans les listes ou calculs habituels."
 
 #: app/templates/vehicles/view.html:371
-#, fuzzy
 msgid "Upcoming Reminders"
 msgstr "Rappels à venir"
 
 #: app/templates/vehicles/view.html:383
-#, fuzzy
 msgid "Mark as completed"
 msgstr "Marquer comme effectué"
 
 #: app/templates/vehicles/view.html:410
 #, python-format
 msgid "%(days)s days overdue"
-msgstr ""
+msgstr "%(days)s jours de retard"
 
 #: app/templates/vehicles/view.html:412
-#, fuzzy
 msgid "Due today"
-msgstr "Dû maintenant"
+msgstr "Échéance aujourd'hui"
 
 #: app/templates/vehicles/view.html:414
-#, fuzzy
 msgid "Due tomorrow"
-msgstr "Dû maintenant"
+msgstr "Échéance demain"
 
 #: app/templates/vehicles/view.html:416
 #, python-format
 msgid "In %(days)s days"
-msgstr ""
+msgstr "Dans %(days)s jours"
 
 #: app/templates/vehicles/view.html:524
 msgid "No parts added yet."
-msgstr ""
+msgstr "Aucune pièce ajoutée pour le moment."
 
 #: app/templates/vehicles/view.html:538
-#, fuzzy
 msgid "Fuel Consumption Trend"
-msgstr "Consommation de carburant"
+msgstr "Tendance de consommation de carburant"
 
 #: app/templates/vehicles/view.html:561
-#, fuzzy
 msgid "(Full)"
-msgstr "Carburant"
+msgstr "(Plein)"
 
 #: app/templates/vehicles/view.html:578
-#, fuzzy
 msgid "Delete this fuel log?"
-msgstr "Supprimer cette station ?"
+msgstr "Supprimer ce registre de carburant ?"
 
 #: app/templates/vehicles/view.html:593
-#, fuzzy
 msgid "No fuel logs yet."
-msgstr "Registres de carburant"
+msgstr "Aucun registre de carburant pour le moment."
 
 #: app/templates/vehicles/view.html:622
-#, fuzzy
 msgid "Delete this expense?"
-msgstr "Supprimer cette dépense récurrente ?"
+msgstr "Supprimer cette dépense ?"
 
 #: app/templates/vehicles/view.html:637
-#, fuzzy
 msgid "No expenses yet."
-msgstr "Autres dépenses"
+msgstr "Aucune dépense pour le moment."
 
 #: app/templates/vehicles/view.html:653
-#, fuzzy
 msgid "Archive this vehicle"
-msgstr "Véhicule non valide"
+msgstr "Archiver ce véhicule"
 
 #: app/templates/vehicles/view.html:654
-msgid ""
-"Archived vehicles won't appear in regular lists or calculations. You can "
-"restore them later."
-msgstr ""
+msgid "Archived vehicles won't appear in regular lists or calculations. You can restore them later."
+msgstr "Les véhicules archivés n'apparaîtront pas dans les listes ou calculs habituels. Vous pourrez les restaurer plus tard."
 
 #: app/templates/vehicles/view.html:656
-#, fuzzy
 msgid "Restore this vehicle"
-msgstr "Vos véhicules"
+msgstr "Restaurer ce véhicule"
 
 #: app/templates/vehicles/view.html:657
-msgid ""
-"Restore this vehicle to make it active again and include it in "
-"calculations."
-msgstr ""
+msgid "Restore this vehicle to make it active again and include it in calculations."
+msgstr "Restaurez ce véhicule pour le rendre à nouveau actif et l'inclure dans les calculs."
 
 #: app/templates/vehicles/view.html:665
-#, fuzzy
 msgid "Archive Vehicle"
-msgstr "Véhicule non valide"
+msgstr "Archiver le véhicule"
 
 #: app/templates/vehicles/view.html:673
-#, fuzzy
 msgid "Restore Vehicle"
-msgstr "Vos véhicules"
+msgstr "Restaurer le véhicule"
 
 #: app/templates/vehicles/view.html:683
-#, fuzzy
 msgid "Delete this vehicle"
-msgstr "Supprimer ce document ?"
+msgstr "Supprimer ce véhicule"
 
 #: app/templates/vehicles/view.html:684
-msgid ""
-"Once you delete a vehicle, there is no going back. This will also delete "
-"all associated fuel logs and expenses."
-msgstr ""
+msgid "Once you delete a vehicle, there is no going back. This will also delete all associated fuel logs and expenses."
+msgstr "Une fois le véhicule supprimé, il n'est plus possible de revenir en arrière. Cela supprimera également tous les registres de carburant et dépenses associés."
 
 #: app/templates/vehicles/view.html:687
-msgid ""
-"Are you sure you want to delete this vehicle? This action cannot be "
-"undone."
-msgstr ""
+msgid "Are you sure you want to delete this vehicle? This action cannot be undone."
+msgstr "Êtes-vous sûr de vouloir supprimer ce véhicule ? Cette action est irréversible."
 
 #: app/templates/vehicles/view.html:691
-#, fuzzy
 msgid "Delete Vehicle"
-msgstr "Tous les véhicules"
+msgstr "Supprimer le véhicule"
 

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.15.0'
+APP_VERSION = '0.16.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'


### PR DESCRIPTION
## Summary

11 bug fixes across calendar feeds, Home Assistant API, vehicle specs, settings page, expense forms, dashboard charts, admin security, CSV imports, MPG calculations, and attachment management.

## Bug Fixes

- **#127** `calendar.py`: `RecurringExpense.remind_days_before` → `notify_before_days`
- **#129** `calendar.py`: `Reminder.notes` → `Reminder.description`
- **#101** `homeassistant.py`: `Expense.amount` → `Expense.cost`
- **#102** `vehicles.py`: Wrap `VEHICLE_SPEC_TYPES` label with `str()` to fix `LazyString` SQLAlchemy error
- **#128** `settings.html`: Use Jinja `tojson` filter for translated strings in JavaScript to prevent apostrophes breaking script parsing in non-English locales
- **#117** `expenses/form.html`: Show per-vehicle odometer unit instead of global user preference
- **#123** `main.py`: Fix duplicate month bars in dashboard Monthly Spending chart
- **#87** `auth.py`: Prevent removing admin status from the last administrator account
- **#96** `api.py`: CSV import now handles date columns that include a time component (e.g. `2025-04-30 09:20`)
- **#100** `models.py`: Fix MPG calculation when fuel volume is stored in litres — convert to UK/US gallons before dividing distance
- **#124** `fuel.py`, `expenses.py`: Add delete buttons for individual attachments on fuel log and expense edit forms

## Translations

- **#126** Spanish: fill in missing vehicle spec and UI translations
- **#114** French: add missing translations and correct fuzzy matches
- **#103** German: add missing vehicle spec translations

## CI

- **#92, #108, #109, #110, #111** Bump GitHub Actions: `setup-python` v5→v6, `setup-buildx-action` v3→v4, `login-action` v3→v4, `metadata-action` v5→v6, `build-push-action` v6→v7

## Version

Bumped to `0.16.0`

## Test plan

- [ ] Calendar feed returns valid ICS with reminders and recurring expenses present
- [ ] Home Assistant `/api/ha/summary` returns JSON without 500 error
- [ ] Saving vehicle specs (e.g. Oil Capacity) succeeds without SQLAlchemy error
- [ ] Settings page navigation works in French locale
- [ ] Expense form odometer label updates correctly when switching vehicles
- [ ] Dashboard Monthly Spending shows 6 distinct months with no duplicates
- [ ] Cannot remove admin from last admin account — flash error shown
- [ ] CSV import with datetime values (e.g. `2025-04-30 09:20`) succeeds
- [ ] MPG shows correct value (~35 mpg not ~8) when using litres + miles
- [ ] Fuel log and expense edit forms show a Delete button per attachment