### PR TITLE
v0.18.0 - Trip Templates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1095,6 +1095,38 @@ class Trip(db.Model):
         }
 
 
+class TripTemplate(db.Model):
+    """Reusable trip templates for common routes"""
+    __tablename__ = 'trip_templates'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    vehicle_id = db.Column(db.Integer, db.ForeignKey('vehicles.id'), nullable=True)
+
+    name = db.Column(db.String(100), nullable=False)
+    purpose = db.Column(db.String(20), nullable=False)
+    start_location = db.Column(db.String(200))
+    end_location = db.Column(db.String(200))
+    description = db.Column(db.String(200))
+    notes = db.Column(db.Text)
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship('User', backref=db.backref('trip_templates', lazy='dynamic'))
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'vehicle_id': self.vehicle_id,
+            'name': self.name,
+            'purpose': self.purpose,
+            'start_location': self.start_location,
+            'end_location': self.end_location,
+            'description': self.description,
+            'notes': self.notes,
+        }
+
+
 class ChargingSession(db.Model):
     """EV charging session logging"""
     __tablename__ = 'charging_sessions'

--- a/app/routes/trips.py
+++ b/app/routes/trips.py
@@ -3,7 +3,8 @@ from flask import Blueprint, render_template, redirect, url_for, flash, request
 from flask_login import login_required, current_user
 from flask_babel import gettext as _
 from app import db
-from app.models import Vehicle, Trip, TRIP_PURPOSES
+from flask import jsonify
+from app.models import Vehicle, Trip, TripTemplate, TRIP_PURPOSES
 
 bp = Blueprint('trips', __name__, url_prefix='/trips')
 
@@ -98,6 +99,13 @@ def new():
     # Pre-select vehicle if provided
     selected_vehicle_id = request.args.get('vehicle_id', type=int) or current_user.default_vehicle_id
 
+    # Pre-fill from template if requested
+    preload_template_id = request.args.get('template_id', type=int)
+    if preload_template_id:
+        tmpl = TripTemplate.query.get(preload_template_id)
+        if tmpl and tmpl.user_id == current_user.id and tmpl.vehicle_id:
+            selected_vehicle_id = tmpl.vehicle_id
+
     # Get last odometer for selected vehicle
     last_odometer = 0
     if selected_vehicle_id:
@@ -107,12 +115,16 @@ def new():
     elif len(vehicles) == 1:
         last_odometer = vehicles[0].get_last_odometer()
 
+    templates = TripTemplate.query.filter_by(user_id=current_user.id).order_by(TripTemplate.name).all()
+
     return render_template('trips/form.html',
                            trip=None,
                            vehicles=vehicles,
                            purposes=TRIP_PURPOSES,
                            selected_vehicle_id=selected_vehicle_id,
-                           last_odometer=last_odometer)
+                           last_odometer=last_odometer,
+                           templates=templates,
+                           preload_template_id=preload_template_id)
 
 
 @bp.route('/<int:trip_id>/edit', methods=['GET', 'POST'])
@@ -146,7 +158,8 @@ def edit(trip_id):
                            vehicles=vehicles,
                            purposes=TRIP_PURPOSES,
                            selected_vehicle_id=trip.vehicle_id,
-                           last_odometer=trip.vehicle.get_last_odometer())
+                           last_odometer=trip.vehicle.get_last_odometer(),
+                           templates=[])
 
 
 @bp.route('/<int:trip_id>/delete', methods=['POST'])
@@ -164,6 +177,121 @@ def delete(trip_id):
     db.session.commit()
     flash(_('Trip deleted successfully'), 'success')
     return redirect(url_for('trips.index'))
+
+
+@bp.route('/templates')
+@login_required
+def templates_index():
+    """List trip templates"""
+    templates = TripTemplate.query.filter_by(user_id=current_user.id).order_by(TripTemplate.name).all()
+    vehicles = current_user.get_all_vehicles()
+    return render_template('trips/templates_index.html',
+                           templates=templates,
+                           vehicles=vehicles,
+                           purposes=TRIP_PURPOSES)
+
+
+@bp.route('/templates/new', methods=['GET', 'POST'])
+@login_required
+def templates_new():
+    """Create a trip template"""
+    vehicles = current_user.get_all_vehicles()
+
+    if request.method == 'POST':
+        vehicle_id = request.form.get('vehicle_id')
+        if vehicle_id:
+            vehicle_id = int(vehicle_id)
+            vehicle = Vehicle.query.get_or_404(vehicle_id)
+            if vehicle not in vehicles:
+                flash(_('Access denied'), 'error')
+                return redirect(url_for('trips.templates_index'))
+        else:
+            vehicle_id = None
+
+        template = TripTemplate(
+            user_id=current_user.id,
+            vehicle_id=vehicle_id,
+            name=request.form.get('name'),
+            purpose=request.form.get('purpose'),
+            start_location=request.form.get('start_location'),
+            end_location=request.form.get('end_location'),
+            description=request.form.get('description'),
+            notes=request.form.get('notes'),
+        )
+        db.session.add(template)
+        db.session.commit()
+        flash(_('Template saved'), 'success')
+        return redirect(url_for('trips.templates_index'))
+
+    return render_template('trips/template_form.html',
+                           template=None,
+                           vehicles=vehicles,
+                           purposes=TRIP_PURPOSES)
+
+
+@bp.route('/templates/<int:template_id>/edit', methods=['GET', 'POST'])
+@login_required
+def templates_edit(template_id):
+    """Edit a trip template"""
+    template = TripTemplate.query.get_or_404(template_id)
+    if template.user_id != current_user.id:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('trips.templates_index'))
+
+    vehicles = current_user.get_all_vehicles()
+
+    if request.method == 'POST':
+        vehicle_id = request.form.get('vehicle_id')
+        if vehicle_id:
+            vehicle_id = int(vehicle_id)
+            vehicle = Vehicle.query.get_or_404(vehicle_id)
+            if vehicle not in vehicles:
+                flash(_('Access denied'), 'error')
+                return redirect(url_for('trips.templates_index'))
+        else:
+            vehicle_id = None
+
+        template.vehicle_id = vehicle_id
+        template.name = request.form.get('name')
+        template.purpose = request.form.get('purpose')
+        template.start_location = request.form.get('start_location')
+        template.end_location = request.form.get('end_location')
+        template.description = request.form.get('description')
+        template.notes = request.form.get('notes')
+
+        db.session.commit()
+        flash(_('Template updated'), 'success')
+        return redirect(url_for('trips.templates_index'))
+
+    return render_template('trips/template_form.html',
+                           template=template,
+                           vehicles=vehicles,
+                           purposes=TRIP_PURPOSES)
+
+
+@bp.route('/templates/<int:template_id>/delete', methods=['POST'])
+@login_required
+def templates_delete(template_id):
+    """Delete a trip template"""
+    template = TripTemplate.query.get_or_404(template_id)
+    if template.user_id != current_user.id:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('trips.templates_index'))
+
+    db.session.delete(template)
+    db.session.commit()
+    flash(_('Template deleted'), 'success')
+    return redirect(url_for('trips.templates_index'))
+
+
+@bp.route('/templates/<int:template_id>/data')
+@login_required
+def templates_data(template_id):
+    """Return template data as JSON for pre-filling the trip form"""
+    template = TripTemplate.query.get_or_404(template_id)
+    if template.user_id != current_user.id:
+        return jsonify({'error': 'Access denied'}), 403
+    return jsonify(template.to_dict())
 
 
 @bp.route('/report')

--- a/app/templates/trips/form.html
+++ b/app/templates/trips/form.html
@@ -8,6 +8,22 @@
         <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">{% if trip %}{{ _('Edit Trip') }}{% else %}{{ _('Log Trip') }}{% endif %}</h1>
     </div>
 
+    {% if not trip and templates %}
+    <div class="mb-4 bg-white dark:bg-gray-800 shadow rounded-lg p-4">
+        <div class="flex items-center gap-3">
+            <label for="template_select" class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">{{ _('Load template') }}</label>
+            <select id="template_select" onchange="loadTemplate(this.value)"
+                    class="block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                <option value="">{{ _('— choose a template —') }}</option>
+                {% for tmpl in templates %}
+                <option value="{{ tmpl.id }}">{{ tmpl.name }}</option>
+                {% endfor %}
+            </select>
+            <a href="{{ url_for('trips.templates_index') }}" class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 whitespace-nowrap">{{ _('Manage') }}</a>
+        </div>
+    </div>
+    {% endif %}
+
     <form method="POST" class="space-y-6">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
@@ -118,6 +134,25 @@
 </div>
 
 <script>
+function loadTemplate(templateId) {
+    if (!templateId) return;
+    fetch('{{ url_for("trips.templates_data", template_id=0) }}'.replace('/0/', '/' + templateId + '/'))
+        .then(r => r.json())
+        .then(data => {
+            if (data.vehicle_id) {
+                const vehicleSelect = document.getElementById('vehicle_id');
+                vehicleSelect.value = data.vehicle_id;
+                updateVehicleOdometer(data.vehicle_id);
+            }
+            const purpose = document.getElementById('purpose');
+            if (data.purpose) purpose.value = data.purpose;
+            if (data.start_location !== null) document.getElementById('start_location').value = data.start_location || '';
+            if (data.end_location !== null) document.getElementById('end_location').value = data.end_location || '';
+            if (data.description !== null) document.getElementById('description').value = data.description || '';
+            if (data.notes !== null) document.getElementById('notes').value = data.notes || '';
+        });
+}
+
 function updateVehicleOdometer(vehicleId) {
     const select = document.getElementById('vehicle_id');
     const selectedOption = select.options[select.selectedIndex];
@@ -152,12 +187,18 @@ function calculateDistance() {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-    // Initialize distance calculation
     calculateDistance();
-
-    // Initialize vehicle odometer
     const vehicleSelect = document.getElementById('vehicle_id');
     updateVehicleOdometer(vehicleSelect.value);
+
+    // Auto-load template if specified in URL
+    {% if preload_template_id %}
+    const templateSelect = document.getElementById('template_select');
+    if (templateSelect) {
+        templateSelect.value = '{{ preload_template_id }}';
+        loadTemplate('{{ preload_template_id }}');
+    }
+    {% endif %}
 });
 </script>
 {% endblock %}

--- a/app/templates/trips/index.html
+++ b/app/templates/trips/index.html
@@ -8,6 +8,13 @@
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Track your trips for mileage and tax deductions') }}</p>
     </div>
     <div class="flex gap-2">
+        <a href="{{ url_for('trips.templates_index') }}"
+           class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
+            <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"/>
+            </svg>
+            {{ _('Templates') }}
+        </a>
         <a href="{{ url_for('trips.report') }}"
            class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
             <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/templates/trips/template_form.html
+++ b/app/templates/trips/template_form.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% block title %}{% if template %}{{ _('Edit Template') }}{% else %}{{ _('New Template') }}{% endif %}{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+    <div class="mb-6">
+        <a href="{{ url_for('trips.templates_index') }}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300">&larr; {{ _('Back to templates') }}</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">
+            {% if template %}{{ _('Edit Template') }}{% else %}{{ _('New Template') }}{% endif %}
+        </h1>
+    </div>
+
+    <form method="POST" class="space-y-6">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+
+                <div class="sm:col-span-2">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Template Name') }} *</label>
+                    <input type="text" name="name" id="name" required
+                           value="{{ template.name if template else '' }}"
+                           placeholder="{{ _('e.g., Office Commute, Client Visit') }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div>
+                    <label for="vehicle_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Default Vehicle') }}</label>
+                    <select name="vehicle_id" id="vehicle_id"
+                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                        <option value="">{{ _('Any vehicle') }}</option>
+                        {% for vehicle in vehicles %}
+                        <option value="{{ vehicle.id }}"
+                                {% if template and template.vehicle_id == vehicle.id %}selected{% endif %}>
+                            {{ vehicle.name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ _('Pre-selects this vehicle when using the template') }}</p>
+                </div>
+
+                <div>
+                    <label for="purpose" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Purpose') }} *</label>
+                    <select name="purpose" id="purpose" required
+                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                        {% for value, label in purposes %}
+                        <option value="{{ value }}" {% if template and template.purpose == value %}selected{% endif %}>{{ label }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div>
+                    <label for="start_location" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Start Location') }}</label>
+                    <input type="text" name="start_location" id="start_location"
+                           value="{{ template.start_location if template else '' }}"
+                           placeholder="{{ _('e.g., Home, Office') }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div>
+                    <label for="end_location" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('End Location') }}</label>
+                    <input type="text" name="end_location" id="end_location"
+                           value="{{ template.end_location if template else '' }}"
+                           placeholder="{{ _('e.g., Client Site, Airport') }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div class="sm:col-span-2">
+                    <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Description') }}</label>
+                    <input type="text" name="description" id="description"
+                           value="{{ template.description if template else '' }}"
+                           placeholder="{{ _('e.g., Weekly client meeting') }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div class="sm:col-span-2">
+                    <label for="notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Notes') }}</label>
+                    <textarea name="notes" id="notes" rows="2"
+                              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">{{ template.notes if template else '' }}</textarea>
+                </div>
+            </div>
+        </div>
+
+        <div class="flex justify-end space-x-3">
+            <a href="{{ url_for('trips.templates_index') }}"
+               class="px-4 py-2 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+                {{ _('Cancel') }}
+            </a>
+            <button type="submit"
+                    class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+                {% if template %}{{ _('Save Changes') }}{% else %}{{ _('Save Template') }}{% endif %}
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/trips/templates_index.html
+++ b/app/templates/trips/templates_index.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Trip Templates') }}{% endblock %}
+
+{% block content %}
+<div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+    <div>
+        <a href="{{ url_for('trips.index') }}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300">&larr; {{ _('Back to trips') }}</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">{{ _('Trip Templates') }}</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Save common routes to quickly fill in trip details') }}</p>
+    </div>
+    <a href="{{ url_for('trips.templates_new') }}"
+       class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
+        <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        {{ _('New Template') }}
+    </a>
+</div>
+
+{% if templates %}
+<div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+    <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+        {% for tmpl in templates %}
+        <li class="p-4 hover:bg-gray-50 dark:hover:bg-gray-700">
+            <div class="flex items-center justify-between">
+                <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2">
+                        <p class="text-sm font-medium text-gray-900 dark:text-white">{{ tmpl.name }}</p>
+                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
+                                     {% if tmpl.purpose == 'business' %}bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200
+                                     {% elif tmpl.purpose == 'personal' %}bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200
+                                     {% elif tmpl.purpose == 'commute' %}bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200
+                                     {% else %}bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300{% endif %}">
+                            {{ dict(purposes)[tmpl.purpose] if tmpl.purpose in dict(purposes) else tmpl.purpose|capitalize }}
+                        </span>
+                    </div>
+                    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                        {% if tmpl.vehicle %}{{ tmpl.vehicle.name }}{% else %}{{ _('Any vehicle') }}{% endif %}
+                        {% if tmpl.description %}&middot; {{ tmpl.description }}{% endif %}
+                    </p>
+                    {% if tmpl.start_location or tmpl.end_location %}
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                        {{ tmpl.start_location or '?' }} &rarr; {{ tmpl.end_location or '?' }}
+                    </p>
+                    {% endif %}
+                </div>
+                <div class="ml-4 flex items-center gap-2">
+                    <a href="{{ url_for('trips.new') }}?template_id={{ tmpl.id }}"
+                       class="text-xs px-3 py-1.5 border border-primary-300 dark:border-primary-600 text-primary-700 dark:text-primary-400 rounded-md hover:bg-primary-50 dark:hover:bg-primary-900 font-medium">
+                        {{ _('Use') }}
+                    </a>
+                    <a href="{{ url_for('trips.templates_edit', template_id=tmpl.id) }}"
+                       class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+                        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                        </svg>
+                    </a>
+                    <form method="POST" action="{{ url_for('trips.templates_delete', template_id=tmpl.id) }}" class="inline"
+                          onsubmit="return confirm('{{ _('Delete this template?') }}');">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="text-gray-400 hover:text-red-600">
+                            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                            </svg>
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% else %}
+<div class="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow">
+    <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"/>
+    </svg>
+    <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">{{ _('No templates yet') }}</h3>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Save common routes as templates to log trips faster.') }}</p>
+    <div class="mt-6">
+        <a href="{{ url_for('trips.templates_new') }}"
+           class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700">
+            <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+            {{ _('Create Your First Template') }}
+        </a>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.17.0'
+APP_VERSION = '0.18.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/migrations/versions/b2c3d4e5f6a7_add_trip_templates.py
+++ b/migrations/versions/b2c3d4e5f6a7_add_trip_templates.py
@@ -1,0 +1,44 @@
+"""add trip_templates table
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-21 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'b2c3d4e5f6a7'
+down_revision = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    from sqlalchemy import inspect
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if 'trip_templates' in inspector.get_table_names():
+        return
+
+    op.create_table(
+        'trip_templates',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('vehicle_id', sa.Integer(), nullable=True),
+        sa.Column('name', sa.String(100), nullable=False),
+        sa.Column('purpose', sa.String(20), nullable=False),
+        sa.Column('start_location', sa.String(200), nullable=True),
+        sa.Column('end_location', sa.String(200), nullable=True),
+        sa.Column('description', sa.String(200), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.ForeignKeyConstraint(['vehicle_id'], ['vehicles.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade():
+    op.drop_table('trip_templates')

--- a/tests/test_trips.py
+++ b/tests/test_trips.py
@@ -1,6 +1,7 @@
+import json
 import pytest
 from app import db
-from app.models import Trip
+from app.models import Trip, TripTemplate
 from datetime import date
 
 
@@ -100,6 +101,205 @@ class TestTripDelete:
         resp = auth_client.post(f'/trips/{trip_id}/delete', follow_redirects=True)
         assert resp.status_code == 200
         assert Trip.query.get(trip_id) is None
+
+
+@pytest.fixture
+def sample_template(app, test_user, sample_vehicle):
+    tmpl = TripTemplate(
+        user_id=test_user.id,
+        vehicle_id=sample_vehicle.id,
+        name='Office Commute',
+        purpose='commute',
+        start_location='Home',
+        end_location='Office',
+        description='Daily commute',
+        notes='Via motorway',
+    )
+    db.session.add(tmpl)
+    db.session.commit()
+    return tmpl
+
+
+class TestTripTemplatesIndex:
+    def test_requires_auth(self, client):
+        resp = client.get('/trips/templates', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_returns_200(self, auth_client):
+        resp = auth_client.get('/trips/templates')
+        assert resp.status_code == 200
+
+    def test_shows_templates(self, auth_client, sample_template):
+        resp = auth_client.get('/trips/templates')
+        assert resp.status_code == 200
+        assert b'Office Commute' in resp.data
+
+    def test_empty_state(self, auth_client):
+        resp = auth_client.get('/trips/templates')
+        assert b'No templates yet' in resp.data
+
+
+class TestTripTemplatesNew:
+    def test_requires_auth(self, client):
+        resp = client.get('/trips/templates/new', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_get_form_returns_200(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/trips/templates/new')
+        assert resp.status_code == 200
+
+    def test_create_template_with_vehicle(self, auth_client, sample_vehicle, test_user):
+        resp = auth_client.post('/trips/templates/new', data={
+            'name': 'Client Visit',
+            'vehicle_id': str(sample_vehicle.id),
+            'purpose': 'business',
+            'start_location': 'Office',
+            'end_location': 'Client HQ',
+            'description': 'Weekly client visit',
+            'notes': 'Bring laptop',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        tmpl = TripTemplate.query.filter_by(name='Client Visit').first()
+        assert tmpl is not None
+        assert tmpl.user_id == test_user.id
+        assert tmpl.vehicle_id == sample_vehicle.id
+        assert tmpl.purpose == 'business'
+        assert tmpl.start_location == 'Office'
+        assert tmpl.end_location == 'Client HQ'
+
+    def test_create_template_without_vehicle(self, auth_client, test_user):
+        resp = auth_client.post('/trips/templates/new', data={
+            'name': 'Any Vehicle Trip',
+            'vehicle_id': '',
+            'purpose': 'personal',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        tmpl = TripTemplate.query.filter_by(name='Any Vehicle Trip').first()
+        assert tmpl is not None
+        assert tmpl.vehicle_id is None
+
+    def test_create_redirects_to_index(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/trips/templates/new', data={
+            'name': 'Test Template',
+            'vehicle_id': '',
+            'purpose': 'personal',
+        }, follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/trips/templates' in resp.headers['Location']
+
+
+class TestTripTemplatesEdit:
+    def test_requires_auth(self, client, sample_template):
+        resp = client.get(f'/trips/templates/{sample_template.id}/edit', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_get_form_returns_200(self, auth_client, sample_template):
+        resp = auth_client.get(f'/trips/templates/{sample_template.id}/edit')
+        assert resp.status_code == 200
+        assert b'Office Commute' in resp.data
+
+    def test_edit_template(self, auth_client, sample_template):
+        resp = auth_client.post(f'/trips/templates/{sample_template.id}/edit', data={
+            'name': 'Updated Commute',
+            'vehicle_id': str(sample_template.vehicle_id),
+            'purpose': 'personal',
+            'start_location': 'New Home',
+            'end_location': 'Office',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        db.session.refresh(sample_template)
+        assert sample_template.name == 'Updated Commute'
+        assert sample_template.purpose == 'personal'
+        assert sample_template.start_location == 'New Home'
+
+    def test_cannot_edit_other_users_template(self, client, app, sample_template):
+        from app.models import User
+        other = User(username='other2', email='other2@example.com')
+        other.set_password('Pass123!')
+        db.session.add(other)
+        db.session.commit()
+        client.post('/auth/login', data={'username': 'other2', 'password': 'Pass123!'}, follow_redirects=True)
+        resp = client.post(f'/trips/templates/{sample_template.id}/edit', data={
+            'name': 'Hijacked', 'vehicle_id': '', 'purpose': 'personal',
+        }, follow_redirects=True)
+        db.session.refresh(sample_template)
+        assert sample_template.name == 'Office Commute'
+
+
+class TestTripTemplatesDelete:
+    def test_requires_auth(self, client, sample_template):
+        resp = client.post(f'/trips/templates/{sample_template.id}/delete', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_delete_template(self, auth_client, sample_template):
+        tmpl_id = sample_template.id
+        resp = auth_client.post(f'/trips/templates/{tmpl_id}/delete', follow_redirects=True)
+        assert resp.status_code == 200
+        assert TripTemplate.query.get(tmpl_id) is None
+
+    def test_cannot_delete_other_users_template(self, client, app, sample_template):
+        from app.models import User
+        other = User(username='other3', email='other3@example.com')
+        other.set_password('Pass123!')
+        db.session.add(other)
+        db.session.commit()
+        client.post('/auth/login', data={'username': 'other3', 'password': 'Pass123!'}, follow_redirects=True)
+        resp = client.post(f'/trips/templates/{sample_template.id}/delete', follow_redirects=True)
+        assert TripTemplate.query.get(sample_template.id) is not None
+
+
+class TestTripTemplatesData:
+    def test_requires_auth(self, client, sample_template):
+        resp = client.get(f'/trips/templates/{sample_template.id}/data', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_returns_json(self, auth_client, sample_template):
+        resp = auth_client.get(f'/trips/templates/{sample_template.id}/data')
+        assert resp.status_code == 200
+        assert resp.content_type == 'application/json'
+
+    def test_json_contains_template_fields(self, auth_client, sample_template):
+        resp = auth_client.get(f'/trips/templates/{sample_template.id}/data')
+        data = json.loads(resp.data)
+        assert data['id'] == sample_template.id
+        assert data['vehicle_id'] == sample_template.vehicle_id
+        assert data['purpose'] == 'commute'
+        assert data['start_location'] == 'Home'
+        assert data['end_location'] == 'Office'
+        assert data['description'] == 'Daily commute'
+        assert data['notes'] == 'Via motorway'
+
+    def test_cannot_access_other_users_template_data(self, client, app, sample_template):
+        from app.models import User
+        other = User(username='other4', email='other4@example.com')
+        other.set_password('Pass123!')
+        db.session.add(other)
+        db.session.commit()
+        client.post('/auth/login', data={'username': 'other4', 'password': 'Pass123!'}, follow_redirects=True)
+        resp = client.get(f'/trips/templates/{sample_template.id}/data')
+        assert resp.status_code == 403
+
+
+class TestTripNewWithTemplate:
+    def test_new_form_shows_template_selector(self, auth_client, sample_vehicle, sample_template):
+        resp = auth_client.get('/trips/new')
+        assert resp.status_code == 200
+        assert b'Load template' in resp.data
+        assert b'Office Commute' in resp.data
+
+    def test_new_form_no_template_selector_without_templates(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/trips/new')
+        assert resp.status_code == 200
+        assert b'Load template' not in resp.data
+
+    def test_template_id_param_accepted(self, auth_client, sample_vehicle, sample_template):
+        resp = auth_client.get(f'/trips/new?template_id={sample_template.id}')
+        assert resp.status_code == 200
 
 
 class TestTripReport:


### PR DESCRIPTION
## What's Changed

### New Features
- **Trip Templates** — save common routes (purpose, vehicle, start/end locations, description, notes) as reusable templates to fill in trip details faster
  - Full CRUD management at `/trips/templates/`
  - "Load template" dropdown on the Log Trip form pre-fills all fields instantly via AJAX
  - "Use" button on the templates list opens a pre-filled new trip form
  - Templates button added to the trips index page

### Other Changes
- New `trip_templates` database table with migration
- 23 new tests covering template CRUD, access control, JSON data endpoint, and form integration (535 total, all passing)