### PR TITLE
v0.20.0 - Bug fixes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -101,7 +101,9 @@ def _bootstrap_alembic_version(app):
     user_cols = {c['name'] for c in inspector.get_columns('users')}
     vehicle_cols = {c['name'] for c in inspector.get_columns('vehicles')}
 
-    if 'default_vehicle_id' in user_cols:
+    if 'trip_templates' in table_names:
+        target = 'b2c3d4e5f6a7'
+    elif 'default_vehicle_id' in user_cols:
         target = 'a1b2c3d4e5f6'
     elif 'odometer_unit' in vehicle_cols:
         target = '613be8af4376'

--- a/app/models.py
+++ b/app/models.py
@@ -430,18 +430,29 @@ class FuelLog(db.Model):
     def get_consumption(self, consumption_unit=None, volume_unit='L'):
         """Calculate consumption for this fill-up.
 
+        For full-tank fill-ups, uses the previous full-tank as the baseline so
+        the figure accounts for a full tank-to-tank cycle.  For partial fills,
+        uses the immediately preceding log (any type) as the baseline to give
+        an instantaneous estimate for that segment.
+
         Args:
             consumption_unit: 'L/100km', 'mpg', or 'mpg_us'. If None, returns L/100km.
             volume_unit: 'L', 'gal' (UK), or 'us_gal'. Used to convert volume for MPG.
         """
-        if not self.is_full_tank or not self.volume:
+        if not self.volume:
             return None
 
-        prev_log = FuelLog.query.filter(
-            FuelLog.vehicle_id == self.vehicle_id,
-            FuelLog.odometer < self.odometer,
-            FuelLog.is_full_tank == True
-        ).order_by(FuelLog.odometer.desc()).first()
+        if self.is_full_tank:
+            prev_log = FuelLog.query.filter(
+                FuelLog.vehicle_id == self.vehicle_id,
+                FuelLog.odometer < self.odometer,
+                FuelLog.is_full_tank == True
+            ).order_by(FuelLog.odometer.desc()).first()
+        else:
+            prev_log = FuelLog.query.filter(
+                FuelLog.vehicle_id == self.vehicle_id,
+                FuelLog.odometer < self.odometer,
+            ).order_by(FuelLog.odometer.desc()).first()
 
         if prev_log:
             distance = self.odometer - prev_log.odometer

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -161,6 +161,10 @@ def edit(log_id):
         return redirect(url_for('fuel.index'))
 
     if request.method == 'POST':
+        # Capture old values before updating for price history sync
+        old_price = log.price_per_unit
+        old_date = log.date
+
         new_vehicle_id = request.form.get('vehicle_id', type=int)
         if new_vehicle_id:
             new_vehicle = Vehicle.query.get_or_404(new_vehicle_id)
@@ -180,6 +184,33 @@ def edit(log_id):
         # Calculate total cost if not provided
         if log.volume and log.price_per_unit and not log.total_cost:
             log.total_cost = round(log.volume * log.price_per_unit, 2)
+
+        # Keep fuel price history in sync with the edited log
+        if old_price and old_date:
+            history_entry = FuelPriceHistory.query.filter_by(
+                user_id=current_user.id,
+                date=old_date,
+                price_per_unit=old_price
+            ).first()
+            if history_entry:
+                if log.price_per_unit:
+                    history_entry.price_per_unit = log.price_per_unit
+                    history_entry.date = log.date
+                else:
+                    db.session.delete(history_entry)
+            else:
+                # No existing history entry — create one if a station is now selected
+                station_id = request.form.get('station_id', type=int)
+                if station_id and log.price_per_unit:
+                    station = FuelStation.query.get(station_id)
+                    if station:
+                        db.session.add(FuelPriceHistory(
+                            station_id=station_id,
+                            user_id=current_user.id,
+                            date=log.date,
+                            fuel_type=log.vehicle.fuel_type or 'petrol',
+                            price_per_unit=log.price_per_unit
+                        ))
 
         # Handle attachment upload
         if 'attachment' in request.files:

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.19.0'
+APP_VERSION = '0.20.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -1,6 +1,7 @@
 import pytest
+from datetime import date
 from app import db
-from app.models import FuelLog
+from app.models import FuelLog, FuelStation, FuelPriceHistory
 
 
 class TestFuelIndex:
@@ -92,6 +93,164 @@ class TestFuelDelete:
         resp = auth_client.post(f'/fuel/{log_id}/delete', follow_redirects=True)
         assert resp.status_code == 200
         assert FuelLog.query.get(log_id) is None
+
+
+class TestPartialFillConsumption:
+    """#122 — consumption should be calculated for partial fills."""
+
+    def test_full_tank_consumption_unchanged(self, app, test_user, sample_vehicle):
+        log1 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       date=date(2024, 1, 1), odometer=10000, volume=40, is_full_tank=True)
+        log2 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       date=date(2024, 1, 15), odometer=10500, volume=42, is_full_tank=True)
+        db.session.add_all([log1, log2])
+        db.session.commit()
+        # 42L / 500km * 100 = 8.4 L/100km
+        assert abs(log2.get_consumption() - 8.4) < 0.01
+
+    def test_partial_fill_returns_consumption(self, app, test_user, sample_vehicle):
+        log1 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       date=date(2024, 1, 1), odometer=10000, volume=40, is_full_tank=True)
+        log2 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       date=date(2024, 1, 10), odometer=10200, volume=20, is_full_tank=False)
+        db.session.add_all([log1, log2])
+        db.session.commit()
+        # 20L / 200km * 100 = 10.0 L/100km
+        consumption = log2.get_consumption()
+        assert consumption is not None
+        assert abs(consumption - 10.0) < 0.01
+
+    def test_partial_fill_no_previous_log_returns_none(self, app, test_user, sample_vehicle):
+        log = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                      date=date(2024, 1, 1), odometer=10000, volume=20, is_full_tank=False)
+        db.session.add(log)
+        db.session.commit()
+        assert log.get_consumption() is None
+
+    def test_no_volume_returns_none(self, app, test_user, sample_vehicle):
+        log = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                      date=date(2024, 1, 1), odometer=10000, volume=None, is_full_tank=True)
+        db.session.add(log)
+        db.session.commit()
+        assert log.get_consumption() is None
+
+    def test_partial_fill_uses_any_previous_log(self, app, test_user, sample_vehicle):
+        """Partial fill looks back to the nearest log regardless of fill type."""
+        log1 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       date=date(2024, 1, 1), odometer=10000, volume=40, is_full_tank=True)
+        log2 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       date=date(2024, 1, 8), odometer=10300, volume=15, is_full_tank=False)
+        log3 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       date=date(2024, 1, 15), odometer=10500, volume=20, is_full_tank=False)
+        db.session.add_all([log1, log2, log3])
+        db.session.commit()
+        # log3 looks back to log2 (nearest), not log1
+        # 20L / 200km * 100 = 10.0 L/100km
+        consumption = log3.get_consumption()
+        assert consumption is not None
+        assert abs(consumption - 10.0) < 0.01
+
+
+@pytest.fixture
+def sample_station(app, test_user):
+    station = FuelStation(
+        user_id=test_user.id,
+        name='Test Station',
+        brand='BP',
+    )
+    db.session.add(station)
+    db.session.commit()
+    return station
+
+
+@pytest.fixture
+def fuel_log_with_price_history(app, test_user, sample_vehicle, sample_station):
+    log = FuelLog(
+        vehicle_id=sample_vehicle.id,
+        user_id=test_user.id,
+        date=date(2024, 3, 1),
+        odometer=15000,
+        volume=45,
+        price_per_unit=1.60,
+        total_cost=72.0,
+        is_full_tank=True,
+    )
+    db.session.add(log)
+    db.session.flush()
+    history = FuelPriceHistory(
+        station_id=sample_station.id,
+        user_id=test_user.id,
+        date=log.date,
+        fuel_type='petrol',
+        price_per_unit=log.price_per_unit,
+    )
+    db.session.add(history)
+    db.session.commit()
+    return log, history
+
+
+class TestPriceHistorySync:
+    """#113 — editing a fuel log must keep FuelPriceHistory in sync."""
+
+    def test_edit_price_updates_history(self, auth_client, fuel_log_with_price_history):
+        log, history = fuel_log_with_price_history
+        auth_client.post(f'/fuel/{log.id}/edit', data={
+            'date': '2024-03-01',
+            'odometer': str(log.odometer),
+            'volume': str(log.volume),
+            'price_per_unit': '1.45',
+            'total_cost': str(log.total_cost),
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        db.session.refresh(history)
+        assert history.price_per_unit == 1.45
+
+    def test_edit_date_updates_history(self, auth_client, fuel_log_with_price_history):
+        log, history = fuel_log_with_price_history
+        auth_client.post(f'/fuel/{log.id}/edit', data={
+            'date': '2024-03-10',
+            'odometer': str(log.odometer),
+            'volume': str(log.volume),
+            'price_per_unit': str(log.price_per_unit),
+            'total_cost': str(log.total_cost),
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        from datetime import date
+        db.session.refresh(history)
+        assert history.date == date(2024, 3, 10)
+
+    def test_edit_remove_price_deletes_history(self, auth_client, fuel_log_with_price_history):
+        log, history = fuel_log_with_price_history
+        history_id = history.id
+        auth_client.post(f'/fuel/{log.id}/edit', data={
+            'date': '2024-03-01',
+            'odometer': str(log.odometer),
+            'volume': str(log.volume),
+            'price_per_unit': '',
+            'total_cost': str(log.total_cost),
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        assert FuelPriceHistory.query.get(history_id) is None
+
+    def test_stale_price_not_shown_after_edit(self, auth_client, fuel_log_with_price_history):
+        """The bad-entry scenario from issue #113: edit fixes the price, history reflects it."""
+        log, history = fuel_log_with_price_history
+        # Simulate the bad entry: history has 254.7
+        history.price_per_unit = 254.7
+        log.price_per_unit = 254.7
+        db.session.commit()
+
+        # User edits to correct value
+        auth_client.post(f'/fuel/{log.id}/edit', data={
+            'date': '2024-03-01',
+            'odometer': str(log.odometer),
+            'volume': str(log.volume),
+            'price_per_unit': '2.547',
+            'total_cost': str(log.total_cost),
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        db.session.refresh(history)
+        assert history.price_per_unit == 2.547
 
 
 class TestFuelQuick:


### PR DESCRIPTION
## What's Changed

### Bug Fixes
- **Consumption calculated for partial fills** — fuel logs without "Full tank fill-up" ticked now show a consumption figure, calculated against the immediately preceding log as an instantaneous estimate (#122)
- **Fuel price history stays in sync on edit** — editing a fuel log's price or date now updates the corresponding `FuelPriceHistory` entry so the cheapest fuel display reflects the corrected value; removing the price deletes the stale history entry (#113)

### Other Changes
- 9 new tests covering partial fill consumption and price history sync (544 total, all passing)
- Updated `_bootstrap_alembic_version` to recognise the `trip_templates` migration, preventing upgrade failures on fresh installs