### PR TITLE
bug: Allow empty end odometer for trips

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1218,6 +1218,8 @@ class Trip(db.Model):
     @property
     def distance(self):
         """Calculate trip distance"""
+        if self.end_odometer is None or self.start_odometer is None:
+            return 0
         return self.end_odometer - self.start_odometer
 
     def to_dict(self):

--- a/app/templates/trips/index.html
+++ b/app/templates/trips/index.html
@@ -118,7 +118,7 @@
                 <div class="ml-4 flex items-center gap-4">
                     <div class="text-right">
                         <p class="text-sm font-medium text-gray-900 dark:text-white">{{ "%.1f"|format(trip.distance) }} {{ current_user.distance_unit }}</p>
-                        <p class="text-xs text-gray-500 dark:text-gray-400">{{ "%.0f"|format(trip.start_odometer) }} &rarr; {{ "%.0f"|format(trip.end_odometer) }}</p>
+                        <p class="text-xs text-gray-500 dark:text-gray-400">{{ "%.0f"|format(trip.start_odometer) }} &rarr; {{ "%.0f"|format(trip.end_odometer or 0) }}</p>
                     </div>
                     <div class="flex items-center gap-2">
                         <a href="{{ url_for('trips.edit', trip_id=trip.id) }}"

--- a/tests/test_trips.py
+++ b/tests/test_trips.py
@@ -65,6 +65,33 @@ class TestTripNew:
         assert trip.end_odometer == 12200.0
         assert trip.user_id == test_user.id
 
+class TestTripNewNoEndOdometer:
+    def test_new_requires_auth(self, client):
+        resp = client.get('/trips/new', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_get_new_form_returns_200(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/trips/new')
+        assert resp.status_code == 200
+
+    def test_create_trip(self, auth_client, sample_vehicle, test_user):
+        resp = auth_client.post('/trips/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-03-01',
+            'start_odometer': '12000',
+            'purpose': 'business',
+            'description': 'No end odometer trip',
+            'start_location': 'Office',
+            'end_location': 'Client',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        trip = Trip.query.filter_by(description='No end odometer trip').first()
+        assert trip is not None
+        assert trip.start_odometer == 12000.0
+        assert trip.end_odometer == None
+        assert trip.user_id == test_user.id
+
 
 class TestTripEdit:
     def test_edit_requires_auth(self, client, sample_trip):


### PR DESCRIPTION
Refs: #185

## Summary

Allows "End Odometer" to be empty.

## Testing

How were these changes tested?

- [x] Tested locally
- [ ] Tested with Docker image
