### PR TITLE
Release v0.22.4 — flexible recurrence + EV coverage

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -252,7 +252,7 @@ class Vehicle(db.Model):
         return sum(exp.cost for exp in self.expenses.all() if exp.cost)
 
     def get_total_cost(self):
-        return self.get_total_fuel_cost() + self.get_total_expense_cost()
+        return self.get_total_fuel_cost() + self.get_total_expense_cost() + self.get_total_charging_cost()
 
     @property
     def vehicle_type_label(self):
@@ -369,6 +369,43 @@ class Vehicle(db.Model):
     def get_total_charging_cost(self):
         """Get total cost of all charging sessions"""
         return sum(session.total_cost for session in self.charging_sessions.all() if session.total_cost) or 0
+
+    def get_total_charging_kwh(self):
+        """Total energy delivered across all charging sessions (kWh)."""
+        return sum(s.kwh_added for s in self.charging_sessions.all() if s.kwh_added) or 0
+
+    def get_average_charging_consumption(self, distance_unit=None):
+        """Mean energy consumption between the first and last charging sessions
+        that have odometer readings.
+
+        Returns kWh per 100 distance units in ``distance_unit`` (falls back to
+        the vehicle's odometer unit). Mirrors the fill-to-fill approach used
+        for fuel: needs at least two anchor sessions with odometers, and sums
+        every charge in between.
+        """
+        sessions = (self.charging_sessions
+                    .filter(ChargingSession.odometer.isnot(None))
+                    .order_by(ChargingSession.odometer)
+                    .all())
+        if len(sessions) < 2:
+            return None
+        first_odo, last_odo = sessions[0].odometer, sessions[-1].odometer
+        raw_distance = last_odo - first_odo
+        if raw_distance <= 0:
+            return None
+        total_kwh = sum(s.kwh_added for s in sessions if s.kwh_added) or 0
+        if total_kwh <= 0:
+            return None
+        target = distance_unit or self.get_effective_odometer_unit()
+        distance = _distance_in(raw_distance, self.get_effective_odometer_unit(), target)
+        return (total_kwh / distance) * 100 if distance > 0 else None
+
+    def get_cost_per_kwh(self):
+        """Average cost per kWh across all charging sessions with data."""
+        total_kwh = self.get_total_charging_kwh()
+        if total_kwh <= 0:
+            return None
+        return self.get_total_charging_cost() / total_kwh
 
     def get_total_trip_distance(self):
         """Get total distance from all trips"""
@@ -909,13 +946,15 @@ REMINDER_TYPES = [
     ('custom', _l('Custom'))
 ]
 
-# Recurrence options
+# Recurrence options. The legacy values (quarterly, biannual) remain accepted on
+# read so saved reminders keep working; new reminders use a unit + interval pair
+# (see Reminder.recurrence_interval).
 RECURRENCE_OPTIONS = [
     ('none', _l('No Repeat')),
-    ('monthly', _l('Monthly')),
-    ('quarterly', _l('Quarterly (3 months)')),
-    ('biannual', _l('Every 6 months')),
-    ('yearly', _l('Yearly')),
+    ('daily', _l('Day(s)')),
+    ('weekly', _l('Week(s)')),
+    ('monthly', _l('Month(s)')),
+    ('yearly', _l('Year(s)')),
 ]
 
 # Trip purposes for tax deductions

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -31,7 +31,16 @@ def index():
         FuelLog.vehicle_id.in_(vehicle_ids)
     ).order_by(FuelLog.date.desc()).all()
 
-    return render_template('fuel/index.html', logs=logs, vehicles=vehicles)
+    # #175 — also surface charging sessions on this page when the user has EVs
+    from app.models import ChargingSession
+    charging_sessions = ChargingSession.query.filter(
+        ChargingSession.vehicle_id.in_(vehicle_ids)
+    ).order_by(ChargingSession.date.desc()).all() if vehicle_ids else []
+
+    return render_template('fuel/index.html',
+                           logs=logs,
+                           vehicles=vehicles,
+                           charging_sessions=charging_sessions)
 
 
 @bp.route('/new', methods=['GET', 'POST'])

--- a/app/routes/reminders.py
+++ b/app/routes/reminders.py
@@ -85,6 +85,7 @@ def new(vehicle_id=None):
             reminder_type=request.form.get('reminder_type'),
             due_date=due_date,
             recurrence=request.form.get('recurrence', 'none'),
+            recurrence_interval=max(int(request.form.get('recurrence_interval') or 1), 1),
             notify_days_before=int(request.form.get('notify_days_before', 7))
         )
 
@@ -137,6 +138,7 @@ def edit(reminder_id):
         reminder.reminder_type = request.form.get('reminder_type')
         reminder.due_date = due_date
         reminder.recurrence = request.form.get('recurrence', 'none')
+        reminder.recurrence_interval = max(int(request.form.get('recurrence_interval') or 1), 1)
         reminder.notify_days_before = int(request.form.get('notify_days_before', 7))
 
         db.session.commit()
@@ -167,7 +169,7 @@ def complete(reminder_id):
 
     # If recurring, create the next occurrence
     if reminder.recurrence != 'none':
-        new_due_date = calculate_next_due_date(reminder.due_date, reminder.recurrence)
+        new_due_date = calculate_next_due_date(reminder.due_date, reminder.recurrence, reminder.recurrence_interval)
         new_reminder = Reminder(
             vehicle_id=reminder.vehicle_id,
             user_id=reminder.user_id,
@@ -176,6 +178,7 @@ def complete(reminder_id):
             reminder_type=reminder.reminder_type,
             due_date=new_due_date,
             recurrence=reminder.recurrence,
+            recurrence_interval=reminder.recurrence_interval,
             notify_days_before=reminder.notify_days_before
         )
         db.session.add(new_reminder)
@@ -239,40 +242,29 @@ def delete(reminder_id):
     return redirect(url_for('reminders.index'))
 
 
-def calculate_next_due_date(current_date, recurrence):
-    """Calculate the next due date based on recurrence"""
+def calculate_next_due_date(current_date, recurrence, interval=1):
+    """Calculate the next due date for the given recurrence unit and interval.
+
+    Accepts the current unit-based vocabulary (daily, weekly, monthly, yearly)
+    and the legacy values (quarterly = 3 months, biannual = 6 months) so old
+    reminders keep working until they're edited.
+    """
+    from dateutil.relativedelta import relativedelta
+
+    step = max(int(interval or 1), 1)
+
+    if recurrence == 'daily':
+        return current_date + relativedelta(days=step)
+    if recurrence == 'weekly':
+        return current_date + relativedelta(weeks=step)
     if recurrence == 'monthly':
-        # Add one month
-        month = current_date.month + 1
-        year = current_date.year
-        if month > 12:
-            month = 1
-            year += 1
-        # Handle day overflow (e.g., Jan 31 -> Feb 28)
-        day = min(current_date.day, 28)  # Safe default
-        return date(year, month, day)
-
-    elif recurrence == 'quarterly':
-        # Add 3 months
-        month = current_date.month + 3
-        year = current_date.year
-        while month > 12:
-            month -= 12
-            year += 1
-        day = min(current_date.day, 28)
-        return date(year, month, day)
-
-    elif recurrence == 'biannual':
-        # Add 6 months
-        month = current_date.month + 6
-        year = current_date.year
-        while month > 12:
-            month -= 12
-            year += 1
-        day = min(current_date.day, 28)
-        return date(year, month, day)
-
-    elif recurrence == 'yearly':
-        return date(current_date.year + 1, current_date.month, current_date.day)
+        return current_date + relativedelta(months=step)
+    if recurrence == 'yearly':
+        return current_date + relativedelta(years=step)
+    # Legacy fixed-interval values from pre-0.22.4 reminders.
+    if recurrence == 'quarterly':
+        return current_date + relativedelta(months=3 * step)
+    if recurrence == 'biannual':
+        return current_date + relativedelta(months=6 * step)
 
     return current_date

--- a/app/routes/vehicles.py
+++ b/app/routes/vehicles.py
@@ -125,12 +125,17 @@ def view(vehicle_id):
     stats = {
         'total_fuel_cost': vehicle.get_total_fuel_cost(),
         'total_expense_cost': vehicle.get_total_expense_cost(),
+        'total_charging_cost': vehicle.get_total_charging_cost(),
+        'total_charging_kwh': vehicle.get_total_charging_kwh(),
+        'avg_charging_consumption': vehicle.get_average_charging_consumption(),
+        'cost_per_kwh': vehicle.get_cost_per_kwh(),
         'total_cost': vehicle.get_total_cost(),
         'total_distance': vehicle.get_total_distance(vehicle.get_effective_odometer_unit()),
         'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit, current_user.volume_unit),
         'cost_per_distance': vehicle.get_cost_per_distance(),
         'fuel_logs_count': vehicle.fuel_logs.count(),
-        'expenses_count': vehicle.expenses.count()
+        'expenses_count': vehicle.expenses.count(),
+        'charging_sessions_count': vehicle.charging_sessions.count(),
     }
 
     # Get reminders for this vehicle (not completed, ordered by due date)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -50,6 +50,26 @@
         </div>
     </div>
 
+    {% if total_charging_cost and total_charging_cost > 0 %}
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+        <div class="p-5">
+            <div class="flex items-center">
+                <div class="flex-shrink-0">
+                    <svg class="h-6 w-6 text-blue-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+                    </svg>
+                </div>
+                <div class="ml-5 w-0 flex-1">
+                    <dl>
+                        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">{{ _('Total Charging Cost') }}</dt>
+                        <dd class="text-lg font-semibold text-gray-900 dark:text-white">{{ "%.2f"|format(total_charging_cost) }} {{ current_user.currency }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     <div class="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
         <div class="p-5">
             <div class="flex items-center">

--- a/app/templates/fuel/index.html
+++ b/app/templates/fuel/index.html
@@ -87,4 +87,62 @@
     </div>
 </div>
 {% endif %}
+
+{% if charging_sessions %}
+<div class="mt-8 sm:flex sm:items-center sm:justify-between mb-6">
+    <div>
+        <h2 class="text-xl font-bold text-gray-900 dark:text-white">{{ _('Charging History') }}</h2>
+        <p class="text-gray-500 dark:text-gray-400">{{ _('Sessions logged for your electric and plug-in hybrid vehicles') }}</p>
+    </div>
+    <a href="{{ url_for('charging.new') }}"
+       class="mt-4 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-500 hover:bg-blue-600">
+        <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        {{ _('Add Charging Session') }}
+    </a>
+</div>
+<div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Date') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Vehicle') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Odometer') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('kWh') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Cost') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Location') }}</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Actions') }}</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                {% for session in charging_sessions %}
+                <tr class="hover:bg-gray-50 dark:bg-gray-700">
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ session.date|format_date }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        <a href="{{ url_for('vehicles.view', vehicle_id=session.vehicle_id) }}" class="text-primary-600 hover:text-primary-500">
+                            {{ session.vehicle.name }}
+                        </a>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        {% if session.odometer %}{{ "%.0f"|format(session.odometer) }} {{ session.vehicle.get_effective_odometer_unit() }}{% else %}-{% endif %}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        {% if session.kwh_added %}{{ "%.1f"|format(session.kwh_added) }} kWh{% else %}-{% endif %}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        {% if session.total_cost %}{{ "%.2f"|format(session.total_cost) }} {{ current_user.currency }}{% else %}-{% endif %}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ session.location or '-' }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <a href="{{ url_for('charging.edit', session_id=session.id) }}" class="text-primary-600 hover:text-primary-900">{{ _('Edit') }}</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endif %}
 {% endblock %}

--- a/app/templates/reminders/form.html
+++ b/app/templates/reminders/form.html
@@ -79,16 +79,25 @@
 
             <!-- Recurrence -->
             <div>
-                <label for="recurrence" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Recurrence</label>
-                <select name="recurrence" id="recurrence"
-                        class="block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-primary-500 focus:ring-primary-500">
-                    {% for rec_id, rec_name in recurrence_options %}
-                    <option value="{{ rec_id }}" {% if reminder and reminder.recurrence == rec_id %}selected{% endif %}>
-                        {{ rec_name }}
-                    </option>
-                    {% endfor %}
-                </select>
-                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">When marked complete, a recurring reminder will automatically create the next occurrence</p>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ _('Recurrence') }}</label>
+                <div class="flex gap-2 items-stretch">
+                    <span class="inline-flex items-center px-3 text-sm text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700 border border-r-0 border-gray-300 dark:border-gray-600 rounded-l-md">
+                        {{ _('Every') }}
+                    </span>
+                    <input type="number" name="recurrence_interval" id="recurrence_interval"
+                           min="1" step="1"
+                           value="{{ reminder.recurrence_interval if reminder and reminder.recurrence_interval else 1 }}"
+                           class="w-20 border-y border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:bg-gray-700 dark:text-white">
+                    <select name="recurrence" id="recurrence"
+                            class="flex-1 rounded-r-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-primary-500 focus:ring-primary-500">
+                        {% for rec_id, rec_name in recurrence_options %}
+                        <option value="{{ rec_id }}" {% if reminder and reminder.recurrence == rec_id %}selected{% endif %}>
+                            {{ rec_name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('e.g. \"Every 2 Year(s)\" for an MOT due every two years. When marked complete, the next occurrence is created automatically.') }}</p>
             </div>
 
             <!-- Notification Days -->

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -70,11 +70,20 @@
 
 <!-- Stats Cards -->
 <div class="grid grid-cols-2 gap-4 sm:grid-cols-5 mb-8">
+    {% if vehicle.uses_fuel() %}
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
         <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Total Fuel Cost') }}</dt>
         <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ "%.2f"|format(stats.total_fuel_cost) }}</dd>
         <dd class="text-sm text-gray-500 dark:text-gray-400">{{ current_user.currency }}</dd>
     </div>
+    {% endif %}
+    {% if vehicle.uses_charging() %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Total Charging Cost') }}</dt>
+        <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ "%.2f"|format(stats.total_charging_cost) }}</dd>
+        <dd class="text-sm text-gray-500 dark:text-gray-400">{{ current_user.currency }}</dd>
+    </div>
+    {% endif %}
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
         <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Other Expenses') }}</dt>
         <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ "%.2f"|format(stats.total_expense_cost) }}</dd>
@@ -85,11 +94,20 @@
         <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ "%.0f"|format(stats.total_distance) }}</dd>
         <dd class="text-sm text-gray-500 dark:text-gray-400">{{ vehicle.get_effective_odometer_unit() }}</dd>
     </div>
+    {% if vehicle.uses_fuel() %}
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
         <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Avg. Consumption') }}</dt>
         <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{% if stats.avg_consumption %}{{ "%.1f"|format(stats.avg_consumption) }}{% else %}-{% endif %}</dd>
         <dd class="text-sm text-gray-500 dark:text-gray-400">{{ current_user.consumption_unit }}</dd>
     </div>
+    {% endif %}
+    {% if vehicle.uses_charging() %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Avg. Charging') }}</dt>
+        <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{% if stats.avg_charging_consumption %}{{ "%.1f"|format(stats.avg_charging_consumption) }}{% else %}-{% endif %}</dd>
+        <dd class="text-sm text-gray-500 dark:text-gray-400">kWh / 100 {{ vehicle.get_effective_odometer_unit() }}</dd>
+    </div>
+    {% endif %}
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
         <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Cost per') }} {{ vehicle.get_effective_odometer_unit() }}</dt>
         <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{% if stats.cost_per_distance %}{{ "%.2f"|format(stats.cost_per_distance) }}{% else %}-{% endif %}</dd>
@@ -694,6 +712,7 @@
 })();
 </script>
 
+{% if vehicle.uses_fuel() %}
 <!-- Consumption Chart -->
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-8">
     <h2 class="text-lg font-medium text-gray-900 dark:text-white mb-4">{{ _('Fuel Consumption Trend') }}</h2>
@@ -701,6 +720,7 @@
         <canvas id="consumptionChart"></canvas>
     </div>
 </div>
+{% endif %}
 
 <!-- Recent Activity -->
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.22.3'
+APP_VERSION = '0.22.4'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_charging.py
+++ b/tests/test_charging.py
@@ -35,6 +35,75 @@ def sample_session(app, test_user, ev_vehicle):
     return session
 
 
+class TestEVStats:
+    """#175 — EV cost/consumption stats must include charging."""
+
+    def test_total_cost_includes_charging(self, app, test_user, ev_vehicle):
+        # Pure EV: no fuel logs, but two charging sessions
+        ev_vehicle.odometer_unit = 'km'
+        db.session.commit()
+        db.session.add_all([
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 1), odometer=10000, kwh_added=30, total_cost=6.0),
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 15), odometer=10500, kwh_added=40, total_cost=8.0),
+        ])
+        db.session.commit()
+        assert ev_vehicle.get_total_cost() == 14.0
+
+    def test_average_charging_consumption_km(self, app, test_user, ev_vehicle):
+        ev_vehicle.odometer_unit = 'km'
+        db.session.commit()
+        db.session.add_all([
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 1), odometer=10000, kwh_added=30),
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 15), odometer=10500, kwh_added=40),
+        ])
+        db.session.commit()
+        # 70 kWh over 500 km = 14 kWh / 100 km
+        consumption = ev_vehicle.get_average_charging_consumption()
+        assert consumption is not None
+        assert abs(consumption - 14.0) < 0.01
+
+    def test_average_charging_consumption_mi_to_km(self, app, test_user, ev_vehicle):
+        """Vehicle in miles, asked for kWh/100km — must convert."""
+        ev_vehicle.odometer_unit = 'mi'
+        db.session.commit()
+        db.session.add_all([
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 1), odometer=10000, kwh_added=30),
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 15), odometer=10500, kwh_added=40),
+        ])
+        db.session.commit()
+        # 70 kWh over 500 mi = 804.672 km → ~8.70 kWh/100km
+        consumption = ev_vehicle.get_average_charging_consumption('km')
+        assert consumption is not None
+        assert abs(consumption - 8.70) < 0.05
+
+    def test_cost_per_kwh(self, app, test_user, ev_vehicle):
+        db.session.add_all([
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 1), kwh_added=30, total_cost=9.0),
+            ChargingSession(vehicle_id=ev_vehicle.id, user_id=test_user.id,
+                            date=date(2026, 4, 15), kwh_added=20, total_cost=4.0),
+        ])
+        db.session.commit()
+        # 13 / 50 = 0.26
+        assert abs(ev_vehicle.get_cost_per_kwh() - 0.26) < 0.001
+
+    def test_no_sessions_returns_none(self, app, test_user, ev_vehicle):
+        assert ev_vehicle.get_average_charging_consumption() is None
+        assert ev_vehicle.get_cost_per_kwh() is None
+
+    def test_fuel_index_lists_charging(self, auth_client, sample_session):
+        resp = auth_client.get('/fuel/')
+        assert resp.status_code == 200
+        assert b'Charging History' in resp.data
+        assert b'Tesla Model 3' in resp.data
+
+
 class TestChargingIndex:
     def test_index_requires_auth(self, client):
         resp = client.get('/charging/', follow_redirects=False)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -118,3 +118,58 @@ class TestReminderComplete:
         assert resp.status_code == 200
         db.session.refresh(sample_reminder)
         assert sample_reminder.is_completed is False
+
+
+class TestReminderFlexibleRecurrence:
+    """#184 — recurrence is now a unit + interval pair (e.g., every 2 years)."""
+
+    def test_create_with_interval(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/reminders/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'title': 'French MOT',
+            'reminder_type': 'mot',
+            'due_date': '2025-06-01',
+            'recurrence': 'yearly',
+            'recurrence_interval': '2',
+            'notify_days_before': '14',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        r = Reminder.query.filter_by(title='French MOT').first()
+        assert r is not None
+        assert r.recurrence == 'yearly'
+        assert r.recurrence_interval == 2
+
+    def test_complete_uses_interval_for_next_occurrence(self, auth_client, sample_vehicle, test_user):
+        r = Reminder(
+            vehicle_id=sample_vehicle.id, user_id=test_user.id,
+            title='Biennial MOT', reminder_type='mot',
+            due_date=date(2025, 6, 1),
+            recurrence='yearly', recurrence_interval=2,
+        )
+        db.session.add(r)
+        db.session.commit()
+        auth_client.post(f'/reminders/{r.id}/complete', follow_redirects=True)
+        next_r = Reminder.query.filter(Reminder.title == 'Biennial MOT', Reminder.is_completed == False).first()
+        assert next_r is not None
+        assert next_r.due_date == date(2027, 6, 1)
+        assert next_r.recurrence_interval == 2
+
+    def test_legacy_quarterly_still_resolves(self):
+        from app.routes.reminders import calculate_next_due_date
+        # Reminders created before 0.22.4 may have recurrence='quarterly'
+        # and recurrence_interval=1; should still advance by 3 months.
+        next_due = calculate_next_due_date(date(2025, 1, 1), 'quarterly', 1)
+        assert next_due == date(2025, 4, 1)
+
+    def test_legacy_biannual_still_resolves(self):
+        from app.routes.reminders import calculate_next_due_date
+        next_due = calculate_next_due_date(date(2025, 1, 1), 'biannual', 1)
+        assert next_due == date(2025, 7, 1)
+
+    def test_daily_interval(self):
+        from app.routes.reminders import calculate_next_due_date
+        assert calculate_next_due_date(date(2025, 6, 1), 'daily', 10) == date(2025, 6, 11)
+
+    def test_weekly_interval(self):
+        from app.routes.reminders import calculate_next_due_date
+        assert calculate_next_due_date(date(2025, 6, 1), 'weekly', 3) == date(2025, 6, 22)


### PR DESCRIPTION
## Summary

### #184 — Flexible reminder recurrence

Replaces the fixed Monthly / Quarterly / Biannual / Yearly picker with a unit + interval pair, so you can pick things like \"every 2 years\" for a French MOT or \"every 3 months\" for a service interval. The form now reads as \`Every [N] [unit]\`.

Legacy values (\`quarterly\`, \`biannual\`) still resolve correctly when reminders created on older versions hit \`calculate_next_due_date\`, so nothing breaks on upgrade.

### #175 — Electric vehicle coverage

The headline bug was that EV vehicles showed £0 in the overview totals because \`Vehicle.get_total_cost\` only summed fuel + expenses. Fixed plus a broader pass:

- \`get_total_cost\` now includes \`get_total_charging_cost\`.
- New helpers on \`Vehicle\`: \`get_total_charging_kwh\`, \`get_average_charging_consumption(distance_unit)\` (kWh per 100 distance, fill-to-fill style with proper unit conversion), \`get_cost_per_kwh\`.
- Vehicle view swaps \"Total Fuel Cost\" → \"Total Charging Cost\" and \"Avg. Consumption\" → \"Avg. Charging (kWh / 100 km)\" on pure EVs. Plug-in hybrids see both blocks. Fuel Consumption Trend chart is hidden on pure EVs (matches the reporter's \"no need for fuel consumption in EVs\").
- Dashboard surfaces a \"Total Charging Cost\" card when there's any charging spend.
- Fuel logs page now shows a \"Charging History\" section beneath the fuel table — so EV users see their sessions in the same place rather than having to navigate to a separate charging page.

### Tests

- 12 new tests (6 for flexible recurrence including legacy-value compatibility; 6 for EV stats including cross-unit conversion).
- 583 total passing.