### PR TITLE
fix(ntfy): set User-Agent so Cloudflare doesn't 403

### DIFF
--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -101,6 +101,7 @@ class NotificationService:
                 'Title': title,
                 'Priority': priority,
                 'Tags': 'car',
+                'User-Agent': 'May-Vehicle-Manager/1.0',
             })
             with urlopen(req, timeout=10) as response:
                 return True, None


### PR DESCRIPTION
## Summary

When ntfy is behind Cloudflare with Bot Fight Mode on, sending a notification fails with `HTTP 403: Forbidden`. The 403 is from Cloudflare, not ntfy (response is CF HTML, not ntfy's `40103` JSON). Cloudflare blocks the default `Python-urllib/X.Y` user agent.

Setting the same `User-Agent: May-Vehicle-Manager/1.0` that `send_webhook` already uses fixes it.

## Repro

```python
from urllib.request import Request, urlopen
url = 'https://ntfy.example.com/topic?auth=<base64url(:token)>'
req = Request(url, data=b'hi', headers={'Title':'Test','Priority':'default','Tags':'car'})
urlopen(req)  # HTTP Error 403: Forbidden
```

After the patch the same call returns 200.

## Test plan

- [x] Reproduced 403 against a Cloudflare-proxied ntfy without the header
- [x] Called the patched `NotificationService.send_ntfy(...)` against the same server, got `ok=True, err=None`, message landed on the topic
- [ ] No regression for ntfy.sh or non-CF self-hosted instances