### PR TITLE
feat: fuel discount, notes and mileage allowance (#209, #204, #208)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -324,7 +324,7 @@ def create_app(config_class=Config):
         fmt = formats.get(style, formats['default'])
         return value.strftime(fmt)
 
-    from app.routes import main, auth, vehicles, fuel, expenses, api, reminders, maintenance, documents, stations, recurring, homeassistant, calendar, trips, charging
+    from app.routes import main, auth, vehicles, fuel, expenses, api, reminders, maintenance, documents, stations, recurring, homeassistant, calendar, trips, charging, notes, allowance
     app.register_blueprint(main.bp)
     app.register_blueprint(auth.bp)
     app.register_blueprint(vehicles.bp)
@@ -340,6 +340,8 @@ def create_app(config_class=Config):
     app.register_blueprint(calendar.bp)
     app.register_blueprint(trips.bp)
     app.register_blueprint(charging.bp)
+    app.register_blueprint(notes.bp)
+    app.register_blueprint(allowance.bp)
 
     # Health check endpoint for container orchestration
     @app.route('/health')

--- a/app/models.py
+++ b/app/models.py
@@ -88,6 +88,8 @@ class User(UserMixin, db.Model):
     show_menu_stations = db.Column(db.Boolean, default=True)
     show_menu_trips = db.Column(db.Boolean, default=True)
     show_menu_charging = db.Column(db.Boolean, default=True)
+    show_menu_notes = db.Column(db.Boolean, default=True)  # issue #204
+    show_menu_allowance = db.Column(db.Boolean, default=True)  # issue #208
     show_quick_entry = db.Column(db.Boolean, default=False)  # Show quick entry button in navbar
 
     # Relationships
@@ -253,6 +255,14 @@ class Vehicle(db.Model):
 
     def get_total_cost(self):
         return self.get_total_fuel_cost() + self.get_total_expense_cost() + self.get_total_charging_cost()
+
+    def get_total_allowance(self):
+        """Total mileage-allowance income recorded for this vehicle (issue #208)."""
+        return sum(a.amount for a in self.mileage_allowances.all() if a.amount) or 0
+
+    def get_net_cost(self):
+        """Running cost after mileage allowance is deducted (issue #208)."""
+        return self.get_total_cost() - self.get_total_allowance()
 
     @property
     def vehicle_type_label(self):
@@ -582,6 +592,7 @@ class FuelLog(db.Model):
     odometer = db.Column(db.Float, nullable=False)  # stored in km
     volume = db.Column(db.Float)  # stored in liters
     price_per_unit = db.Column(db.Float)  # price per liter
+    discount_per_unit = db.Column(db.Float)  # optional loyalty discount per liter (issue #209)
     total_cost = db.Column(db.Float)
 
     fuel_type = db.Column(db.String(20), nullable=True)  # overrides vehicle primary; set when vehicle has secondary fuel type
@@ -656,6 +667,7 @@ class FuelLog(db.Model):
             'odometer': self.odometer,
             'volume': self.volume,
             'price_per_unit': self.price_per_unit,
+            'discount_per_unit': self.discount_per_unit,
             'total_cost': self.total_cost,
             'is_full_tank': self.is_full_tank,
             'is_missed': self.is_missed,
@@ -1462,3 +1474,75 @@ class FuelPriceHistory(db.Model):
     # Relationships
     station = db.relationship('FuelStation', backref=db.backref('price_history', lazy='dynamic'))
     user = db.relationship('User', backref=db.backref('fuel_price_history', lazy='dynamic'))
+
+
+class Note(db.Model):
+    """Freeform note attached to a vehicle, with optional odometer reading.
+
+    Issue #204: a place to record things that don't fit fuel/expenses/maintenance
+    (e.g. a DPF regeneration) without inventing a cost.
+    """
+    __tablename__ = 'notes'
+
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(db.Integer, db.ForeignKey('vehicles.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+
+    date = db.Column(db.Date, nullable=False, default=datetime.utcnow)
+    title = db.Column(db.String(200))
+    content = db.Column(db.Text, nullable=False)
+    odometer = db.Column(db.Float)  # optional, stored in vehicle odometer unit
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    # Relationships — backref is `note_entries` to avoid clashing with Vehicle.notes column
+    vehicle = db.relationship('Vehicle', backref=db.backref('note_entries', lazy='dynamic', cascade='all, delete-orphan'))
+    user = db.relationship('User', backref=db.backref('notes', lazy='dynamic'))
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'vehicle_id': self.vehicle_id,
+            'date': self.date.isoformat() if self.date else None,
+            'title': self.title,
+            'content': self.content,
+            'odometer': self.odometer,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }
+
+
+class MileageAllowance(db.Model):
+    """Mileage-allowance income for a vehicle used for business (issue #208).
+
+    Records money received per the recorded distance; the totals offset the
+    vehicle's running costs (see Vehicle.get_net_cost).
+    """
+    __tablename__ = 'mileage_allowances'
+
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(db.Integer, db.ForeignKey('vehicles.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+
+    date = db.Column(db.Date, nullable=False, default=datetime.utcnow)
+    description = db.Column(db.String(200))
+    distance = db.Column(db.Float)  # optional, stored in vehicle odometer unit
+    rate_per_unit = db.Column(db.Float)  # optional reimbursement rate per distance unit
+    amount = db.Column(db.Float, nullable=False)  # total amount received
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    # Relationships
+    vehicle = db.relationship('Vehicle', backref=db.backref('mileage_allowances', lazy='dynamic', cascade='all, delete-orphan'))
+    user = db.relationship('User', backref=db.backref('mileage_allowances', lazy='dynamic'))
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'vehicle_id': self.vehicle_id,
+            'date': self.date.isoformat() if self.date else None,
+            'description': self.description,
+            'distance': self.distance,
+            'rate_per_unit': self.rate_per_unit,
+            'amount': self.amount,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }

--- a/app/routes/allowance.py
+++ b/app/routes/allowance.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask_login import login_required, current_user
+from flask_babel import gettext as _
+from app import db
+from app.models import Vehicle, MileageAllowance
+
+bp = Blueprint('allowance', __name__, url_prefix='/allowance')
+
+
+@bp.route('/')
+@login_required
+def index():
+    vehicles = current_user.get_all_vehicles()
+    vehicle_ids = [v.id for v in vehicles]
+
+    allowances = MileageAllowance.query.filter(
+        MileageAllowance.vehicle_id.in_(vehicle_ids)
+    ).order_by(MileageAllowance.date.desc()).all()
+
+    return render_template('allowance/index.html', allowances=allowances, vehicles=vehicles)
+
+
+@bp.route('/new', methods=['GET', 'POST'])
+@login_required
+def new():
+    vehicles = current_user.get_all_vehicles()
+
+    if not vehicles:
+        flash(_('Please add a vehicle first'), 'info')
+        return redirect(url_for('vehicles.new'))
+
+    if request.method == 'POST':
+        vehicle_id = int(request.form.get('vehicle_id'))
+        vehicle = Vehicle.query.get_or_404(vehicle_id)
+
+        # Check access
+        if vehicle not in vehicles:
+            flash(_('Access denied'), 'error')
+            return redirect(url_for('allowance.index'))
+
+        try:
+            date_str = request.form.get('date')
+            allowance = MileageAllowance(
+                vehicle_id=vehicle_id,
+                user_id=current_user.id,
+                date=datetime.strptime(date_str, '%Y-%m-%d').date() if date_str else datetime.now().date(),
+                description=request.form.get('description') or None,
+                distance=float(request.form.get('distance')) if request.form.get('distance') else None,
+                rate_per_unit=float(request.form.get('rate_per_unit')) if request.form.get('rate_per_unit') else None,
+                amount=float(request.form.get('amount')),
+            )
+        except (ValueError, TypeError):
+            flash(_('Invalid data submitted. Please check the date and amount fields.'), 'error')
+            return render_template('allowance/form.html', allowance=None, vehicles=vehicles,
+                                   selected_vehicle_id=vehicle_id)
+
+        db.session.add(allowance)
+        db.session.commit()
+        flash(_('Mileage allowance added successfully'), 'success')
+        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+    selected_vehicle_id = request.args.get('vehicle_id', type=int) or current_user.default_vehicle_id
+
+    return render_template('allowance/form.html', allowance=None, vehicles=vehicles,
+                           selected_vehicle_id=selected_vehicle_id)
+
+
+@bp.route('/<int:allowance_id>/edit', methods=['GET', 'POST'])
+@login_required
+def edit(allowance_id):
+    allowance = MileageAllowance.query.get_or_404(allowance_id)
+    vehicles = current_user.get_all_vehicles()
+
+    # Check access
+    if allowance.vehicle not in vehicles:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('allowance.index'))
+
+    if request.method == 'POST':
+        try:
+            date_str = request.form.get('date')
+            allowance.date = datetime.strptime(date_str, '%Y-%m-%d').date() if date_str else allowance.date
+            allowance.description = request.form.get('description') or None
+            allowance.distance = float(request.form.get('distance')) if request.form.get('distance') else None
+            allowance.rate_per_unit = float(request.form.get('rate_per_unit')) if request.form.get('rate_per_unit') else None
+            allowance.amount = float(request.form.get('amount'))
+        except (ValueError, TypeError):
+            flash(_('Invalid data submitted. Please check the date and amount fields.'), 'error')
+            return render_template('allowance/form.html', allowance=allowance, vehicles=vehicles,
+                                   selected_vehicle_id=allowance.vehicle_id)
+
+        db.session.commit()
+        flash(_('Mileage allowance updated successfully'), 'success')
+        return redirect(url_for('vehicles.view', vehicle_id=allowance.vehicle_id))
+
+    return render_template('allowance/form.html', allowance=allowance, vehicles=vehicles,
+                           selected_vehicle_id=allowance.vehicle_id)
+
+
+@bp.route('/<int:allowance_id>/delete', methods=['POST'])
+@login_required
+def delete(allowance_id):
+    allowance = MileageAllowance.query.get_or_404(allowance_id)
+    vehicles = current_user.get_all_vehicles()
+
+    # Check access
+    if allowance.vehicle not in vehicles:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('allowance.index'))
+
+    vehicle_id = allowance.vehicle_id
+    db.session.delete(allowance)
+    db.session.commit()
+    flash(_('Mileage allowance deleted successfully'), 'success')
+    return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -143,6 +143,8 @@ def get_start_page_url(user):
         'stations': 'stations.index',
         'trips': 'trips.index',
         'charging': 'charging.index',
+        'notes': 'notes.index',
+        'allowance': 'allowance.index',
     }
     route = page_routes.get(start_page, 'main.dashboard')
     return url_for(route)
@@ -352,6 +354,8 @@ def menu_preferences():
     current_user.show_menu_stations = request.form.get('show_menu_stations') == 'on'
     current_user.show_menu_trips = request.form.get('show_menu_trips') == 'on'
     current_user.show_menu_charging = request.form.get('show_menu_charging') == 'on'
+    current_user.show_menu_notes = request.form.get('show_menu_notes') == 'on'
+    current_user.show_menu_allowance = request.form.get('show_menu_allowance') == 'on'
     current_user.show_quick_entry = request.form.get('show_quick_entry') == 'on'
     db.session.commit()
     flash(_('Menu preferences updated'), 'success')

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -80,6 +80,13 @@ def new():
             flash(err, 'error')
             return render_template('fuel/new.html', vehicles=vehicles)
 
+        discount_per_unit = None
+        if request.form.get('discount_per_unit'):
+            discount_per_unit, err = validate_positive_number(request.form.get('discount_per_unit'), 'Discount per unit', max_value=1000)
+            if err:
+                flash(err, 'error')
+                return render_template('fuel/new.html', vehicles=vehicles)
+
         total_cost, err = validate_positive_number(request.form.get('total_cost'), 'Total cost', max_value=100000)
         if err:
             flash(err, 'error')
@@ -92,6 +99,7 @@ def new():
             odometer=odometer,
             volume=volume,
             price_per_unit=price_per_unit,
+            discount_per_unit=discount_per_unit,
             total_cost=total_cost,
             fuel_type=request.form.get('fuel_type') or None,
             is_full_tank=request.form.get('is_full_tank') == 'on',
@@ -100,9 +108,10 @@ def new():
             notes=request.form.get('notes')
         )
 
-        # Calculate total cost if not provided
+        # Calculate total cost if not provided, applying any per-unit discount (#209)
         if log.volume and log.price_per_unit and not log.total_cost:
-            log.total_cost = round(log.volume * log.price_per_unit, 2)
+            effective_price = log.price_per_unit - (log.discount_per_unit or 0)
+            log.total_cost = round(log.volume * effective_price, 2)
 
         db.session.add(log)
         db.session.commit()
@@ -186,6 +195,7 @@ def edit(log_id):
         log.odometer = float(request.form.get('odometer'))
         log.volume = float(request.form.get('volume')) if request.form.get('volume') else None
         log.price_per_unit = float(request.form.get('price_per_unit')) if request.form.get('price_per_unit') else None
+        log.discount_per_unit = float(request.form.get('discount_per_unit')) if request.form.get('discount_per_unit') else None
         log.total_cost = float(request.form.get('total_cost')) if request.form.get('total_cost') else None
         log.fuel_type = request.form.get('fuel_type') or None
         log.is_full_tank = request.form.get('is_full_tank') == 'on'
@@ -193,9 +203,10 @@ def edit(log_id):
         log.station = request.form.get('station')
         log.notes = request.form.get('notes')
 
-        # Calculate total cost if not provided
+        # Calculate total cost if not provided, applying any per-unit discount (#209)
         if log.volume and log.price_per_unit and not log.total_cost:
-            log.total_cost = round(log.volume * log.price_per_unit, 2)
+            effective_price = log.price_per_unit - (log.discount_per_unit or 0)
+            log.total_cost = round(log.volume * effective_price, 2)
 
         # Reconcile fuel price history with the edited log.
         # Issue #170: linking a station to an existing log via edit must

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -3,7 +3,7 @@ from flask_login import login_required, current_user
 from datetime import datetime, timedelta
 from sqlalchemy import func
 from app import db
-from app.models import Vehicle, FuelLog, Expense, ChargingSession, FuelPriceHistory, FuelStation
+from app.models import Vehicle, FuelLog, Expense, ChargingSession, FuelPriceHistory, FuelStation, MileageAllowance
 
 bp = Blueprint('main', __name__)
 
@@ -26,6 +26,8 @@ def index():
             'stations': 'stations.index',
             'trips': 'trips.index',
             'charging': 'charging.index',
+            'notes': 'notes.index',
+            'allowance': 'allowance.index',
         }
         route = page_routes.get(start_page, 'main.dashboard')
         return redirect(url_for(route))
@@ -97,8 +99,17 @@ def dashboard():
         ).scalar()
         total_charging_cost = charging_result or 0
 
+    # Total mileage allowance received (#208) — offsets running costs
+    total_allowance = 0
+    if vehicle_ids:
+        allowance_result = db.session.query(func.sum(MileageAllowance.amount)).filter(
+            MileageAllowance.vehicle_id.in_(vehicle_ids)
+        ).scalar()
+        total_allowance = allowance_result or 0
+
     # Calculate cost per distance
     total_cost = total_fuel_cost + total_expense_cost + total_charging_cost
+    net_cost = total_cost - total_allowance
     cost_per_distance = None
     if total_distance > 0:
         cost_per_distance = total_cost / total_distance
@@ -124,6 +135,8 @@ def dashboard():
                            total_fuel_cost=total_fuel_cost,
                            total_expense_cost=total_expense_cost,
                            total_charging_cost=total_charging_cost,
+                           total_allowance=total_allowance,
+                           net_cost=net_cost,
                            total_distance=total_distance,
                            cost_per_distance=cost_per_distance,
                            recent_logs=recent_logs,

--- a/app/routes/notes.py
+++ b/app/routes/notes.py
@@ -1,0 +1,124 @@
+from datetime import datetime
+from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask_login import login_required, current_user
+from flask_babel import gettext as _
+from app import db
+from app.models import Vehicle, Note
+
+bp = Blueprint('notes', __name__, url_prefix='/notes')
+
+
+@bp.route('/')
+@login_required
+def index():
+    vehicles = current_user.get_all_vehicles()
+    vehicle_ids = [v.id for v in vehicles]
+
+    notes = Note.query.filter(
+        Note.vehicle_id.in_(vehicle_ids)
+    ).order_by(Note.date.desc()).all()
+
+    return render_template('notes/index.html', notes=notes, vehicles=vehicles)
+
+
+@bp.route('/new', methods=['GET', 'POST'])
+@login_required
+def new():
+    vehicles = current_user.get_all_vehicles()
+
+    if not vehicles:
+        flash(_('Please add a vehicle first'), 'info')
+        return redirect(url_for('vehicles.new'))
+
+    if request.method == 'POST':
+        vehicle_id = int(request.form.get('vehicle_id'))
+        vehicle = Vehicle.query.get_or_404(vehicle_id)
+
+        # Check access
+        if vehicle not in vehicles:
+            flash(_('Access denied'), 'error')
+            return redirect(url_for('notes.index'))
+
+        try:
+            date_str = request.form.get('date')
+            note = Note(
+                vehicle_id=vehicle_id,
+                user_id=current_user.id,
+                date=datetime.strptime(date_str, '%Y-%m-%d').date() if date_str else datetime.now().date(),
+                title=request.form.get('title') or None,
+                content=request.form.get('content'),
+                odometer=float(request.form.get('odometer')) if request.form.get('odometer') else None,
+            )
+        except (ValueError, TypeError):
+            flash(_('Invalid data submitted. Please check the date and odometer fields.'), 'error')
+            return render_template('notes/form.html', note=None, vehicles=vehicles,
+                                   selected_vehicle_id=vehicle_id)
+
+        if not note.content:
+            flash(_('Please enter some note text'), 'error')
+            return render_template('notes/form.html', note=None, vehicles=vehicles,
+                                   selected_vehicle_id=vehicle_id)
+
+        db.session.add(note)
+        db.session.commit()
+        flash(_('Note added successfully'), 'success')
+        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+    selected_vehicle_id = request.args.get('vehicle_id', type=int) or current_user.default_vehicle_id
+
+    return render_template('notes/form.html', note=None, vehicles=vehicles,
+                           selected_vehicle_id=selected_vehicle_id)
+
+
+@bp.route('/<int:note_id>/edit', methods=['GET', 'POST'])
+@login_required
+def edit(note_id):
+    note = Note.query.get_or_404(note_id)
+    vehicles = current_user.get_all_vehicles()
+
+    # Check access
+    if note.vehicle not in vehicles:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('notes.index'))
+
+    if request.method == 'POST':
+        try:
+            date_str = request.form.get('date')
+            note.date = datetime.strptime(date_str, '%Y-%m-%d').date() if date_str else note.date
+            note.title = request.form.get('title') or None
+            note.content = request.form.get('content')
+            note.odometer = float(request.form.get('odometer')) if request.form.get('odometer') else None
+        except (ValueError, TypeError):
+            flash(_('Invalid data submitted. Please check the date and odometer fields.'), 'error')
+            return render_template('notes/form.html', note=note, vehicles=vehicles,
+                                   selected_vehicle_id=note.vehicle_id)
+
+        if not note.content:
+            flash(_('Please enter some note text'), 'error')
+            return render_template('notes/form.html', note=note, vehicles=vehicles,
+                                   selected_vehicle_id=note.vehicle_id)
+
+        db.session.commit()
+        flash(_('Note updated successfully'), 'success')
+        return redirect(url_for('vehicles.view', vehicle_id=note.vehicle_id))
+
+    return render_template('notes/form.html', note=note, vehicles=vehicles,
+                           selected_vehicle_id=note.vehicle_id)
+
+
+@bp.route('/<int:note_id>/delete', methods=['POST'])
+@login_required
+def delete(note_id):
+    note = Note.query.get_or_404(note_id)
+    vehicles = current_user.get_all_vehicles()
+
+    # Check access
+    if note.vehicle not in vehicles:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('notes.index'))
+
+    vehicle_id = note.vehicle_id
+    db.session.delete(note)
+    db.session.commit()
+    flash(_('Note deleted successfully'), 'success')
+    return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))

--- a/app/routes/vehicles.py
+++ b/app/routes/vehicles.py
@@ -130,6 +130,8 @@ def view(vehicle_id):
         'avg_charging_consumption': vehicle.get_average_charging_consumption(),
         'cost_per_kwh': vehicle.get_cost_per_kwh(),
         'total_cost': vehicle.get_total_cost(),
+        'total_allowance': vehicle.get_total_allowance(),
+        'net_cost': vehicle.get_net_cost(),
         'total_distance': vehicle.get_total_distance(vehicle.get_effective_odometer_unit()),
         'avg_consumption': vehicle.get_average_consumption(current_user.consumption_unit, current_user.volume_unit),
         'cost_per_distance': vehicle.get_cost_per_distance(),

--- a/app/templates/allowance/form.html
+++ b/app/templates/allowance/form.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+{% block title %}{% if allowance %}{{ _('Edit Allowance') }}{% else %}{{ _('Add Allowance') }}{% endif %}{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+    <div class="mb-6">
+        <a href="{{ url_for('allowance.index') }}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300">&larr; {{ _('Back to mileage allowance') }}</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">{% if allowance %}{{ _('Edit Allowance') }}{% else %}{{ _('Add Allowance') }}{% endif %}</h1>
+    </div>
+
+    <form method="POST" class="space-y-6">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+                <div class="sm:col-span-2">
+                    <label for="vehicle_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Vehicle') }} *</label>
+                    <select name="vehicle_id" id="vehicle_id" required
+                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                        {% for vehicle in vehicles %}
+                        <option value="{{ vehicle.id }}"
+                                data-odometer-unit="{{ vehicle.get_effective_odometer_unit() }}"
+                                {% if (allowance and allowance.vehicle_id == vehicle.id) or (selected_vehicle_id == vehicle.id) %}selected{% endif %}>
+                            {{ vehicle.name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div>
+                    <label for="date" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Date') }} *</label>
+                    <input type="text" name="date" id="date" required data-datepicker data-default-today
+                           value="{{ allowance.date.strftime('%Y-%m-%d') if allowance else '' }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div>
+                    <label for="amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Amount') }} ({{ current_user.currency }}) *</label>
+                    <input type="number" name="amount" id="amount" required step="0.01"
+                           value="{{ allowance.amount if allowance else '' }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div>
+                    <label for="distance" id="distance-label" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Distance') }} ({{ current_user.distance_unit }})</label>
+                    <input type="number" name="distance" id="distance" step="0.1"
+                           value="{{ allowance.distance if allowance and allowance.distance is not none else '' }}"
+                           onchange="calculateAmount()"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div>
+                    <label for="rate_per_unit" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Rate per unit') }} ({{ current_user.currency }})</label>
+                    <input type="number" name="rate_per_unit" id="rate_per_unit" step="0.001"
+                           value="{{ allowance.rate_per_unit if allowance and allowance.rate_per_unit is not none else '' }}"
+                           onchange="calculateAmount()"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ _('Optional. If set with distance, the amount is calculated for you.') }}</p>
+                </div>
+
+                <div class="sm:col-span-2">
+                    <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Description') }}</label>
+                    <input type="text" name="description" id="description" maxlength="200"
+                           value="{{ allowance.description if allowance and allowance.description else '' }}"
+                           placeholder="{{ _('e.g., June client visits') }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+            </div>
+        </div>
+
+        <div class="flex justify-end space-x-3">
+            <a href="{{ url_for('allowance.index') }}"
+               class="px-4 py-2 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+                {{ _('Cancel') }}
+            </a>
+            <button type="submit"
+                    class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+                {% if allowance %}{{ _('Save Changes') }}{% else %}{{ _('Add Allowance') }}{% endif %}
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+    function calculateAmount() {
+        const distance = parseFloat(document.getElementById('distance').value) || 0;
+        const rate = parseFloat(document.getElementById('rate_per_unit').value) || 0;
+        if (distance && rate) {
+            document.getElementById('amount').value = (distance * rate).toFixed(2);
+        }
+    }
+
+    (function() {
+        const vehicleSelect = document.getElementById('vehicle_id');
+        const distanceLabel = document.getElementById('distance-label');
+
+        function updateOdometerUnit() {
+            const selected = vehicleSelect.options[vehicleSelect.selectedIndex];
+            const unit = selected ? selected.dataset.odometerUnit : '{{ current_user.distance_unit }}';
+            if (unit) {
+                distanceLabel.textContent = distanceLabel.textContent.replace(/\([^)]*\)/, '(' + unit + ')');
+            }
+        }
+
+        vehicleSelect.addEventListener('change', updateOdometerUnit);
+        updateOdometerUnit();
+    })();
+</script>
+{% endblock %}

--- a/app/templates/allowance/index.html
+++ b/app/templates/allowance/index.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Mileage Allowance') }}{% endblock %}
+
+{% block content %}
+<div class="sm:flex sm:items-center sm:justify-between mb-6">
+    <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ _('Mileage Allowance') }}</h1>
+        <p class="text-gray-500 dark:text-gray-400">{{ _('Record allowance income for business use; it offsets your running costs') }}</p>
+    </div>
+    <a href="{{ url_for('allowance.new') }}"
+       class="mt-4 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
+        <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        {{ _('Add Allowance') }}
+    </a>
+</div>
+
+{% if allowances %}
+<div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Date') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Vehicle') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Description') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Distance') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Amount') }}</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Actions') }}</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                {% for allowance in allowances %}
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ allowance.date|format_date }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        <a href="{{ url_for('vehicles.view', vehicle_id=allowance.vehicle_id) }}" class="text-primary-600 hover:text-primary-500">
+                            {{ allowance.vehicle.name }}
+                        </a>
+                    </td>
+                    <td class="px-6 py-4 text-sm text-gray-900 dark:text-white">{{ allowance.description or '-' }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        {% if allowance.distance %}{{ allowance.distance|int }} {{ allowance.vehicle.get_effective_odometer_unit() }}{% else %}-{% endif %}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ "%.2f"|format(allowance.amount) }} {{ current_user.currency }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <a href="{{ url_for('allowance.edit', allowance_id=allowance.id) }}" class="text-primary-600 hover:text-primary-900 mr-3">{{ _('Edit') }}</a>
+                        <form method="POST" action="{{ url_for('allowance.delete', allowance_id=allowance.id) }}" class="inline"
+                              onsubmit="return confirm('{{ _('Delete this allowance entry?') }}');">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="text-red-600 hover:text-red-900">{{ _('Delete') }}</button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% else %}
+<div class="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow">
+    <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    </svg>
+    <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">{{ _('No allowance entries') }}</h3>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Track mileage allowance you receive for business journeys.') }}</p>
+    <div class="mt-6">
+        <a href="{{ url_for('allowance.new') }}"
+           class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
+            <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+            {{ _('Add Allowance') }}
+        </a>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -411,6 +411,8 @@
                                     <option value="stations" {% if current_user.start_page == 'stations' %}selected{% endif %}>{{ _('Fuel Stations') }}</option>
                                     <option value="trips" {% if current_user.start_page == 'trips' %}selected{% endif %}>{{ _('Trips') }}</option>
                                     <option value="charging" {% if current_user.start_page == 'charging' %}selected{% endif %}>{{ _('EV Charging') }}</option>
+                                    <option value="allowance" {% if current_user.start_page == 'allowance' %}selected{% endif %}>{{ _('Mileage Allowance') }}</option>
+                                    <option value="notes" {% if current_user.start_page == 'notes' %}selected{% endif %}>{{ _('Notes') }}</option>
                                 </select>
                             </div>
 
@@ -495,6 +497,16 @@
                                         <input type="checkbox" name="show_menu_charging" {% if current_user.show_menu_charging is not defined or current_user.show_menu_charging %}checked{% endif %}
                                                class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500">
                                         <span class="ml-3 text-sm text-gray-700 dark:text-gray-300">{{ _('EV Charging') }}</span>
+                                    </label>
+                                    <label class="flex items-center">
+                                        <input type="checkbox" name="show_menu_allowance" {% if current_user.show_menu_allowance is not defined or current_user.show_menu_allowance %}checked{% endif %}
+                                               class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500">
+                                        <span class="ml-3 text-sm text-gray-700 dark:text-gray-300">{{ _('Mileage Allowance') }}</span>
+                                    </label>
+                                    <label class="flex items-center">
+                                        <input type="checkbox" name="show_menu_notes" {% if current_user.show_menu_notes is not defined or current_user.show_menu_notes %}checked{% endif %}
+                                               class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500">
+                                        <span class="ml-3 text-sm text-gray-700 dark:text-gray-300">{{ _('Notes') }}</span>
                                     </label>
                                 </div>
                             </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -288,7 +288,9 @@
                                                     (current_user.show_menu_recurring is not defined or current_user.show_menu_recurring) or
                                                     (current_user.show_menu_documents is not defined or current_user.show_menu_documents) or
                                                     (current_user.show_menu_stations is not defined or current_user.show_menu_stations) or
-                                                    (current_user.show_menu_charging is not defined or current_user.show_menu_charging) %}
+                                                    (current_user.show_menu_charging is not defined or current_user.show_menu_charging) or
+                                                    (current_user.show_menu_notes is not defined or current_user.show_menu_notes) or
+                                                    (current_user.show_menu_allowance is not defined or current_user.show_menu_allowance) %}
                             {% if show_more_menu %}
                             <div class="relative inline-flex items-center" id="more-menu-container">
                                 <button onclick="document.getElementById('more-dropdown').classList.toggle('hidden')" class="inline-flex items-center px-3 py-2 text-sm font-medium {% if 'maintenance' in request.endpoint or 'recurring' in request.endpoint or 'documents' in request.endpoint or 'stations' in request.endpoint %}text-primary-600 border-b-2 border-primary-600{% else %}text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white{% endif %}">
@@ -313,6 +315,12 @@
                                         {% endif %}
                                         {% if current_user.show_menu_charging is not defined or current_user.show_menu_charging %}
                                         <a href="{{ url_for('charging.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('EV Charging') }}</a>
+                                        {% endif %}
+                                        {% if current_user.show_menu_allowance is not defined or current_user.show_menu_allowance %}
+                                        <a href="{{ url_for('allowance.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Mileage Allowance') }}</a>
+                                        {% endif %}
+                                        {% if current_user.show_menu_notes is not defined or current_user.show_menu_notes %}
+                                        <a href="{{ url_for('notes.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Notes') }}</a>
                                         {% endif %}
                                         <a href="{{ url_for('fuel.quick') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Quick Fuel Entry') }}</a>
                                     </div>
@@ -385,6 +393,12 @@
                     {% endif %}
                     {% if current_user.show_menu_stations is not defined or current_user.show_menu_stations %}
                     <a href="{{ url_for('stations.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Fuel Stations') }}</a>
+                    {% endif %}
+                    {% if current_user.show_menu_allowance is not defined or current_user.show_menu_allowance %}
+                    <a href="{{ url_for('allowance.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Mileage Allowance') }}</a>
+                    {% endif %}
+                    {% if current_user.show_menu_notes is not defined or current_user.show_menu_notes %}
+                    <a href="{{ url_for('notes.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Notes') }}</a>
                     {% endif %}
                     <a href="{{ url_for('fuel.quick') }}" class="block px-4 py-2 text-base font-medium text-primary-600 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Quick Fuel Entry') }}</a>
                     <a href="{{ url_for('auth.settings') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Settings') }}</a>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -125,6 +125,44 @@
             </div>
         </div>
     </div>
+
+    {% if total_allowance and total_allowance > 0 %}
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+        <div class="p-5">
+            <div class="flex items-center">
+                <div class="flex-shrink-0">
+                    <svg class="h-6 w-6 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                </div>
+                <div class="ml-5 w-0 flex-1">
+                    <dl>
+                        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">{{ _('Mileage Allowance') }}</dt>
+                        <dd class="text-lg font-semibold text-emerald-600 dark:text-emerald-400">-{{ "%.2f"|format(total_allowance) }} {{ current_user.currency }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+        <div class="p-5">
+            <div class="flex items-center">
+                <div class="flex-shrink-0">
+                    <svg class="h-6 w-6 text-primary-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+                    </svg>
+                </div>
+                <div class="ml-5 w-0 flex-1">
+                    <dl>
+                        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">{{ _('Net Cost') }}</dt>
+                        <dd class="text-lg font-semibold text-gray-900 dark:text-white">{{ "%.2f"|format(net_cost) }} {{ current_user.currency }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 </div>
 
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/app/templates/fuel/form.html
+++ b/app/templates/fuel/form.html
@@ -75,6 +75,16 @@
                 </div>
 
                 <div>
+                    <label for="discount_per_unit" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Discount per') }} {{ current_user.volume_unit }} ({{ current_user.currency }})</label>
+                    <input type="number" name="discount_per_unit" id="discount_per_unit" step="0.001" min="0"
+                           value="{{ log.discount_per_unit if log and log.discount_per_unit is not none else '' }}"
+                           onchange="calculateTotal()"
+                           placeholder="0.000"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ _('Optional loyalty discount, subtracted from the price per unit.') }}</p>
+                </div>
+
+                <div>
                     <label for="total_cost" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Total Cost ({{ current_user.currency }})</label>
                     <input type="number" name="total_cost" id="total_cost" step="0.01"
                            value="{{ log.total_cost if log else '' }}"
@@ -236,8 +246,10 @@ function updateFuelTypeSelector(selectedOption) {
 function calculateTotal() {
     const volume = parseFloat(document.getElementById('volume').value) || 0;
     const pricePerUnit = parseFloat(document.getElementById('price_per_unit').value) || 0;
+    const discountPerUnit = parseFloat(document.getElementById('discount_per_unit').value) || 0;
     if (volume && pricePerUnit) {
-        document.getElementById('total_cost').value = (volume * pricePerUnit).toFixed(2);
+        const effectivePrice = Math.max(pricePerUnit - discountPerUnit, 0);
+        document.getElementById('total_cost').value = (volume * effectivePrice).toFixed(2);
     }
 }
 

--- a/app/templates/notes/form.html
+++ b/app/templates/notes/form.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+{% block title %}{% if note %}{{ _('Edit Note') }}{% else %}{{ _('Add Note') }}{% endif %}{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+    <div class="mb-6">
+        <a href="{{ url_for('notes.index') }}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300">&larr; {{ _('Back to notes') }}</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">{% if note %}{{ _('Edit Note') }}{% else %}{{ _('Add Note') }}{% endif %}</h1>
+    </div>
+
+    <form method="POST" class="space-y-6">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+                <div class="sm:col-span-2">
+                    <label for="vehicle_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Vehicle') }} *</label>
+                    <select name="vehicle_id" id="vehicle_id" required
+                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                        {% for vehicle in vehicles %}
+                        <option value="{{ vehicle.id }}"
+                                data-odometer-unit="{{ vehicle.get_effective_odometer_unit() }}"
+                                {% if (note and note.vehicle_id == vehicle.id) or (selected_vehicle_id == vehicle.id) %}selected{% endif %}>
+                            {{ vehicle.name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <div>
+                    <label for="date" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Date') }} *</label>
+                    <input type="text" name="date" id="date" required data-datepicker data-default-today
+                           value="{{ note.date.strftime('%Y-%m-%d') if note else '' }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div>
+                    <label for="odometer" id="odometer-label" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Odometer') }} ({{ current_user.distance_unit }})</label>
+                    <input type="number" name="odometer" id="odometer" step="0.1"
+                           value="{{ note.odometer if note and note.odometer is not none else '' }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div class="sm:col-span-2">
+                    <label for="title" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Title') }}</label>
+                    <input type="text" name="title" id="title" maxlength="200"
+                           value="{{ note.title if note and note.title else '' }}"
+                           placeholder="{{ _('e.g., DPF regeneration') }}"
+                           class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                </div>
+
+                <div class="sm:col-span-2">
+                    <label for="content" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Note') }} *</label>
+                    <textarea name="content" id="content" rows="5" required
+                              placeholder="{{ _('What happened?') }}"
+                              class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">{{ note.content if note else '' }}</textarea>
+                </div>
+            </div>
+        </div>
+
+        <div class="flex justify-end space-x-3">
+            <a href="{{ url_for('notes.index') }}"
+               class="px-4 py-2 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+                {{ _('Cancel') }}
+            </a>
+            <button type="submit"
+                    class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+                {% if note %}{{ _('Save Changes') }}{% else %}{{ _('Add Note') }}{% endif %}
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+    (function() {
+        const vehicleSelect = document.getElementById('vehicle_id');
+        const odometerLabel = document.getElementById('odometer-label');
+
+        function updateOdometerUnit() {
+            const selected = vehicleSelect.options[vehicleSelect.selectedIndex];
+            const unit = selected ? selected.dataset.odometerUnit : '{{ current_user.distance_unit }}';
+            if (unit) {
+                odometerLabel.textContent = odometerLabel.textContent.replace(/\([^)]*\)/, '(' + unit + ')');
+            }
+        }
+
+        vehicleSelect.addEventListener('change', updateOdometerUnit);
+        updateOdometerUnit();
+    })();
+</script>
+{% endblock %}

--- a/app/templates/notes/index.html
+++ b/app/templates/notes/index.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Notes') }}{% endblock %}
+
+{% block content %}
+<div class="sm:flex sm:items-center sm:justify-between mb-6">
+    <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ _('Notes') }}</h1>
+        <p class="text-gray-500 dark:text-gray-400">{{ _('Record events and observations that don\'t fit fuel, expenses or maintenance') }}</p>
+    </div>
+    <a href="{{ url_for('notes.new') }}"
+       class="mt-4 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
+        <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        {{ _('Add Note') }}
+    </a>
+</div>
+
+{% if notes %}
+<div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="w-8 px-3 py-3"></th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Date') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Vehicle') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Note') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Odometer') }}</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Actions') }}</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                {% for note in notes %}
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer" onclick="toggleNoteDetail({{ note.id }})">
+                    <td class="px-3 py-4 text-center">
+                        <svg id="chevron-{{ note.id }}" class="h-4 w-4 text-gray-400 transition-transform duration-150 inline-block" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                        </svg>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ note.date|format_date }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        <a href="{{ url_for('vehicles.view', vehicle_id=note.vehicle_id) }}" class="text-primary-600 hover:text-primary-500" onclick="event.stopPropagation()">
+                            {{ note.vehicle.name }}
+                        </a>
+                    </td>
+                    <td class="px-6 py-4 text-sm text-gray-900 dark:text-white">{{ note.title or (note.content[:60] ~ ('…' if note.content|length > 60 else '')) }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        {% if note.odometer %}{{ note.odometer|int }} {{ note.vehicle.get_effective_odometer_unit() }}{% else %}-{% endif %}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium" onclick="event.stopPropagation()">
+                        <a href="{{ url_for('notes.edit', note_id=note.id) }}" class="text-primary-600 hover:text-primary-900 mr-3">{{ _('Edit') }}</a>
+                        <form method="POST" action="{{ url_for('notes.delete', note_id=note.id) }}" class="inline"
+                              onsubmit="return confirm('{{ _('Delete this note?') }}');">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="text-red-600 hover:text-red-900">{{ _('Delete') }}</button>
+                        </form>
+                    </td>
+                </tr>
+                <tr id="detail-{{ note.id }}" class="hidden bg-gray-50 dark:bg-gray-700/50">
+                    <td></td>
+                    <td colspan="5" class="px-6 py-3">
+                        {% if note.title %}<p class="text-sm font-medium text-gray-900 dark:text-white mb-1">{{ note.title }}</p>{% endif %}
+                        <p class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-line">{{ note.content }}</p>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% else %}
+<div class="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow">
+    <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">{{ _('No notes') }}</h3>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Jot down anything worth remembering about your vehicles.') }}</p>
+    <div class="mt-6">
+        <a href="{{ url_for('notes.new') }}"
+           class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
+            <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+            {{ _('Add Note') }}
+        </a>
+    </div>
+</div>
+{% endif %}
+
+<script>
+function toggleNoteDetail(id) {
+    const row = document.getElementById('detail-' + id);
+    const chevron = document.getElementById('chevron-' + id);
+    if (row.classList.contains('hidden')) {
+        row.classList.remove('hidden');
+        chevron.style.transform = 'rotate(90deg)';
+    } else {
+        row.classList.add('hidden');
+        chevron.style.transform = '';
+    }
+}
+</script>
+{% endblock %}

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -89,6 +89,18 @@
         <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ "%.2f"|format(stats.total_expense_cost) }}</dd>
         <dd class="text-sm text-gray-500 dark:text-gray-400">{{ current_user.currency }}</dd>
     </div>
+    {% if stats.total_allowance and stats.total_allowance > 0 %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Mileage Allowance') }}</dt>
+        <dd class="mt-1 text-xl font-semibold text-emerald-600 dark:text-emerald-400">-{{ "%.2f"|format(stats.total_allowance) }}</dd>
+        <dd class="text-sm text-gray-500 dark:text-gray-400">{{ current_user.currency }}</dd>
+    </div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+        <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Net Cost') }}</dt>
+        <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ "%.2f"|format(stats.net_cost) }}</dd>
+        <dd class="text-sm text-gray-500 dark:text-gray-400">{{ current_user.currency }}</dd>
+    </div>
+    {% endif %}
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
         <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ _('Total Distance') }}</dt>
         <dd class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ "%.0f"|format(stats.total_distance) }}</dd>

--- a/migrations/versions/c1d2e3f4a5b6_add_discount_per_unit_to_fuel_logs.py
+++ b/migrations/versions/c1d2e3f4a5b6_add_discount_per_unit_to_fuel_logs.py
@@ -1,0 +1,33 @@
+"""add discount_per_unit to fuel_logs
+
+Revision ID: c1d2e3f4a5b6
+Revises: 42b26bf6d488
+Create Date: 2026-06-04 19:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = 'c1d2e3f4a5b6'
+down_revision = '42b26bf6d488'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if 'fuel_logs' not in inspector.get_table_names():
+        return
+    existing_cols = [col['name'] for col in inspector.get_columns('fuel_logs')]
+    if 'discount_per_unit' in existing_cols:
+        return
+
+    with op.batch_alter_table('fuel_logs', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('discount_per_unit', sa.Float(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('fuel_logs', schema=None) as batch_op:
+        batch_op.drop_column('discount_per_unit')

--- a/migrations/versions/c2d3e4f5a6b7_add_notes_table.py
+++ b/migrations/versions/c2d3e4f5a6b7_add_notes_table.py
@@ -1,0 +1,48 @@
+"""add notes table and show_menu_notes preference
+
+Revision ID: c2d3e4f5a6b7
+Revises: c1d2e3f4a5b6
+Create Date: 2026-06-04 19:01:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = 'c2d3e4f5a6b7'
+down_revision = 'c1d2e3f4a5b6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if 'notes' not in inspector.get_table_names():
+        op.create_table(
+            'notes',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('vehicle_id', sa.Integer(), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=False),
+            sa.Column('date', sa.Date(), nullable=False),
+            sa.Column('title', sa.String(length=200), nullable=True),
+            sa.Column('content', sa.Text(), nullable=False),
+            sa.Column('odometer', sa.Float(), nullable=True),
+            sa.Column('created_at', sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(['vehicle_id'], ['vehicles.id']),
+            sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+            sa.PrimaryKeyConstraint('id'),
+        )
+
+    if 'users' in inspector.get_table_names():
+        user_cols = [col['name'] for col in inspector.get_columns('users')]
+        if 'show_menu_notes' not in user_cols:
+            with op.batch_alter_table('users', schema=None) as batch_op:
+                batch_op.add_column(sa.Column('show_menu_notes', sa.Boolean(), nullable=True, server_default=sa.true()))
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('show_menu_notes')
+    op.drop_table('notes')

--- a/migrations/versions/c3d4e5f6a7b8_add_mileage_allowances_table.py
+++ b/migrations/versions/c3d4e5f6a7b8_add_mileage_allowances_table.py
@@ -1,0 +1,49 @@
+"""add mileage_allowances table and show_menu_allowance preference
+
+Revision ID: c3d4e5f6a7b8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-06-04 19:02:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = 'c3d4e5f6a7b8'
+down_revision = 'c2d3e4f5a6b7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if 'mileage_allowances' not in inspector.get_table_names():
+        op.create_table(
+            'mileage_allowances',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('vehicle_id', sa.Integer(), nullable=False),
+            sa.Column('user_id', sa.Integer(), nullable=False),
+            sa.Column('date', sa.Date(), nullable=False),
+            sa.Column('description', sa.String(length=200), nullable=True),
+            sa.Column('distance', sa.Float(), nullable=True),
+            sa.Column('rate_per_unit', sa.Float(), nullable=True),
+            sa.Column('amount', sa.Float(), nullable=False),
+            sa.Column('created_at', sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(['vehicle_id'], ['vehicles.id']),
+            sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+            sa.PrimaryKeyConstraint('id'),
+        )
+
+    if 'users' in inspector.get_table_names():
+        user_cols = [col['name'] for col in inspector.get_columns('users')]
+        if 'show_menu_allowance' not in user_cols:
+            with op.batch_alter_table('users', schema=None) as batch_op:
+                batch_op.add_column(sa.Column('show_menu_allowance', sa.Boolean(), nullable=True, server_default=sa.true()))
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('show_menu_allowance')
+    op.drop_table('mileage_allowances')

--- a/tests/test_allowance.py
+++ b/tests/test_allowance.py
@@ -1,0 +1,105 @@
+import pytest
+from datetime import date
+from app import db
+from app.models import MileageAllowance
+
+
+@pytest.fixture(scope='function')
+def sample_allowance(app, test_user, sample_vehicle):
+    allowance = MileageAllowance(
+        vehicle_id=sample_vehicle.id,
+        user_id=test_user.id,
+        date=date(2024, 1, 25),
+        description='January business miles',
+        distance=200.0,
+        rate_per_unit=0.45,
+        amount=90.0,
+    )
+    db.session.add(allowance)
+    db.session.commit()
+    return allowance
+
+
+class TestAllowanceIndex:
+    def test_index_requires_auth(self, client):
+        resp = client.get('/allowance/', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_index_returns_200(self, auth_client):
+        resp = auth_client.get('/allowance/')
+        assert resp.status_code == 200
+
+    def test_index_shows_allowances(self, auth_client, sample_allowance):
+        resp = auth_client.get('/allowance/')
+        assert resp.status_code == 200
+        assert b'January business miles' in resp.data
+
+
+class TestAllowanceNew:
+    def test_new_requires_auth(self, client):
+        resp = client.get('/allowance/new', follow_redirects=False)
+        assert resp.status_code == 302
+
+    def test_get_new_form_returns_200(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/allowance/new')
+        assert resp.status_code == 200
+
+    def test_create_allowance(self, auth_client, sample_vehicle, test_user):
+        resp = auth_client.post('/allowance/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-02-10',
+            'description': 'February miles',
+            'distance': '100',
+            'rate_per_unit': '0.45',
+            'amount': '45.00',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        allowance = MileageAllowance.query.filter_by(description='February miles').first()
+        assert allowance is not None
+        assert allowance.amount == 45.0
+        assert allowance.user_id == test_user.id
+
+    def test_create_allowance_amount_only(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/allowance/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-02-12',
+            'amount': '120.50',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        allowance = MileageAllowance.query.filter_by(amount=120.5).first()
+        assert allowance is not None
+        assert allowance.distance is None
+        assert allowance.rate_per_unit is None
+
+
+class TestAllowanceEdit:
+    def test_edit_requires_auth(self, client, sample_allowance):
+        resp = client.get(f'/allowance/{sample_allowance.id}/edit', follow_redirects=False)
+        assert resp.status_code == 302
+
+    def test_edit_allowance(self, auth_client, sample_allowance):
+        resp = auth_client.post(f'/allowance/{sample_allowance.id}/edit', data={
+            'date': '2024-01-25',
+            'description': 'January business miles',
+            'amount': '100.00',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        db.session.refresh(sample_allowance)
+        assert sample_allowance.amount == 100.0
+
+
+class TestAllowanceDelete:
+    def test_delete_allowance(self, auth_client, sample_allowance):
+        allowance_id = sample_allowance.id
+        resp = auth_client.post(f'/allowance/{allowance_id}/delete', follow_redirects=True)
+        assert resp.status_code == 200
+        assert MileageAllowance.query.get(allowance_id) is None
+
+
+class TestAllowanceOffsetsCost:
+    def test_total_allowance_and_net_cost(self, app, sample_vehicle, sample_fuel_log, sample_allowance):
+        # sample_fuel_log total_cost = 60.0; sample_allowance amount = 90.0
+        assert sample_vehicle.get_total_allowance() == 90.0
+        gross = sample_vehicle.get_total_cost()
+        assert sample_vehicle.get_net_cost() == gross - 90.0

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -48,6 +48,55 @@ class TestFuelNew:
         assert log.volume == 45.0
         assert log.user_id == test_user.id
 
+    def test_discount_applied_to_calculated_total(self, auth_client, sample_vehicle):
+        # No total_cost given: server computes volume * (price - discount) (#209)
+        resp = auth_client.post('/fuel/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-03-02',
+            'odometer': '15100',
+            'volume': '50.0',
+            'price_per_unit': '1.50',
+            'discount_per_unit': '0.10',
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id, odometer=15100.0).first()
+        assert log is not None
+        assert log.discount_per_unit == 0.10
+        # 50 * (1.50 - 0.10) = 70.00
+        assert log.total_cost == 70.0
+
+    def test_explicit_total_overrides_discount_calc(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/fuel/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-03-03',
+            'odometer': '15200',
+            'volume': '50.0',
+            'price_per_unit': '1.50',
+            'discount_per_unit': '0.10',
+            'total_cost': '68.0',
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id, odometer=15200.0).first()
+        assert log is not None
+        assert log.total_cost == 68.0
+
+    def test_no_discount_is_none(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/fuel/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-03-04',
+            'odometer': '15300',
+            'volume': '40.0',
+            'price_per_unit': '1.50',
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id, odometer=15300.0).first()
+        assert log is not None
+        assert log.discount_per_unit is None
+        assert log.total_cost == 60.0
+
     def test_new_redirects_to_vehicles_if_none(self, auth_client):
         # No vehicles exist for this user
         resp = auth_client.get('/fuel/new', follow_redirects=False)

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,114 @@
+import pytest
+from datetime import date
+from app import db
+from app.models import Note
+
+
+@pytest.fixture(scope='function')
+def sample_note(app, test_user, sample_vehicle):
+    note = Note(
+        vehicle_id=sample_vehicle.id,
+        user_id=test_user.id,
+        date=date(2024, 1, 18),
+        title='DPF regeneration',
+        content='Active regen completed on the motorway.',
+        odometer=12345.0,
+    )
+    db.session.add(note)
+    db.session.commit()
+    return note
+
+
+class TestNotesIndex:
+    def test_index_requires_auth(self, client):
+        resp = client.get('/notes/', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_index_returns_200(self, auth_client):
+        resp = auth_client.get('/notes/')
+        assert resp.status_code == 200
+
+    def test_index_shows_notes(self, auth_client, sample_note):
+        resp = auth_client.get('/notes/')
+        assert resp.status_code == 200
+        assert b'DPF regeneration' in resp.data
+
+
+class TestNotesNew:
+    def test_new_requires_auth(self, client):
+        resp = client.get('/notes/new', follow_redirects=False)
+        assert resp.status_code == 302
+
+    def test_get_new_form_returns_200(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/notes/new')
+        assert resp.status_code == 200
+
+    def test_create_note(self, auth_client, sample_vehicle, test_user):
+        resp = auth_client.post('/notes/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-02-10',
+            'title': 'Tyre pressure check',
+            'content': 'All four at 32 psi.',
+            'odometer': '13000',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        note = Note.query.filter_by(vehicle_id=sample_vehicle.id, title='Tyre pressure check').first()
+        assert note is not None
+        assert note.content == 'All four at 32 psi.'
+        assert note.odometer == 13000.0
+        assert note.user_id == test_user.id
+
+    def test_create_note_without_content_rejected(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/notes/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-02-10',
+            'content': '',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        assert Note.query.filter_by(vehicle_id=sample_vehicle.id).count() == 0
+
+    def test_create_note_optional_odometer(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/notes/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'date': '2024-02-11',
+            'content': 'No odometer recorded.',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        note = Note.query.filter_by(content='No odometer recorded.').first()
+        assert note is not None
+        assert note.odometer is None
+
+
+class TestNotesEdit:
+    def test_edit_requires_auth(self, client, sample_note):
+        resp = client.get(f'/notes/{sample_note.id}/edit', follow_redirects=False)
+        assert resp.status_code == 302
+
+    def test_get_edit_form_returns_200(self, auth_client, sample_note):
+        resp = auth_client.get(f'/notes/{sample_note.id}/edit')
+        assert resp.status_code == 200
+
+    def test_edit_note(self, auth_client, sample_note):
+        resp = auth_client.post(f'/notes/{sample_note.id}/edit', data={
+            'date': '2024-01-18',
+            'title': 'DPF regeneration',
+            'content': 'Updated: regen completed twice.',
+            'odometer': '12400',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        db.session.refresh(sample_note)
+        assert sample_note.content == 'Updated: regen completed twice.'
+        assert sample_note.odometer == 12400.0
+
+
+class TestNotesDelete:
+    def test_delete_requires_auth(self, client, sample_note):
+        resp = client.post(f'/notes/{sample_note.id}/delete', follow_redirects=False)
+        assert resp.status_code == 302
+
+    def test_delete_note(self, auth_client, sample_note):
+        note_id = sample_note.id
+        resp = auth_client.post(f'/notes/{note_id}/delete', follow_redirects=True)
+        assert resp.status_code == 200
+        assert Note.query.get(note_id) is None


### PR DESCRIPTION
Implements three feature requests from the issue tracker.

## #209 — Fuel discount field
Adds an optional **discount per unit** to fuel logs. When the total cost isn't entered, it's now calculated as `volume * (price_per_unit - discount_per_unit)`, so the recorded total matches the amount actually paid when a loyalty discount applies. The form's live total calculator accounts for it too. No discount → behaviour unchanged.

## #204 — Notes
A new **Notes** section: freeform per-vehicle notes with a date and optional odometer reading, for things that don't fit fuel/expenses/maintenance (the requester's example was logging DPF regenerations). Full CRUD, list with expandable detail, and a menu-visibility toggle in settings.

## #208 — Mileage allowance
A new **Mileage Allowance** section to record allowance income for business use. You can enter an amount directly, or a distance + rate to have the amount calculated. The totals **offset running costs**: the dashboard and the vehicle detail page now show the total allowance and the resulting **net cost** (only when allowance has been recorded, so it stays out of the way for everyone else). Gross `get_total_cost()` / cost-per-distance semantics are unchanged. Full CRUD with a menu-visibility toggle.

## Implementation notes
- New models `Note` and `MileageAllowance`; `FuelLog.discount_per_unit`; `Vehicle.get_total_allowance()` / `get_net_cost()`; two new `User.show_menu_*` flags.
- Three idempotent Flask-Migrate migrations (one column add, two table adds) chained from the current head, following the existing defensive `inspect()` pattern. Verified `flask db upgrade` applies cleanly to a fresh DB.
- Nav (desktop "More" dropdown + mobile), settings toggles, and start-page options wired up for both new sections.
- Tests: `tests/test_notes.py`, `tests/test_allowance.py`, plus discount cases in `tests/test_fuel.py`. Full suite green (621 passed).