### PR TITLE
fix: convert last_performed_odometer to km before storing on maintenance schedules

### DIFF
--- a/app/routes/maintenance.py
+++ b/app/routes/maintenance.py
@@ -68,7 +68,11 @@ def new():
                 request.form.get('last_performed_date'), '%Y-%m-%d'
             ).date()
         if request.form.get('last_performed_odometer'):
-            schedule.last_performed_odometer = float(request.form.get('last_performed_odometer'))
+            raw_odo = float(request.form.get('last_performed_odometer'))
+            if vehicle.get_effective_odometer_unit() == 'mi':
+                schedule.last_performed_odometer = raw_odo * 1.60934
+            else:
+                schedule.last_performed_odometer = raw_odo
 
         # Calculate next due
         schedule.calculate_next_due()
@@ -121,7 +125,11 @@ def edit(schedule_id):
                 request.form.get('last_performed_date'), '%Y-%m-%d'
             ).date()
         if request.form.get('last_performed_odometer'):
-            schedule.last_performed_odometer = float(request.form.get('last_performed_odometer'))
+            raw_odo = float(request.form.get('last_performed_odometer'))
+            if schedule.vehicle.get_effective_odometer_unit() == 'mi':
+                schedule.last_performed_odometer = raw_odo * 1.60934
+            else:
+                schedule.last_performed_odometer = raw_odo
 
         schedule.calculate_next_due()
         db.session.commit()
@@ -150,7 +158,11 @@ def complete(schedule_id):
     # Update last performed
     schedule.last_performed_date = date.today()
     if request.form.get('odometer'):
-        schedule.last_performed_odometer = float(request.form.get('odometer'))
+        raw_odo = float(request.form.get('odometer'))
+        if schedule.vehicle.get_effective_odometer_unit() == 'mi':
+            schedule.last_performed_odometer = raw_odo * 1.60934
+        else:
+            schedule.last_performed_odometer = raw_odo
     else:
         schedule.last_performed_odometer = schedule.vehicle.get_last_odometer()
 

--- a/app/templates/maintenance/form.html
+++ b/app/templates/maintenance/form.html
@@ -103,9 +103,11 @@
                            class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
                 </div>
                 <div>
-                    <label for="last_performed_odometer" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Odometer') }}</label>
+                    {% set odometer_unit = schedule.vehicle.get_effective_odometer_unit() if schedule else None %}
+                    <label for="last_performed_odometer" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Odometer') }}{% if odometer_unit %} ({{ odometer_unit }}){% endif %}</label>
+                    {% set odometer_display = ((schedule.last_performed_odometer * 0.621371 if odometer_unit == 'mi' else schedule.last_performed_odometer) | round(1)) if schedule and schedule.last_performed_odometer else '' %}
                     <input type="number" name="last_performed_odometer" id="last_performed_odometer" step="0.1"
-                           value="{{ schedule.last_performed_odometer if schedule and schedule.last_performed_odometer else '' }}"
+                           value="{{ odometer_display }}"
                            placeholder="{{ _('e.g., 50000') }}"
                            class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
                 </div>

--- a/app/templates/maintenance/index.html
+++ b/app/templates/maintenance/index.html
@@ -60,8 +60,10 @@
                     </p>
                     {% endif %}
                     {% if schedule.next_due_odometer %}
+                    {% set next_due_unit = schedule.vehicle.get_effective_odometer_unit() %}
+                    {% set next_due_display = schedule.next_due_odometer * 0.621371 if next_due_unit == 'mi' else schedule.next_due_odometer %}
                     <p class="text-xs text-gray-500 dark:text-gray-400">
-                        @ {{ "{:,.0f}".format(schedule.next_due_odometer) }} {{ current_user.distance_unit }}
+                        @ {{ "{:,.0f}".format(next_due_display) }} {{ next_due_unit }}
                     </p>
                     {% endif %}
                     {% if schedule.estimated_cost %}

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -614,7 +614,8 @@
                         <span>{{ schedule.next_due_date|format_date }}</span>
                         {% endif %}
                         {% if schedule.next_due_odometer %}
-                        <span>{{ schedule.next_due_odometer|int }} {{ vehicle.get_effective_odometer_unit() }}</span>
+                        {% set next_due_display = schedule.next_due_odometer * 0.621371 if vehicle.get_effective_odometer_unit() == 'mi' else schedule.next_due_odometer %}
+                        <span>{{ next_due_display|int }} {{ vehicle.get_effective_odometer_unit() }}</span>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Maintenance schedules stored `last_performed_odometer` as a raw form value without unit conversion, while `MaintenanceSchedule.calculate_next_due()` assumes km-based storage (it adds `interval_miles * 1.60934` directly to `last_performed_odometer`). For vehicles set to miles, this meant the interval was converted to km and added to a value that was still in miles, producing a wildly incorrect `next_due_odometer`.

Example: a vehicle at 29,711 mi with a 5,000 mi service interval should show the next service due at 34,711 mi. It previously showed ~37,758 mi.

## Changelog

- Fixed: `last_performed_odometer` is now converted to km (the app's internal odometer convention) before being stored, based on the vehicle's effective odometer unit — in `new()`, `edit()`, and `complete()` in `app/routes/maintenance.py`.
- Fixed: `next_due_odometer` is now converted back to the vehicle's display unit wherever it's rendered (`maintenance/index.html`, `vehicles/view.html`), instead of showing the raw km value labeled with the wrong unit.
- Fixed: the maintenance edit form now converts the stored km value back to the vehicle's display unit when pre-filling the odometer field, and shows the unit in the field label.

## Testing

- [x] Tested locally
- [x] Tested with Docker image

Verified with the reported repro case: a mi-unit vehicle with `last_performed_odometer` = 29,711 mi and a 5,000 mi interval now correctly shows the next service due at 34,711 mi.