### PR TITLE
v0.24.1 — fix "None" appearing in blank form fields

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -270,6 +270,12 @@ def create_app(config_class=Config):
     app = Flask(__name__)
     app.config.from_object(config_class)
 
+    # Render None as an empty string in all templates. Nullable model fields
+    # (tank capacity, odometer, notes, ...) otherwise stringify to the literal
+    # text "None" in value="" attributes, which then blocks form validation on
+    # save (issues #217, #241).
+    app.jinja_env.finalize = lambda value: '' if value is None else value
+
     # Babel configuration
     app.config['BABEL_DEFAULT_LOCALE'] = 'en'
     app.config['BABEL_SUPPORTED_LOCALES'] = list(LANGUAGES.keys())

--- a/app/utils.py
+++ b/app/utils.py
@@ -31,7 +31,10 @@ def parse_decimal(value, default=None):
         return float(value)
 
     s = str(value).strip()
-    if s == '':
+    if s == '' or s == 'None':
+        # A literal "None" is a server-rendered artefact of a NULL field (a
+        # user wouldn't type it), so treat it as absent rather than invalid
+        # (issues #217, #241).
         return default
 
     # Preserve a leading sign, strip spaces used as grouping separators.

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.24.0'
+APP_VERSION = '0.24.1'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,12 @@ class TestParseDecimal:
     def test_period_decimal_unchanged(self):
         assert parse_decimal('9.99') == 9.99
 
+    def test_literal_none_string_treated_as_absent(self):
+        # A NULL field rendered into a form comes back as the text "None";
+        # treat it like an empty submission rather than a parse error (#241).
+        assert parse_decimal('None') is None
+        assert parse_decimal('None', default=0) == 0
+
     def test_comma_decimal(self):
         assert parse_decimal('9,99') == 9.99
 

--- a/tests/test_vehicles.py
+++ b/tests/test_vehicles.py
@@ -71,6 +71,16 @@ class TestVehicleEdit:
         resp = auth_client.get(f'/vehicles/{sample_vehicle.id}/edit')
         assert resp.status_code == 200
 
+    def test_edit_form_renders_null_fields_blank(self, auth_client, sample_vehicle):
+        # Nullable numeric fields (tank capacity etc.) must render as empty
+        # strings, not the literal text "None", which blocks validation on
+        # save (#241).
+        sample_vehicle.tank_capacity = None
+        db.session.commit()
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}/edit')
+        assert resp.status_code == 200
+        assert b'value="None"' not in resp.data
+
     def test_edit_vehicle(self, auth_client, sample_vehicle):
         resp = auth_client.post(f'/vehicles/{sample_vehicle.id}/edit', data={
             'name': 'Updated Car',


### PR DESCRIPTION
## What's Changed

### Bug Fixes
- Blank optional fields (tank capacity, odometer, etc.) no longer render as the literal text "None" when editing, which blocked saving with a validation error (#241). Fixed centrally with a Jinja finalize hook so every nullable field across all forms renders blank, plus server-side tolerance in `parse_decimal` as defence in depth.

This was a latent template bug exposed by v0.24.0's locale-aware decimal inputs (as `type="number"`, browsers silently discarded the bad value; as text inputs, it became visible and blocked validation).

Full test suite: 662 passed.