### PR TITLE
v0.24.3 — average consumption survives missed fill-ups

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -299,30 +299,54 @@ class Vehicle(db.Model):
             return _distance_in(raw_distance, self.get_effective_odometer_unit(), distance_unit)
         return raw_distance
 
-    def get_average_consumption(self, consumption_unit=None, volume_unit='L'):
-        """Calculate average fuel consumption between the first and last
-        full-tank fill-ups.
+    def _valid_consumption_segments(self):
+        """Collect (distance, fuel) spans usable for the consumption average.
 
-        Sums every litre poured between those two anchors so partial fills
-        in the middle are counted (issue #169). Returns None when any log
-        in the range is flagged ``is_missed`` — we have no way to make the
-        figure honest in that case.
+        Each span runs between consecutive full-tank fill-ups, counting every
+        litre poured within it so partial fills are included (issue #169).
+        A span containing a log flagged ``is_missed`` is discarded — there is
+        no way to make that span honest — but spans either side of it remain
+        usable, so one missed fill-up doesn't invalidate the whole history
+        (issue #251).
+
+        Returns ``None`` when there are fewer than two full-tank anchors,
+        otherwise a (possibly empty) list of ``(distance, fuel)`` tuples.
         """
         full_logs = self.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.odometer).all()
         if len(full_logs) < 2:
             return None
 
-        first_odo = full_logs[0].odometer
-        last_odo = full_logs[-1].odometer
         range_logs = self.fuel_logs.filter(
-            FuelLog.odometer > first_odo,
-            FuelLog.odometer <= last_odo,
-        ).all()
-        if any(log.is_missed for log in range_logs):
+            FuelLog.odometer > full_logs[0].odometer,
+            FuelLog.odometer <= full_logs[-1].odometer,
+        ).order_by(FuelLog.odometer).all()
+
+        segments = []
+        for start, end in zip(full_logs, full_logs[1:]):
+            span_logs = [log for log in range_logs
+                         if start.odometer < log.odometer <= end.odometer]
+            if any(log.is_missed for log in span_logs):
+                continue
+            fuel = sum(log.volume for log in span_logs if log.volume)
+            distance = end.odometer - start.odometer
+            if distance > 0 and fuel > 0:
+                segments.append((distance, fuel))
+        return segments
+
+    def get_average_consumption(self, consumption_unit=None, volume_unit='L'):
+        """Calculate average fuel consumption across full-tank fill-up spans.
+
+        Spans contaminated by a missed fill-up are excluded rather than
+        poisoning the whole figure (issue #251); the average covers every
+        remaining span, partial fills included (issue #169). Returns None
+        when no honest span exists.
+        """
+        segments = self._valid_consumption_segments()
+        if not segments:
             return None
 
-        total_fuel = sum(log.volume for log in range_logs if log.volume)
-        total_distance = last_odo - first_odo
+        total_distance = sum(distance for distance, _ in segments)
+        total_fuel = sum(fuel for _, fuel in segments)
 
         if total_distance > 0 and total_fuel > 0:
             odometer_unit = self.get_effective_odometer_unit()
@@ -348,28 +372,23 @@ class Vehicle(db.Model):
         helpful empty state instead of a bare dash (issue #214):
 
         - ``'insufficient_full_tanks'`` — fewer than two full-tank fill-ups
-        - ``'missed_fill_up'`` — a fill-up in the range is flagged missed
+        - ``'missed_fill_up'`` — every span is invalidated by a missed fill-up
         - ``'insufficient_data'`` — not enough distance/volume to calculate
         """
-        full_logs = self.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.odometer).all()
-        if len(full_logs) < 2:
+        segments = self._valid_consumption_segments()
+        if segments is None:
             return 'insufficient_full_tanks'
+        if segments:
+            return None
 
-        first_odo = full_logs[0].odometer
-        last_odo = full_logs[-1].odometer
+        full_logs = self.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.odometer).all()
         range_logs = self.fuel_logs.filter(
-            FuelLog.odometer > first_odo,
-            FuelLog.odometer <= last_odo,
+            FuelLog.odometer > full_logs[0].odometer,
+            FuelLog.odometer <= full_logs[-1].odometer,
         ).all()
         if any(log.is_missed for log in range_logs):
             return 'missed_fill_up'
-
-        total_fuel = sum(log.volume for log in range_logs if log.volume)
-        total_distance = last_odo - first_odo
-        if total_distance <= 0 or total_fuel <= 0:
-            return 'insufficient_data'
-
-        return None
+        return 'insufficient_data'
 
     def uses_tessie_odometer(self):
         """Check if this vehicle uses Tessie for odometer tracking"""

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.24.2'
+APP_VERSION = '0.24.3'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -584,6 +584,36 @@ class TestConsumptionUnavailableReason:
         assert sample_vehicle.get_average_consumption() is None
         assert sample_vehicle.get_consumption_unavailable_reason() == 'missed_fill_up'
 
+    def test_missed_fill_up_only_invalidates_its_own_span(
+            self, app, test_user, sample_vehicle):
+        """#251 — one missed fill-up must not kill the whole average.
+
+        Spans between full tanks that don't contain the missed log stay
+        usable; only the contaminated span is excluded.
+        """
+        logs = [
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2024, 1, 1), odometer=10000, volume=40, is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2024, 1, 10), odometer=10500, volume=40, is_full_tank=True),
+            # Contaminated span: missed fill-up between the next two anchors.
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2024, 1, 15), odometer=10700, volume=20,
+                    is_full_tank=False, is_missed=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2024, 1, 20), odometer=11000, volume=45, is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2024, 1, 30), odometer=11500, volume=40, is_full_tank=True),
+        ]
+        db.session.add_all(logs)
+        db.session.commit()
+        # Valid spans: 10000->10500 (40 L / 500) and 11000->11500 (40 L / 500).
+        # The 10500->11000 span is excluded, so: 80 L / 1000 km = 8.0 L/100km.
+        avg = sample_vehicle.get_average_consumption()
+        assert avg is not None
+        assert abs(avg - 8.0) < 0.01
+        assert sample_vehicle.get_consumption_unavailable_reason() is None
+
     def test_reason_none_when_available(self, app, test_user, sample_vehicle):
         log1 = FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
                        date=date(2024, 1, 1), odometer=10000, volume=40, is_full_tank=True)


### PR DESCRIPTION
## What's Changed

### Bug Fixes
- Average consumption is now calculated across full-tank-to-full-tank spans, excluding only spans that contain a missed fill-up instead of abandoning the whole figure (#251). Previously a single missed fill-up anywhere in a vehicle's history disabled the average permanently, even with plenty of clean data either side. The "can't calculate honestly" empty state now only appears when every span is affected.

Full test suite: 663 passed.