### PR TITLE
v0.24.4 — import, station and Tessie fixes

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -404,15 +404,16 @@ class Vehicle(db.Model):
         Otherwise, returns the highest from fuel logs, trips, or charging sessions.
 
         Args:
-            distance_unit: If provided ('km' or 'mi'), converts Tessie odometer to this unit.
-                          Tessie odometer is stored in km internally.
+            distance_unit: If provided ('km' or 'mi'), converts Tessie odometer to
+                          this unit. When omitted, the vehicle's effective odometer
+                          unit is used so the result is comparable with logged
+                          odometer values, which are stored in that unit (#245).
+                          Tessie itself reports km internally.
         """
         # If Tessie is enabled, use Tessie odometer exclusively
         if self.uses_tessie_odometer() and self.tessie_last_odometer:
-            odometer = self.tessie_last_odometer
-            # Convert from km to user's unit if specified
-            if distance_unit == 'mi':
-                odometer = odometer * 0.621371
+            target = distance_unit or self.get_effective_odometer_unit()
+            odometer = _distance_in(self.tessie_last_odometer, 'km', target)
             return round(odometer)
 
         last_fuel = self.fuel_logs.order_by(FuelLog.odometer.desc()).first()

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 import os
+import re
 import sqlite3
 import tempfile
 import traceback
@@ -20,6 +21,7 @@ from app.models import (
     TRIP_PURPOSES, CHARGER_TYPES
 )
 from app.services.tessie import TessieService
+from app.utils import parse_decimal
 from flask_babel import gettext as _
 from config import APP_VERSION
 
@@ -534,10 +536,10 @@ def api_create_fuel_log(vehicle_id):
         vehicle_id=vehicle_id,
         user_id=user.id,
         date=date,
-        odometer=float(data['odometer']),
-        volume=float(data['volume']) if data.get('volume') else None,
-        price_per_unit=float(data['price_per_unit']) if data.get('price_per_unit') else None,
-        total_cost=float(data['total_cost']) if data.get('total_cost') else None,
+        odometer=parse_decimal(data['odometer']),
+        volume=parse_decimal(data['volume']) if data.get('volume') else None,
+        price_per_unit=parse_decimal(data['price_per_unit']) if data.get('price_per_unit') else None,
+        total_cost=parse_decimal(data['total_cost']) if data.get('total_cost') else None,
         is_full_tank=data.get('is_full_tank', True),
         is_missed=data.get('is_missed', False),
         station=data.get('station'),
@@ -588,13 +590,13 @@ def api_update_fuel_log(log_id):
             return jsonify({'error': 'Invalid date format. Use YYYY-MM-DD', 'code': 'validation_error'}), 400
 
     if 'odometer' in data:
-        log.odometer = float(data['odometer'])
+        log.odometer = parse_decimal(data['odometer'])
     if 'volume' in data:
-        log.volume = float(data['volume']) if data['volume'] else None
+        log.volume = parse_decimal(data['volume']) if data['volume'] else None
     if 'price_per_unit' in data:
-        log.price_per_unit = float(data['price_per_unit']) if data['price_per_unit'] else None
+        log.price_per_unit = parse_decimal(data['price_per_unit']) if data['price_per_unit'] else None
     if 'total_cost' in data:
-        log.total_cost = float(data['total_cost']) if data['total_cost'] else None
+        log.total_cost = parse_decimal(data['total_cost']) if data['total_cost'] else None
     if 'is_full_tank' in data:
         log.is_full_tank = data['is_full_tank']
     if 'is_missed' in data:
@@ -714,8 +716,8 @@ def api_create_expense(vehicle_id):
         date=date,
         category=data['category'],
         description=data['description'],
-        cost=float(data['cost']),
-        odometer=float(data['odometer']) if data.get('odometer') else None,
+        cost=parse_decimal(data['cost']),
+        odometer=parse_decimal(data['odometer']) if data.get('odometer') else None,
         vendor=data.get('vendor'),
         notes=data.get('notes')
     )
@@ -771,9 +773,9 @@ def api_update_expense(expense_id):
     if 'description' in data:
         expense.description = data['description']
     if 'cost' in data:
-        expense.cost = float(data['cost'])
+        expense.cost = parse_decimal(data['cost'])
     if 'odometer' in data:
-        expense.odometer = float(data['odometer']) if data['odometer'] else None
+        expense.odometer = parse_decimal(data['odometer']) if data['odometer'] else None
     if 'vendor' in data:
         expense.vendor = data['vendor']
     if 'notes' in data:
@@ -2845,16 +2847,29 @@ def parse_bool_value(value):
 
 
 def parse_float_value(value):
-    """Parse a float, stripping currency symbols and commas."""
-    if not value or not str(value).strip():
+    """Parse a CSV numeric value, stripping currency symbols and tolerating
+    locale separators (#244).
+
+    Uses :func:`app.utils.parse_decimal` (so ``9,99``, ``1.234,56`` and
+    ``1,234.56`` all parse correctly) with one CSV-specific refinement: a
+    single comma followed by exactly three digits with two or more digits
+    before it (e.g. ``12,345``) is read as Anglo thousands grouping, which is
+    how such values appear in exported odometer columns. A short integer part
+    (e.g. the German fuel price ``1,899``) still reads the comma as a decimal
+    separator.
+    """
+    if value is None or not str(value).strip():
         return None
     cleaned = str(value).strip()
-    for ch in ['$', '\u20ac', '\u00a3', '\u00a5', '\u20b9', ',']:
+    for ch in ['$', '\u20ac', '\u00a3', '\u00a5', '\u20b9']:
         cleaned = cleaned.replace(ch, '')
     cleaned = cleaned.strip()
     if not cleaned:
         return None
-    return float(cleaned)
+    m = re.fullmatch(r'(-?\d{2,}),(\d{3})', cleaned)
+    if m:
+        cleaned = m.group(1) + m.group(2)
+    return parse_decimal(cleaned)
 
 
 def parse_int_value(value):

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -2773,24 +2773,48 @@ def auto_suggest_mappings(csv_columns, target_fields):
     return suggestions
 
 
-def parse_date_value(value, date_format='auto'):
-    """Parse a date string, optionally with a format hint."""
+def _ordered_slash_formats(prefer_mdy):
+    """Return ambiguous day/month date formats, preferred interpretation first.
+
+    ``strptime`` rejects out-of-range values, so listing the preferred order
+    first means a value that is unambiguous (e.g. a 31 in the day slot) still
+    falls through to the only interpretation that parses, without silently
+    reversing values that are valid under the preferred format.
+    """
+    dmy = ['%d/%m/%Y %H:%M:%S', '%d/%m/%Y %H:%M', '%d/%m/%Y',
+           '%d-%m-%Y', '%d.%m.%Y', '%d/%m/%y']
+    mdy = ['%m/%d/%Y %H:%M:%S', '%m/%d/%Y %H:%M', '%m/%d/%Y',
+           '%m-%d-%Y', '%m/%d/%y']
+    return (mdy + dmy) if prefer_mdy else (dmy + mdy)
+
+
+def parse_date_value(value, date_format='auto', user_date_format=None):
+    """Parse a date string, optionally with a format hint.
+
+    ``date_format`` is the format chosen on the import screen. When it is
+    ``'auto'`` the importing user's own ``date_format`` preference
+    (``user_date_format``) disambiguates slash-separated dates such as
+    ``12/01/2026`` (issue #250), so a US user's ``MM/DD/YYYY`` data is not
+    silently read as ``DD/MM/YYYY``. Unambiguous ISO dates (``YYYY-MM-DD``)
+    are always parsed first and are unaffected by the preference.
+    """
     if not value or not value.strip():
         return None
     value = value.strip()
 
+    iso_formats = ['%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M', '%Y-%m-%d', '%Y/%m/%d']
+
     if date_format == 'DD/MM/YYYY':
-        formats = ['%d/%m/%Y %H:%M:%S', '%d/%m/%Y %H:%M', '%d/%m/%Y', '%d-%m-%Y', '%d.%m.%Y', '%d/%m/%y']
+        formats = _ordered_slash_formats(prefer_mdy=False)
     elif date_format == 'MM/DD/YYYY':
-        formats = ['%m/%d/%Y %H:%M:%S', '%m/%d/%Y %H:%M', '%m/%d/%Y', '%m-%d-%Y', '%m/%d/%y']
+        formats = _ordered_slash_formats(prefer_mdy=True)
     elif date_format == 'YYYY-MM-DD':
-        formats = ['%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M', '%Y-%m-%d', '%Y/%m/%d']
+        formats = iso_formats
     else:
-        # Auto-detect: try unambiguous formats first
-        formats = ['%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M', '%Y-%m-%d', '%Y/%m/%d',
-                   '%d/%m/%Y %H:%M:%S', '%d/%m/%Y %H:%M', '%d/%m/%Y',
-                   '%m/%d/%Y %H:%M:%S', '%m/%d/%Y %H:%M', '%m/%d/%Y',
-                   '%d-%m-%Y', '%m-%d-%Y', '%d.%m.%Y', '%d/%m/%y', '%m/%d/%y']
+        # Auto-detect: unambiguous ISO first, then slash formats ordered by
+        # the importing user's preference so US dates are not reversed.
+        prefer_mdy = (user_date_format == 'MM/DD/YYYY')
+        formats = iso_formats + _ordered_slash_formats(prefer_mdy)
 
     for fmt in formats:
         try:
@@ -2850,9 +2874,9 @@ def _cleanup_temp_file(path):
         pass
 
 
-def create_record(data_type, mapped_row, vehicle_id, user_id, date_format):
+def create_record(data_type, mapped_row, vehicle_id, user_id, date_format, user_date_format=None):
     """Create a model instance from a mapped CSV row."""
-    date_val = parse_date_value(mapped_row.get('date', ''), date_format)
+    date_val = parse_date_value(mapped_row.get('date', ''), date_format, user_date_format)
 
     if data_type == 'fuel_logs':
         if not date_val:
@@ -3092,7 +3116,7 @@ def csv_import_execute():
                 for csv_col, field_name in col_mapping.items():
                     mapped_row[field_name] = row.get(csv_col, '')
 
-                record = create_record(data_type, mapped_row, vehicle_id, current_user.id, date_format)
+                record = create_record(data_type, mapped_row, vehicle_id, current_user.id, date_format, current_user.date_format)
                 db.session.add(record)
                 imported += 1
             except (ValueError, KeyError) as e:

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -231,6 +231,12 @@ def edit(log_id):
                 if station_id and existing_entry.station_id != station_id:
                     new_station = FuelStation.query.get(station_id)
                     if new_station:
+                        # Reassigning the log moves the usage count too (#252):
+                        # decrement the station we're leaving before bumping the
+                        # new one, so no station is over-counted.
+                        old_station = existing_entry.station
+                        if old_station and old_station.times_used:
+                            old_station.times_used = max(0, old_station.times_used - 1)
                         existing_entry.station_id = station_id
                         new_station.increment_usage()
         elif station_id and log.price_per_unit:
@@ -297,13 +303,21 @@ def delete(log_id):
         if os.path.exists(file_path):
             os.remove(file_path)
 
-    # Clean up matching fuel price history entries
+    # Clean up matching fuel price history entries and keep each affected
+    # station's usage counter in step with the chart view (#252): deleting a
+    # log must decrement the overview "used N times" counter, not just drop the
+    # price-history row the chart reads from.
     if log.price_per_unit and log.date:
-        FuelPriceHistory.query.filter(
+        entries = FuelPriceHistory.query.filter(
             FuelPriceHistory.user_id == current_user.id,
             FuelPriceHistory.date == log.date,
             FuelPriceHistory.price_per_unit == log.price_per_unit
-        ).delete()
+        ).all()
+        for entry in entries:
+            station = entry.station
+            if station and station.times_used:
+                station.times_used = max(0, station.times_used - 1)
+            db.session.delete(entry)
 
     db.session.delete(log)
     db.session.commit()
@@ -380,22 +394,40 @@ def quick():
             volume=volume,
             total_cost=total_cost,
             price_per_unit=price_per_unit,
+            fuel_type=request.form.get('fuel_type') or None,
             is_full_tank=request.form.get('is_full_tank') == 'on',
             station=request.form.get('station'),
         )
 
-        # Update station usage
-        station_name = request.form.get('station')
-        if station_name:
-            station = FuelStation.query.filter_by(
-                user_id=current_user.id,
-                name=station_name
-            ).first()
-            if station:
-                station.increment_usage()
-
         db.session.add(log)
         db.session.commit()
+
+        # Associate with a saved station the same way fuel.new() does (#252):
+        # record a FuelPriceHistory row and bump the usage counter together, so
+        # quick logs show up in the station chart view and keep the overview
+        # counter in step. Prefer the station_id sent by the dropdown; fall back
+        # to a name match for manually typed stations.
+        station_id = request.form.get('station_id', type=int)
+        station = None
+        if station_id:
+            station = FuelStation.query.get(station_id)
+        else:
+            station_name = request.form.get('station')
+            if station_name:
+                station = FuelStation.query.filter_by(
+                    user_id=current_user.id,
+                    name=station_name
+                ).first()
+        if station and log.price_per_unit:
+            db.session.add(FuelPriceHistory(
+                station_id=station.id,
+                user_id=current_user.id,
+                date=log.date,
+                fuel_type=log.fuel_type or vehicle.fuel_type or 'petrol',
+                price_per_unit=log.price_per_unit,
+            ))
+            station.increment_usage()
+            db.session.commit()
 
         flash(_('Fuel log added!'), 'success')
 

--- a/app/templates/stations/prices.html
+++ b/app/templates/stations/prices.html
@@ -69,31 +69,66 @@ document.addEventListener('DOMContentLoaded', function() {
     const ctx = document.getElementById('priceChart').getContext('2d');
     const prices = {{ prices_json | tojson }};
 
-    // Reverse to show chronological order
-    const sortedPrices = prices.slice().reverse();
+    // Petrol and diesel (etc.) at the same station have naturally different
+    // prices, so plot one line per fuel type rather than mixing them into a
+    // single misleading series (#252).
+    const sortedPrices = prices.slice().sort((a, b) => new Date(a.date) - new Date(b.date));
+
+    // Shared, ordered set of dates so every series lines up on the x-axis.
+    const dates = [...new Set(sortedPrices.map(p => p.date))];
+    const labels = dates.map(d => new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }));
+
+    // Group prices by fuel type: { fuelType: { date: price } }
+    const byType = {};
+    sortedPrices.forEach(p => {
+        const ft = p.fuel_type || 'unknown';
+        (byType[ft] = byType[ft] || {})[p.date] = p.price_per_unit;
+    });
+
+    // Stable, readable colours per known fuel type, with a fallback palette.
+    const typeColours = {
+        petrol: 'rgb(14, 165, 233)',
+        diesel: 'rgb(234, 88, 12)',
+        electric: 'rgb(16, 185, 129)',
+        hybrid: 'rgb(250, 204, 21)',
+        plugin_hybrid: 'rgb(132, 204, 22)',
+        lpg: 'rgb(168, 85, 247)',
+        cng: 'rgb(236, 72, 153)',
+        hydrogen: 'rgb(6, 182, 212)',
+        e85: 'rgb(217, 70, 239)',
+        other: 'rgb(100, 116, 139)'
+    };
+    const fallback = ['rgb(59, 130, 246)', 'rgb(239, 68, 68)', 'rgb(34, 197, 94)', 'rgb(245, 158, 11)', 'rgb(139, 92, 246)'];
+
+    const fuelTypes = Object.keys(byType);
+    const datasets = fuelTypes.map((ft, i) => {
+        const colour = typeColours[ft] || fallback[i % fallback.length];
+        const label = ft.charAt(0).toUpperCase() + ft.slice(1).replace('_', ' ');
+        return {
+            label: label,
+            data: dates.map(d => (d in byType[ft]) ? byType[ft][d] : null),
+            borderColor: colour,
+            backgroundColor: colour,
+            tension: 0.3,
+            fill: false,
+            spanGaps: true
+        };
+    });
 
     new Chart(ctx, {
         type: 'line',
         data: {
-            labels: sortedPrices.map(p => {
-                const date = new Date(p.date);
-                return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-            }),
-            datasets: [{
-                label: '{{ _("Price per") }} {{ current_user.volume_unit }}',
-                data: sortedPrices.map(p => p.price_per_unit),
-                borderColor: 'rgb(14, 165, 233)',
-                backgroundColor: 'rgba(14, 165, 233, 0.1)',
-                tension: 0.3,
-                fill: true
-            }]
+            labels: labels,
+            datasets: datasets
         },
         options: {
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
                 legend: {
-                    display: false
+                    // Only worth showing the key once more than one fuel type
+                    // is being charted.
+                    display: datasets.length > 1
                 }
             },
             scales: {

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.24.3'
+APP_VERSION = '0.24.4'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/migrations/versions/e5f6a7b8c9d0_backfill_quick_log_price_history.py
+++ b/migrations/versions/e5f6a7b8c9d0_backfill_quick_log_price_history.py
@@ -1,0 +1,109 @@
+"""backfill fuel price history for quick-log entries (#252)
+
+Quick Fuel Log entries never wrote a FuelPriceHistory row, so they were
+counted in a station's "used N times" overview but were missing from the
+station chart/price-history view. The route is now fixed to record the row
+at save time; this migration repairs existing data so historic quick logs
+show up in the chart without the user having to re-edit each one.
+
+The repair is model-driven: for every fuel log that names a saved station and
+has a price, we recreate the missing price-history row (matching what the
+route now does). It only touches logs that resolve to a station and have no
+matching price-history row yet, so full-form logs (which already have one) and
+unmatched free-text stations are left untouched. The station usage counter is
+deliberately not changed — quick saves already incremented it, so recreating
+only the price-history row brings the chart back in step with the overview.
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-15 00:00:00.000000
+
+"""
+from alembic import op
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+revision = 'e5f6a7b8c9d0'
+down_revision = 'd4e5f6a7b8c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    tables = inspector.get_table_names()
+    if 'fuel_logs' not in tables or 'fuel_stations' not in tables \
+            or 'fuel_price_history' not in tables:
+        return
+
+    # Import lazily so the migration only depends on the models when it runs.
+    from app.models import FuelLog, FuelStation, FuelPriceHistory
+
+    session = Session(bind=bind)
+    try:
+        stations = session.query(FuelStation).all()
+        if not stations:
+            session.close()
+            return
+
+        # Resolve a log's free-text station name to a saved station. The quick
+        # dropdown stored either the plain name or "Name (Brand)", so index both
+        # forms per owning user.
+        station_lookup = {}
+        for station in stations:
+            if not station.name:
+                continue
+            station_lookup.setdefault((station.user_id, station.name), station)
+            if station.brand:
+                combined = '%s (%s)' % (station.name, station.brand)
+                station_lookup.setdefault((station.user_id, combined), station)
+
+        logs = session.query(FuelLog).filter(
+            FuelLog.station.isnot(None),
+            FuelLog.price_per_unit.isnot(None),
+        ).all()
+
+        for log in logs:
+            if not log.station or not log.price_per_unit or not log.date:
+                continue
+            station = station_lookup.get((log.user_id, log.station))
+            if not station:
+                continue
+
+            existing = session.query(FuelPriceHistory).filter_by(
+                station_id=station.id,
+                user_id=log.user_id,
+                date=log.date,
+                price_per_unit=log.price_per_unit,
+            ).first()
+            if existing:
+                continue
+
+            fuel_type = log.fuel_type
+            if not fuel_type and log.vehicle is not None:
+                fuel_type = log.vehicle.fuel_type
+            fuel_type = fuel_type or 'petrol'
+
+            session.add(FuelPriceHistory(
+                station_id=station.id,
+                user_id=log.user_id,
+                date=log.date,
+                fuel_type=fuel_type,
+                price_per_unit=log.price_per_unit,
+            ))
+
+        session.commit()
+    except Exception:
+        # A data backfill must never break the upgrade chain. If anything goes
+        # wrong, leave existing data untouched; users can still repair a log by
+        # re-selecting its station in the editor.
+        session.rollback()
+    finally:
+        session.close()
+
+
+def downgrade():
+    # Data-only backfill; there is nothing to reverse.
+    pass

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -623,3 +623,134 @@ class TestConsumptionUnavailableReason:
         db.session.commit()
         assert sample_vehicle.get_average_consumption() is not None
         assert sample_vehicle.get_consumption_unavailable_reason() is None
+
+
+class TestFuelStationSync:
+    """#252 — quick logs, delete counter, and per-fuel-type price series."""
+
+    def test_quick_log_appears_in_station_chart(
+            self, auth_client, sample_vehicle, sample_station):
+        """Defect 1: a quick log at a saved station records price history
+        (so it shows in the chart view) and bumps the usage counter."""
+        starting = sample_station.times_used or 0
+        auth_client.post('/fuel/quick', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'odometer': '30000',
+            'volume': '40',
+            'price_per_unit': '1.70',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        history = FuelPriceHistory.query.filter_by(
+            station_id=sample_station.id, price_per_unit=1.70).first()
+        assert history is not None
+        assert history.date == date.today()
+
+        db.session.refresh(sample_station)
+        assert sample_station.times_used == starting + 1
+
+    def test_quick_log_matches_station_by_name(
+            self, auth_client, sample_vehicle, sample_station):
+        """Defect 1: a manually typed station name (no station_id) still
+        records price history via name match."""
+        auth_client.post('/fuel/quick', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'odometer': '31000',
+            'volume': '35',
+            'price_per_unit': '1.65',
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        history = FuelPriceHistory.query.filter_by(
+            station_id=sample_station.id, price_per_unit=1.65).first()
+        assert history is not None
+
+    def test_delete_decrements_station_counter(
+            self, auth_client, sample_vehicle, sample_station):
+        """Defect 2: deleting a fuel log decrements the overview counter,
+        not just the chart's price-history row."""
+        auth_client.post('/fuel/quick', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'odometer': '32000',
+            'volume': '40',
+            'price_per_unit': '1.80',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        db.session.refresh(sample_station)
+        assert sample_station.times_used == 1
+
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).order_by(
+            FuelLog.id.desc()).first()
+        auth_client.post(f'/fuel/{log.id}/delete', follow_redirects=True)
+
+        db.session.refresh(sample_station)
+        assert sample_station.times_used == 0
+        assert FuelPriceHistory.query.filter_by(
+            station_id=sample_station.id).count() == 0
+
+    def test_edit_reassign_moves_counter(
+            self, auth_client, test_user, sample_vehicle, sample_station):
+        """Defect 2: reassigning a log's station decrements the old station
+        and increments the new one, so neither is over-counted."""
+        other = FuelStation(user_id=test_user.id, name='Esso Station', brand='Esso')
+        db.session.add(other)
+        db.session.commit()
+
+        # Log created at sample_station via quick (usage 1 + price history).
+        auth_client.post('/fuel/quick', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'odometer': '33000',
+            'volume': '40',
+            'price_per_unit': '1.90',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+        db.session.refresh(sample_station)
+        assert sample_station.times_used == 1
+
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).order_by(
+            FuelLog.id.desc()).first()
+
+        # Reassign to the other station via edit.
+        auth_client.post(f'/fuel/{log.id}/edit', data={
+            'date': log.date.isoformat(),
+            'odometer': '33000',
+            'volume': '40',
+            'price_per_unit': '1.90',
+            'station_id': str(other.id),
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        db.session.refresh(sample_station)
+        db.session.refresh(other)
+        assert sample_station.times_used == 0
+        assert other.times_used == 1
+
+    def test_price_history_separates_fuel_types(
+            self, auth_client, test_user, sample_station):
+        """Defect 3: the chart data keeps petrol and diesel as distinct
+        series rather than aggregating them into one price line."""
+        db.session.add_all([
+            FuelPriceHistory(station_id=sample_station.id, user_id=test_user.id,
+                             date=date(2024, 3, 1), fuel_type='petrol',
+                             price_per_unit=1.60),
+            FuelPriceHistory(station_id=sample_station.id, user_id=test_user.id,
+                             date=date(2024, 3, 2), fuel_type='diesel',
+                             price_per_unit=1.75),
+        ])
+        db.session.commit()
+
+        resp = auth_client.get(f'/stations/{sample_station.id}/prices')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # Both fuel types reach the template as distinct data...
+        assert '"fuel_type": "petrol"' in html
+        assert '"fuel_type": "diesel"' in html
+        # ...and the chart groups by fuel type instead of one flat series.
+        assert 'byType' in html

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -440,6 +440,49 @@ class TestCsvImportExecute:
 
 
 # ---------------------------------------------------------------------------
+# Locale-tolerant numeric handling on CSV import (issue #244)
+# ---------------------------------------------------------------------------
+
+class TestParseFloatValue:
+    """parse_float_value must accept locale decimal separators without
+    corrupting Anglo thousands-grouped values."""
+
+    def _parse(self, value):
+        from app.routes.api import parse_float_value
+        return parse_float_value(value)
+
+    def test_dot_decimal_unchanged(self):
+        assert self._parse('9.99') == 9.99
+
+    def test_comma_decimal(self):
+        # Previously imported as 999 (comma stripped) — a silent 100x error.
+        assert self._parse('9,99') == 9.99
+
+    def test_german_grouping(self):
+        assert self._parse('1.234,56') == 1234.56
+
+    def test_anglo_grouping(self):
+        assert self._parse('1,234.56') == 1234.56
+
+    def test_anglo_thousands_only(self):
+        # Odometer-style value: two or more digits before a comma with three
+        # after is thousands grouping, not a decimal.
+        assert self._parse('12,345') == 12345
+
+    def test_short_integer_part_is_decimal(self):
+        # German fuel price: 1,899 €/L.
+        assert self._parse('1,899') == 1.899
+
+    def test_currency_symbols_stripped(self):
+        assert self._parse('€1.234,56') == 1234.56
+        assert self._parse('$1,234.56') == 1234.56
+
+    def test_empty_returns_none(self):
+        assert self._parse('') is None
+        assert self._parse(None) is None
+
+
+# ---------------------------------------------------------------------------
 # Date-format handling on CSV import (issue #250)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -437,3 +437,127 @@ class TestCsvImportExecute:
             content_type='multipart/form-data'
         )
         assert execute_resp.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# Date-format handling on CSV import (issue #250)
+# ---------------------------------------------------------------------------
+
+class TestParseDateValue:
+    """Unit tests for parse_date_value date-format disambiguation."""
+
+    def test_auto_us_preference_ambiguous_reads_as_mdy(self):
+        """A US user's ambiguous 12/01/2026 should be 1 December, not 12 Jan."""
+        from datetime import date
+        from app.routes.api import parse_date_value
+        result = parse_date_value('12/01/2026', 'auto', user_date_format='MM/DD/YYYY')
+        assert result == date(2026, 12, 1)
+
+    def test_auto_us_preference_unambiguous_day_still_parses(self):
+        """12/31/2026 has no DD/MM reading, so it stays 31 December."""
+        from datetime import date
+        from app.routes.api import parse_date_value
+        result = parse_date_value('12/31/2026', 'auto', user_date_format='MM/DD/YYYY')
+        assert result == date(2026, 12, 31)
+
+    def test_auto_uk_preference_ambiguous_reads_as_dmy(self):
+        """A DD/MM user keeps the original behaviour: 12/01/2026 is 12 January."""
+        from datetime import date
+        from app.routes.api import parse_date_value
+        result = parse_date_value('12/01/2026', 'auto', user_date_format='DD/MM/YYYY')
+        assert result == date(2026, 1, 12)
+
+    def test_auto_no_preference_defaults_to_dmy(self):
+        """With no preference (legacy default) 12/01/2026 stays DD/MM = 12 January."""
+        from datetime import date
+        from app.routes.api import parse_date_value
+        result = parse_date_value('12/01/2026', 'auto')
+        assert result == date(2026, 1, 12)
+
+    def test_iso_unaffected_by_preference(self):
+        """Unambiguous ISO dates parse identically regardless of preference."""
+        from datetime import date
+        from app.routes.api import parse_date_value
+        assert parse_date_value('2026-12-01', 'auto', user_date_format='MM/DD/YYYY') == date(2026, 12, 1)
+        assert parse_date_value('2026-12-01', 'auto', user_date_format='DD/MM/YYYY') == date(2026, 12, 1)
+        assert parse_date_value('2026-12-01', 'YYYY-MM-DD') == date(2026, 12, 1)
+
+    def test_explicit_mdy_falls_back_for_out_of_range_month(self):
+        """Explicit MM/DD/YYYY falls back to DD/MM when the month slot is invalid."""
+        from datetime import date
+        from app.routes.api import parse_date_value
+        # 31 cannot be a month, so this must be 31 December.
+        assert parse_date_value('31/12/2026', 'MM/DD/YYYY') == date(2026, 12, 31)
+
+    def test_explicit_dmy_unchanged(self):
+        from datetime import date
+        from app.routes.api import parse_date_value
+        assert parse_date_value('12/01/2026', 'DD/MM/YYYY') == date(2026, 1, 12)
+
+
+class TestCsvImportUsDateFormat:
+    """End-to-end import flow honours the importing user's date preference."""
+
+    def _import(self, auth_client, sample_vehicle, csv_content):
+        preview_data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'file': (io.BytesIO(csv_content), 'fuel.csv'),
+        }
+        preview_resp = auth_client.post(
+            '/api/import/csv/preview',
+            data=preview_data,
+            content_type='multipart/form-data',
+        )
+        assert preview_resp.status_code == 200
+        execute_data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'date_format': 'auto',
+            'mapping_0': 'date',
+            'mapping_1': 'odometer',
+            'mapping_2': 'volume',
+            'mapping_3': 'total_cost',
+        }
+        execute_resp = auth_client.post(
+            '/api/import/csv/execute',
+            data=execute_data,
+            content_type='multipart/form-data',
+        )
+        assert execute_resp.status_code == 302
+
+    def test_us_user_ambiguous_date_not_reversed(self, auth_client, test_user, sample_vehicle):
+        """US-preference user importing 12/01/2026 gets 1 December 2026."""
+        from datetime import date
+        test_user.date_format = 'MM/DD/YYYY'
+        _db_ext.session.commit()
+        self._import(
+            auth_client, sample_vehicle,
+            b'date,odometer,volume,total_cost\n12/01/2026,10000,40.0,60.0\n',
+        )
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).one()
+        assert log.date == date(2026, 12, 1)
+
+    def test_us_user_unambiguous_date_correct(self, auth_client, test_user, sample_vehicle):
+        """US-preference user importing 12/31/2026 gets 31 December 2026."""
+        from datetime import date
+        test_user.date_format = 'MM/DD/YYYY'
+        _db_ext.session.commit()
+        self._import(
+            auth_client, sample_vehicle,
+            b'date,odometer,volume,total_cost\n12/31/2026,10000,40.0,60.0\n',
+        )
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).one()
+        assert log.date == date(2026, 12, 31)
+
+    def test_uk_user_keeps_dmy_behaviour(self, auth_client, test_user, sample_vehicle):
+        """DD/MM-preference user importing 12/01/2026 gets 12 January 2026."""
+        from datetime import date
+        test_user.date_format = 'DD/MM/YYYY'
+        _db_ext.session.commit()
+        self._import(
+            auth_client, sample_vehicle,
+            b'date,odometer,volume,total_cost\n12/01/2026,10000,40.0,60.0\n',
+        )
+        log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).one()
+        assert log.date == date(2026, 1, 12)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -194,6 +194,35 @@ class TestVehicleOdometerUnit:
         assert abs(v.get_total_distance('mi') - 621.371) < 0.05
 
 
+class TestTessieOdometerUnit:
+    def _tessie_vehicle(self, test_user, monkeypatch, unit):
+        from app.services.tessie import TessieService
+        monkeypatch.setattr(TessieService, 'is_configured', staticmethod(lambda: True))
+        v = Vehicle(
+            owner_id=test_user.id,
+            name='Tesla', vehicle_type='car', fuel_type='electric',
+            odometer_unit=unit,
+            tessie_enabled=True, tessie_vin='5YJ3TEST', tessie_last_odometer=10000,
+        )
+        db.session.add(v)
+        db.session.commit()
+        return v
+
+    def test_default_unit_matches_vehicle_for_miles(self, app, test_user, monkeypatch):
+        # #245 — Tessie reports km; a miles vehicle must get miles back by
+        # default so the value is comparable with logged odometer readings.
+        v = self._tessie_vehicle(test_user, monkeypatch, 'mi')
+        assert v.get_last_odometer() == round(10000 * 0.621371)
+
+    def test_default_unit_matches_vehicle_for_km(self, app, test_user, monkeypatch):
+        v = self._tessie_vehicle(test_user, monkeypatch, 'km')
+        assert v.get_last_odometer() == 10000
+
+    def test_explicit_unit_still_wins(self, app, test_user, monkeypatch):
+        v = self._tessie_vehicle(test_user, monkeypatch, 'mi')
+        assert v.get_last_odometer(distance_unit='km') == 10000
+
+
 class TestVehicleRelationships:
     def test_vehicle_has_owner(self, sample_vehicle, test_user):
         assert sample_vehicle.owner.id == test_user.id


### PR DESCRIPTION
## What's Changed

### Bug Fixes
- CSV import now honours your date format preference when parsing ambiguous slash dates like `12/01/2026`, instead of always assuming DD/MM/YYYY (#250)
- CSV import and the JSON API accept comma decimal separators; previously a value like `9,99` imported as `999` because commas were stripped wholesale (#244)
- Quick Fuel Log entries now appear in the station chart view; a data migration backfills existing quick logs (#252)
- Station "used N times" counters decrease when fuel logs are deleted, and move correctly when a log is reassigned to a different station (#252)
- Station price charts show one line per fuel type instead of merging petrol and diesel prices into a single misleading series (#252)
- Tessie-tracked vehicles now report their odometer in the vehicle's own unit, fixing maintenance schedules recorded ~60% out for miles-unit Teslas (#245)

### Other Changes
- Version bumped to 0.24.4

Full test suite: 689 passed.