### PR TITLE
v0.25.0 — branding logo as tab icon

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -45,7 +45,16 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="{{ APP_NAME }}">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    {# Tab icon: the uploaded branding logo when one is set, else the bundled
+       default (#259). Browsers accept PNG/JPEG/SVG here, no .ico needed. #}
+    {% if APP_LOGO %}
+    <link rel="icon" href="{{ url_for('api.uploaded_file', filename=APP_LOGO) }}">
+    <link rel="apple-touch-icon" href="{{ url_for('api.uploaded_file', filename=APP_LOGO) }}">
+    {% else %}
+    <link rel="icon" href="{{ url_for('static', filename='icons/icon.svg') }}" type="image/svg+xml">
+    <link rel="icon" href="{{ url_for('static', filename='icons/icon-96x96.png') }}" sizes="96x96" type="image/png">
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='icons/icon.svg') }}">
+    {% endif %}
 
     <!-- Tailwind CSS - Critical for styling, loaded first -->
     <script>

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 basedir = Path(__file__).parent.absolute()
 
 
-APP_VERSION = '0.24.5'
+APP_VERSION = '0.25.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -300,6 +300,20 @@ class TestBrandingRoute:
         with app.app_context():
             assert AppSettings.get('app_name') == 'MyFleet'
 
+    def test_uploaded_logo_used_as_favicon(self, auth_client, app):
+        # #259 — a branding logo should become the tab icon.
+        with app.app_context():
+            AppSettings.set('logo_filename', 'my-logo.png')
+        resp = auth_client.get('/auth/login', follow_redirects=True)
+        assert b'rel="icon" href="/api/uploads/my-logo.png"' in resp.data
+        with app.app_context():
+            AppSettings.set('logo_filename', '')
+
+    def test_default_favicon_without_logo(self, auth_client):
+        resp = auth_client.get('/auth/login', follow_redirects=True)
+        assert b'rel="icon"' in resp.data
+        assert b'icons/icon.svg' in resp.data
+
     def test_post_branding_non_admin_forbidden(self, auth_client):
         response = auth_client.post('/auth/branding', data={
             'app_name': 'Hacked',


### PR DESCRIPTION
## What's Changed

### New Features
- The uploaded branding logo is now used as the browser tab icon (and touch icon), so custom-branded instances are identifiable at a glance; instances without a logo get the bundled May icon, which previously wasn't declared as a favicon at all (#259)

### Other Changes
- Version bumped to 0.25.0

Full test suite: 705 passed.