### PR TITLE
Release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   editing an expense, and the expandable row in the expense list links to each
   one. Files rejected for an unsupported extension are now reported rather than
   dropped silently. ([#234](https://github.com/dannymcc/may/issues/234))
+- UK fuel prices. Admins can switch on the government fuel price feeds in
+  Settings → Integrations → UK Fuel Prices; saved stations are then matched to
+  forecourts by postcode and their prices recorded, feeding the existing price
+  history and Cheapest Fuel screens. Refreshes run every six hours in the
+  background, or on demand from the Fuel Stations page. No API key is needed,
+  and the retailer feed list can be overridden.
+  ([#258](https://github.com/dannymcc/may/issues/258))
 - API v1 endpoints for trips and charging sessions: list, create, read, update
   and delete under `/api/v1/vehicles/{id}/trips`, `/api/v1/trips/{id}`,
   `/api/v1/vehicles/{id}/charging` and `/api/v1/charging/{id}`, plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file starts at 0.28.0. Notes for earlier releases are on the
 [GitHub releases page](https://github.com/dannymcc/may/releases).
 
+## [0.29.0] - 2026-08-23
+
+### Added
+
+- UK fuel prices. Admins can switch on the government fuel price feeds in
+  Settings → Integrations → UK Fuel Prices; saved stations are then matched to
+  forecourts by postcode and their prices recorded, feeding the existing price
+  history and Cheapest Fuel screens. Refreshes run every six hours in the
+  background, or on demand with the "Update UK Prices" button on the Fuel
+  Stations page or a station's price history. No API key is needed, and the
+  retailer feed list can be overridden.
+  ([#258](https://github.com/dannymcc/may/issues/258))
+- The vehicle PDF report lists the vehicle's parts and consumables, with type,
+  specification, quantity and part number, alongside the existing
+  specifications, fuel logs and expenses. Vehicles with no parts recorded are
+  unchanged. ([#235](https://github.com/dannymcc/may/issues/235))
+
 ## [0.28.0] - 2026-08-23
 
 ### Added
@@ -23,13 +40,6 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   editing an expense, and the expandable row in the expense list links to each
   one. Files rejected for an unsupported extension are now reported rather than
   dropped silently. ([#234](https://github.com/dannymcc/may/issues/234))
-- UK fuel prices. Admins can switch on the government fuel price feeds in
-  Settings → Integrations → UK Fuel Prices; saved stations are then matched to
-  forecourts by postcode and their prices recorded, feeding the existing price
-  history and Cheapest Fuel screens. Refreshes run every six hours in the
-  background, or on demand from the Fuel Stations page. No API key is needed,
-  and the retailer feed list can be overridden.
-  ([#258](https://github.com/dannymcc/may/issues/258))
 - API v1 endpoints for trips and charging sessions: list, create, read, update
   and delete under `/api/v1/vehicles/{id}/trips`, `/api/v1/trips/{id}`,
   `/api/v1/vehicles/{id}/charging` and `/api/v1/charging/{id}`, plus

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Named after James May, completing the trio of Top Gear presenters (alongside [Cl
 - **🌙 Dark Mode**: Toggle between light and dark themes
 - **📥 Import/Export**: Import from Fuelly CSV, export all data as JSON or CSV
 - **🇬🇧 DVLA Integration**: Look up UK vehicle MOT and tax status automatically
+- **⛽ UK Fuel Prices**: Pull live forecourt prices for your saved UK stations from the government fuel price feeds, no API key needed
 - **📱 PWA Support**: Install as a mobile app with offline capabilities
 - **🔌 REST API**: Full API access for integrations and automation
 - **🏠 Home Assistant Integration**: Create sensors and automations for your vehicles

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Save your favorite stations:
 - Quick selection during fuel logging
 - Track prices at different stations
 - Notes and location information
+- UK stations can pull live prices from the government fuel price feeds
+  (see [UK Fuel Prices](#uk-fuel-prices))
 
 ### Notifications
 Configure your preferred notification method:
@@ -251,6 +253,7 @@ Administrators can configure:
 - **SMTP Settings**: Email server for notifications
 - **Pushover**: Application token for push notifications
 - **DVLA API**: API key for UK vehicle lookups ([get one here](https://developer-portal.driver-vehicle-licensing.api.gov.uk/))
+- **UK Fuel Prices**: live forecourt prices for saved stations (see below)
 - **Branding**: Custom logo, app name, tagline, and primary color
 - **User Management**: Create, edit, and manage user accounts
 
@@ -268,6 +271,33 @@ Vehicles, fuel logs, expenses, trips, and charging sessions can all be read and
 created through the API. See the API documentation at `/api/docs` when logged in.
 
 ## 🔗 Integrations
+
+### UK Fuel Prices
+
+UK retailers publish their forecourt prices as open JSON feeds under the
+government [fuel price transparency scheme](https://www.gov.uk/guidance/access-the-latest-fuel-prices-and-forecourt-data-via-api-or-email).
+May can read those feeds and record the prices against your saved stations, so
+price history and Cheapest Fuel stay current without manual entry. No API key is
+needed.
+
+To use it:
+
+1. An admin enables it in **Settings → Integrations → UK Fuel Prices**.
+2. Give each saved station its postcode — that is what stations are matched on.
+   Where a postcode covers more than one forecourt, coordinates (if set) and
+   then brand break the tie.
+3. Prices refresh in the background every six hours, and on demand with the
+   **Update UK Prices** button on the Fuel Stations page or on a single
+   station's price history.
+
+Prices are stored one row per station, fuel type and day, so re-running the
+refresh updates the day's entry rather than adding duplicates. Premium grades
+are recorded separately (E5 as "Petrol Premium", SDV as "Diesel Premium").
+
+The built-in retailer list follows the gov.uk guidance page. Retailers join and
+leave the scheme, so the settings panel takes an optional override — one feed
+per line, either `Retailer name|https://...` or a bare URL. A feed that is
+unreachable is reported and the rest still apply.
 
 ### Home Assistant
 Create vehicle sensors in Home Assistant:

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Add and manage your vehicles with detailed information:
 - **Vehicle Sharing**: Mark a vehicle as "Shared" to make it visible and loggable by all users on the instance
 - **Upcoming Maintenance**: Vehicle detail pages show a live panel of scheduled maintenance tasks, with overdue and due-soon alerts
 - **Parts & Consumables**: Collapsible section on the vehicle page remembers your expand/collapse preference per vehicle
-- **PDF Report**: The "PDF" button downloads a summary of the vehicle, its fuel logs and its expenses. "PDF + Receipts" does the same and appends the receipt images attached to those entries, which is the version to hand to an accountant or employer. Non-image attachments (PDF scans, for example) are listed at the end of the report rather than embedded.
+- **PDF Report**: The "PDF" button downloads a summary of the vehicle, its specifications, its parts and consumables, its fuel logs and its expenses. "PDF + Receipts" does the same and appends the receipt images attached to those entries, which is the version to hand to an accountant or employer. Non-image attachments (PDF scans, for example) are listed at the end of the report rather than embedded.
 
 ### Fuel Logs
 Track every fill-up with:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -543,6 +543,20 @@ def _start_reminder_scheduler(app):
             except Exception as e:
                 logger.error(f"Error in recurring expense scheduler: {e}")
 
+            try:
+                with app.app_context():
+                    from app.services.uk_fuel_prices import UKFuelPriceService
+                    fuel_stats = UKFuelPriceService.refresh_if_due()
+                    if fuel_stats:
+                        logger.info(
+                            f"UK fuel price check: {fuel_stats['prices']} prices "
+                            f"from {fuel_stats['matched']} forecourts, "
+                            f"{fuel_stats['unmatched']} unmatched, "
+                            f"{len(fuel_stats['errors'])} feed errors"
+                        )
+            except Exception as e:
+                logger.error(f"Error in UK fuel price scheduler: {e}")
+
             # Check every hour
             time.sleep(3600)
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -295,6 +295,16 @@ def settings():
             'api_token': AppSettings.get('tessie_api_token'),
         }
 
+    # Get UK fuel price settings for admins
+    uk_fuel_settings = {}
+    if current_user.is_admin:
+        from app.services.uk_fuel_prices import SETTING_FEEDS, UKFuelPriceService
+        uk_fuel_settings = {
+            'enabled': UKFuelPriceService.is_enabled(),
+            'feed_urls': AppSettings.get(SETTING_FEEDS, ''),
+            'retailer_count': len(UKFuelPriceService.get_feeds()),
+        }
+
     # Get registration setting
     registration_enabled = AppSettings.get('registration_enabled', 'true') == 'true'
 
@@ -305,6 +315,7 @@ def settings():
                            pushover_configured=pushover_configured,
                            dvla_settings=dvla_settings,
                            tessie_settings=tessie_settings,
+                           uk_fuel_settings=uk_fuel_settings,
                            app_version=DISPLAY_VERSION,
                            release_channel=RELEASE_CHANNEL,
                            github_repo=GITHUB_REPO,
@@ -452,6 +463,21 @@ def dvla_settings():
 
     flash(_('DVLA settings updated'), 'success')
     return redirect(url_for('auth.settings') + '#services-dvla')
+
+
+@bp.route('/uk-fuel-settings', methods=['POST'])
+@login_required
+@admin_required
+def uk_fuel_settings():
+    """Update UK fuel price feed settings (admin only)"""
+    from app.services.uk_fuel_prices import SETTING_ENABLED, SETTING_FEEDS
+
+    enabled = request.form.get('uk_fuel_prices_enabled') == 'on'
+    AppSettings.set(SETTING_ENABLED, 'true' if enabled else 'false')
+    AppSettings.set(SETTING_FEEDS, request.form.get('uk_fuel_feed_urls', '').strip())
+
+    flash(_('UK fuel price settings updated'), 'success')
+    return redirect(url_for('auth.settings') + '#services-uk-fuel')
 
 
 @bp.route('/tessie-settings', methods=['POST'])

--- a/app/routes/stations.py
+++ b/app/routes/stations.py
@@ -6,6 +6,7 @@ from flask_babel import gettext as _
 from app import db
 from app.utils import parse_decimal
 from app.models import FuelStation, FuelPriceHistory
+from app.services.uk_fuel_prices import UKFuelPriceService
 
 bp = Blueprint('stations', __name__, url_prefix='/stations')
 
@@ -19,7 +20,11 @@ def index():
         FuelStation.times_used.desc()
     ).all()
 
-    return render_template('stations/index.html', stations=stations)
+    return render_template(
+        'stations/index.html',
+        stations=stations,
+        uk_fuel_enabled=UKFuelPriceService.is_enabled(),
+    )
 
 
 @bp.route('/new', methods=['GET', 'POST'])
@@ -149,7 +154,65 @@ def price_history(station_id):
         for p in price_records
     ]
 
-    return render_template('stations/prices.html', station=station, prices=prices, prices_json=prices_json)
+    return render_template(
+        'stations/prices.html',
+        station=station,
+        prices=prices,
+        prices_json=prices_json,
+        uk_fuel_enabled=UKFuelPriceService.is_enabled(),
+    )
+
+
+def _flash_uk_refresh(stats):
+    """Summarise a UK fuel price refresh as flash messages"""
+    if stats['matched']:
+        flash(
+            _('Updated %(prices)s live prices from %(matched)s forecourts')
+            % {'prices': stats['prices'], 'matched': stats['matched']},
+            'success',
+        )
+    else:
+        flash(
+            _('No matching forecourts found. Check the station postcodes.'),
+            'info',
+        )
+
+    if stats['errors']:
+        flash(
+            _('Some retailer feeds could not be read: %(errors)s')
+            % {'errors': ', '.join(stats['errors'][:3])},
+            'warning',
+        )
+
+
+@bp.route('/uk-prices/refresh', methods=['POST'])
+@login_required
+def refresh_uk_prices():
+    """Pull live UK forecourt prices for every saved station"""
+    if not UKFuelPriceService.is_enabled():
+        flash(_('UK fuel prices are not enabled. An admin can turn them on in Settings.'), 'error')
+        return redirect(url_for('stations.index'))
+
+    stats = UKFuelPriceService.refresh_prices()
+    _flash_uk_refresh(stats)
+
+    return redirect(url_for('stations.index'))
+
+
+@bp.route('/<int:station_id>/uk-prices/refresh', methods=['POST'])
+@login_required
+def refresh_station_uk_prices(station_id):
+    """Pull live UK forecourt prices for a single station"""
+    station = FuelStation.query.get_or_404(station_id)
+
+    if not UKFuelPriceService.is_enabled():
+        flash(_('UK fuel prices are not enabled. An admin can turn them on in Settings.'), 'error')
+        return redirect(url_for('stations.price_history', station_id=station.id))
+
+    stats = UKFuelPriceService.refresh_prices([station])
+    _flash_uk_refresh(stats)
+
+    return redirect(url_for('stations.price_history', station_id=station.id))
 
 
 @bp.route('/prices/<int:price_id>/delete', methods=['POST'])

--- a/app/routes/vehicles.py
+++ b/app/routes/vehicles.py
@@ -480,6 +480,7 @@ def report(vehicle_id):
     fuel_logs = vehicle.fuel_logs.order_by(FuelLog.date.desc(), FuelLog.odometer.desc()).all()
     expenses = vehicle.expenses.order_by(Expense.date.desc()).all()
     specs = vehicle.specs.all()
+    parts = vehicle.parts.order_by(VehiclePart.part_type, VehiclePart.name).all()
 
     # Calculate statistics
     stats = {
@@ -511,6 +512,8 @@ def report(vehicle_id):
         fuel_logs=fuel_logs,
         expenses=expenses,
         specs=specs,
+        parts=parts,
+        part_type_labels=dict(PART_TYPES),
         stats=stats,
         user=current_user,
         branding=branding,

--- a/app/services/uk_fuel_prices.py
+++ b/app/services/uk_fuel_prices.py
@@ -1,0 +1,375 @@
+"""
+UK Fuel Price Scheme Integration
+
+Retailers in the UK government's fuel price transparency scheme publish a
+JSON feed of forecourt prices. This service downloads those feeds, matches
+the forecourts against saved fuel stations (by postcode, then brand or
+proximity) and records the prices into FuelPriceHistory, so the existing
+price history and "Cheapest Fuel" screens work from live data.
+
+Scheme documentation (including the canonical list of retailer feeds):
+https://www.gov.uk/guidance/access-the-latest-fuel-prices-and-forecourt-data-via-api-or-email
+
+The default feed list below reflects the retailers published at the time of
+writing. Retailers join and leave the scheme, so an admin can override the
+list entirely in Settings -> Integrations -> UK Fuel Prices.
+"""
+
+from datetime import date, datetime, timedelta
+from math import asin, cos, radians, sin, sqrt
+
+import requests
+
+from app import db
+from app.models import AppSettings, FuelPriceHistory, FuelStation
+
+# Setting keys
+SETTING_ENABLED = 'uk_fuel_prices_enabled'
+SETTING_FEEDS = 'uk_fuel_feed_urls'
+SETTING_LAST_RUN = 'uk_fuel_prices_last_run'
+
+
+class UKFuelPriceService:
+    """Service for the UK fuel price transparency scheme feeds"""
+
+    #: Retailer name -> feed URL, as published on the gov.uk guidance page.
+    DEFAULT_FEEDS = {
+        'Applegreen': 'https://applegreenstores.com/fuel-prices/data.json',
+        'Asda': 'https://storelocator.asda.com/fuel_prices_data.json',
+        'Ascona Group': 'https://fuelprices.asconagroup.co.uk/newfuel.json',
+        'BP': 'https://www.bp.com/en_gb/united-kingdom/home/fuelprices/fuel_prices_data.json',
+        'Esso Tesco Alliance': 'https://fuelprices.esso.co.uk/electronicfieldsystems/fuelvendor/EssoTescoJSON/data.json',
+        'JET': 'https://jetlocal.co.uk/fuel_prices_data.json',
+        'Morrisons': 'https://www.morrisons.com/fuel-prices/fuel.json',
+        'Moto': 'https://moto-way.com/fuel-price/fuel_prices.json',
+        'Motor Fuel Group': 'https://fuel.motorfuelgroup.com/fuel_prices_data.json',
+        'Rontec': 'https://www.rontec-servicestations.co.uk/fuel-prices/data/fuel_prices_data.json',
+        "Sainsbury's": 'https://api.sainsburys.co.uk/v1/exports/latest/fuel_prices_data.json',
+        'Shell': 'https://www.shell.co.uk/fuel-prices-data.html',
+        'Tesco': 'https://www.tesco.com/fuel_prices/fuel_prices_data.json',
+    }
+
+    #: Scheme fuel codes -> May fuel type strings.
+    FUEL_CODE_MAP = {
+        'E10': 'petrol',
+        'E5': 'petrol_premium',
+        'B7': 'diesel',
+        'SDV': 'diesel_premium',
+    }
+
+    #: A forecourt has to be this close to a saved station's coordinates to
+    #: count as a match when the postcode alone is ambiguous.
+    MATCH_RADIUS_KM = 1.0
+
+    REQUEST_TIMEOUT = 15
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def is_enabled(cls):
+        """Whether the integration has been switched on by an admin"""
+        return AppSettings.get(SETTING_ENABLED, 'false') == 'true'
+
+    @classmethod
+    def get_feeds(cls):
+        """Return the retailer name -> feed URL mapping in use.
+
+        Admins can override the built-in list with one feed per line, each
+        either `Name|https://...` or a bare URL.
+        """
+        custom = (AppSettings.get(SETTING_FEEDS) or '').strip()
+        if not custom:
+            return dict(cls.DEFAULT_FEEDS)
+
+        feeds = {}
+        for line in custom.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '|' in line:
+                name, _, url = line.partition('|')
+                name, url = name.strip(), url.strip()
+            else:
+                name, url = line, line
+            if url:
+                feeds[name or url] = url
+        return feeds
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def normalise_postcode(postcode):
+        """Uppercase a postcode and strip spaces/punctuation for comparison"""
+        if not postcode:
+            return ''
+        return ''.join(c for c in str(postcode).upper() if c.isalnum())
+
+    @staticmethod
+    def normalise_price(value):
+        """Convert a feed price to pounds per litre.
+
+        Most retailers publish pence (139.9), a few publish pounds (1.399).
+        Anything above 10 is therefore treated as pence.
+        """
+        try:
+            price = float(value)
+        except (TypeError, ValueError):
+            return None
+        if price <= 0:
+            return None
+        if price > 10:
+            price = price / 100
+        return round(price, 3)
+
+    @classmethod
+    def parse_feed(cls, payload, retailer=None):
+        """Parse one retailer feed into a list of forecourt dicts.
+
+        Malformed entries are skipped rather than failing the whole feed.
+        """
+        if not isinstance(payload, dict):
+            return []
+
+        forecourts = []
+        for raw in payload.get('stations') or []:
+            if not isinstance(raw, dict):
+                continue
+
+            prices = {}
+            for code, value in (raw.get('prices') or {}).items():
+                fuel_type = cls.FUEL_CODE_MAP.get(str(code).upper())
+                if not fuel_type:
+                    continue
+                price = cls.normalise_price(value)
+                if price is not None:
+                    prices[fuel_type] = price
+
+            if not prices:
+                continue
+
+            location = raw.get('location') or {}
+            try:
+                latitude = float(location.get('latitude'))
+                longitude = float(location.get('longitude'))
+            except (TypeError, ValueError):
+                latitude = longitude = None
+
+            forecourts.append({
+                'site_id': raw.get('site_id'),
+                'brand': raw.get('brand'),
+                'address': raw.get('address'),
+                'postcode': raw.get('postcode'),
+                'postcode_key': cls.normalise_postcode(raw.get('postcode')),
+                'latitude': latitude,
+                'longitude': longitude,
+                'prices': prices,
+                'retailer': retailer,
+            })
+
+        return forecourts
+
+    @staticmethod
+    def _distance_km(lat1, lon1, lat2, lon2):
+        """Great-circle distance between two points in kilometres"""
+        radius = 6371.0
+        dlat = radians(lat2 - lat1)
+        dlon = radians(lon2 - lon1)
+        a = (
+            sin(dlat / 2) ** 2
+            + cos(radians(lat1)) * cos(radians(lat2)) * sin(dlon / 2) ** 2
+        )
+        return 2 * radius * asin(sqrt(a))
+
+    # ------------------------------------------------------------------
+    # Fetching
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def fetch_forecourts(cls, timeout=None):
+        """Download and parse every configured feed.
+
+        Returns:
+            tuple: (forecourts: list[dict], errors: list[str])
+        """
+        forecourts = []
+        errors = []
+
+        for retailer, url in cls.get_feeds().items():
+            try:
+                response = requests.get(
+                    url,
+                    timeout=timeout or cls.REQUEST_TIMEOUT,
+                    headers={'User-Agent': 'May Vehicle Management'},
+                )
+                if response.status_code != 200:
+                    errors.append(f"{retailer}: HTTP {response.status_code}")
+                    continue
+                payload = response.json()
+            except ValueError:
+                errors.append(f"{retailer}: invalid JSON")
+                continue
+            except requests.exceptions.Timeout:
+                errors.append(f"{retailer}: request timed out")
+                continue
+            except requests.exceptions.RequestException as e:
+                errors.append(f"{retailer}: {e}")
+                continue
+
+            forecourts.extend(cls.parse_feed(payload, retailer))
+
+        return forecourts, errors
+
+    # ------------------------------------------------------------------
+    # Matching and recording
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def match_forecourt(cls, station, forecourts):
+        """Find the forecourt matching a saved station, or None.
+
+        Matching is by postcode first. Where a postcode covers more than one
+        forecourt, the nearest one within MATCH_RADIUS_KM wins, falling back
+        to a brand match and finally to the first candidate.
+        """
+        postcode_key = cls.normalise_postcode(station.postcode)
+        if not postcode_key:
+            return None
+
+        candidates = [f for f in forecourts if f['postcode_key'] == postcode_key]
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+
+        if station.latitude is not None and station.longitude is not None:
+            located = [
+                f for f in candidates
+                if f['latitude'] is not None and f['longitude'] is not None
+            ]
+            if located:
+                nearest = min(located, key=lambda f: cls._distance_km(
+                    station.latitude, station.longitude, f['latitude'], f['longitude']
+                ))
+                distance = cls._distance_km(
+                    station.latitude, station.longitude,
+                    nearest['latitude'], nearest['longitude'],
+                )
+                if distance <= cls.MATCH_RADIUS_KM:
+                    return nearest
+
+        if station.brand:
+            brand = station.brand.strip().lower()
+            for candidate in candidates:
+                if (candidate.get('brand') or '').strip().lower() == brand:
+                    return candidate
+
+        return candidates[0]
+
+    @classmethod
+    def record_prices(cls, station, forecourt, on_date=None):
+        """Store today's prices for a station, one row per fuel type.
+
+        Re-running on the same day updates the existing rows instead of
+        piling up duplicates, so the history stays one entry per day.
+        Nothing is committed here; the caller commits.
+
+        Returns:
+            int: number of rows created or updated
+        """
+        on_date = on_date or date.today()
+        changed = 0
+
+        for fuel_type, price in forecourt['prices'].items():
+            existing = FuelPriceHistory.query.filter_by(
+                station_id=station.id,
+                date=on_date,
+                fuel_type=fuel_type,
+            ).first()
+
+            if existing:
+                if existing.price_per_unit != price:
+                    existing.price_per_unit = price
+                    changed += 1
+                continue
+
+            db.session.add(FuelPriceHistory(
+                station_id=station.id,
+                user_id=station.user_id,
+                date=on_date,
+                fuel_type=fuel_type,
+                price_per_unit=price,
+            ))
+            changed += 1
+
+        return changed
+
+    @classmethod
+    def refresh_prices(cls, stations=None, timeout=None):
+        """Pull live prices for saved stations.
+
+        Args:
+            stations: stations to update, or None for every saved station
+            timeout: per-feed request timeout
+
+        Returns:
+            dict: {matched, unmatched, skipped, prices, errors}
+        """
+        if stations is None:
+            stations = FuelStation.query.all()
+
+        stats = {
+            'matched': 0,
+            'unmatched': 0,
+            'skipped': 0,
+            'prices': 0,
+            'errors': [],
+        }
+
+        # Stations without a postcode can't be matched to a forecourt.
+        matchable = [s for s in stations if cls.normalise_postcode(s.postcode)]
+        stats['skipped'] = len(stations) - len(matchable)
+        if not matchable:
+            return stats
+
+        forecourts, errors = cls.fetch_forecourts(timeout=timeout)
+        stats['errors'] = errors
+        if not forecourts:
+            stats['unmatched'] = len(matchable)
+            return stats
+
+        for station in matchable:
+            forecourt = cls.match_forecourt(station, forecourts)
+            if not forecourt:
+                stats['unmatched'] += 1
+                continue
+            stats['matched'] += 1
+            stats['prices'] += cls.record_prices(station, forecourt)
+
+        db.session.commit()
+        AppSettings.set(SETTING_LAST_RUN, datetime.utcnow().isoformat())
+
+        return stats
+
+    @classmethod
+    def refresh_if_due(cls, min_interval_hours=6):
+        """Refresh prices from the background scheduler, at most every N hours.
+
+        Returns the refresh stats, or None when disabled or not yet due.
+        """
+        if not cls.is_enabled():
+            return None
+
+        last_run = AppSettings.get(SETTING_LAST_RUN)
+        if last_run:
+            try:
+                previous = datetime.fromisoformat(last_run)
+            except ValueError:
+                previous = None
+            if previous and datetime.utcnow() - previous < timedelta(hours=min_interval_hours):
+                return None
+
+        return cls.refresh_prices()

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -855,6 +855,28 @@
                             <span class="mt-3 inline-flex items-center px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-600 text-gray-600 dark:text-gray-400 dark:bg-gray-700 dark:text-gray-400 rounded">{{ _('Not configured') }}</span>
                             {% endif %}
                         </button>
+
+                        <!-- UK Fuel Prices Card (Admin Only) -->
+                        <button type="button" onclick="showIntegration('uk-fuel')"
+                                class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 text-left hover:shadow-md hover:border-primary-300 border-2 border-transparent transition-all">
+                            <div class="flex items-center mb-3">
+                                <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-green-100 dark:bg-green-900 flex items-center justify-center">
+                                    <svg class="h-6 w-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                                    </svg>
+                                </div>
+                                <div class="ml-3">
+                                    <h3 class="text-sm font-medium text-gray-900 dark:text-white">{{ _('UK Fuel Prices') }}</h3>
+                                    <span class="px-1.5 py-0.5 text-xs font-medium bg-amber-100 text-amber-800 rounded">{{ _('Admin') }}</span>
+                                </div>
+                            </div>
+                            <p class="text-sm text-gray-500 dark:text-gray-400">{{ _('Pull live forecourt prices for saved stations') }}</p>
+                            {% if uk_fuel_settings.enabled %}
+                            <span class="mt-3 inline-flex items-center px-2 py-0.5 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 rounded">{{ _('Enabled') }}</span>
+                            {% else %}
+                            <span class="mt-3 inline-flex items-center px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-gray-600 text-gray-600 dark:text-gray-400 dark:bg-gray-700 dark:text-gray-400 rounded">{{ _('Disabled') }}</span>
+                            {% endif %}
+                        </button>
                         {% endif %}
                     </div>
                 </div>
@@ -1183,6 +1205,79 @@
                                         <button type="submit"
                                                 class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
                                             {{ _('Save Tessie Settings') }}
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- UK Fuel Prices Integration Detail -->
+                <div id="integration-uk-fuel" class="integration-detail hidden">
+                    <div class="mb-6">
+                        <button type="button" onclick="hideIntegration()" class="inline-flex items-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-4">
+                            <svg class="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                            </svg>
+                            {{ _('Back to Integrations') }}
+                        </button>
+                    </div>
+
+                    <div class="bg-white dark:bg-gray-800 shadow rounded-lg divide-y divide-gray-200 dark:divide-gray-700">
+                        <div class="p-6">
+                            <div class="flex items-center">
+                                <div class="flex-shrink-0 w-12 h-12 rounded-lg bg-green-100 dark:bg-green-900 flex items-center justify-center">
+                                    <svg class="h-7 w-7 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                                    </svg>
+                                </div>
+                                <div class="ml-4">
+                                    <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('UK Fuel Prices') }}</h2>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ _('Pull live forecourt prices for saved stations') }}</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="p-6">
+                            <div class="space-y-4">
+                                <p class="text-sm text-gray-600 dark:text-gray-300">
+                                    {{ _('UK retailers publish forecourt prices under the government fuel price transparency scheme. May matches your saved stations to those forecourts by postcode and records the prices, so price history and Cheapest Fuel stay up to date without manual entry.') }}
+                                </p>
+
+                                <div class="p-4 bg-blue-50 dark:bg-blue-900/30 rounded-lg">
+                                    <h4 class="text-sm font-medium text-blue-800 dark:text-blue-300 mb-2">{{ _('Before you start') }}</h4>
+                                    <ul class="text-sm text-blue-700 dark:text-blue-400 list-disc list-inside space-y-1">
+                                        <li>{{ _('No API key is needed; the feeds are open data') }}</li>
+                                        <li>{{ _('Give each station a postcode so it can be matched to a forecourt') }}</li>
+                                        <li>{{ _('Prices refresh automatically every few hours, or on demand from the Fuel Stations page') }}</li>
+                                        <li>{{ _('See the') }} <a href="https://www.gov.uk/guidance/access-the-latest-fuel-prices-and-forecourt-data-via-api-or-email" target="_blank" class="underline">{{ _('gov.uk guidance') }}</a> {{ _('for the current retailer list') }}</li>
+                                    </ul>
+                                </div>
+
+                                <form method="POST" action="{{ url_for('auth.uk_fuel_settings') }}" class="space-y-4">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <div class="flex items-center">
+                                        <input type="checkbox" name="uk_fuel_prices_enabled" id="uk_fuel_prices_enabled"
+                                               {% if uk_fuel_settings.enabled %}checked{% endif %}
+                                               class="h-4 w-4 text-primary-600 border-gray-300 dark:border-gray-600 rounded focus:ring-primary-500">
+                                        <label for="uk_fuel_prices_enabled" class="ml-2 text-sm text-gray-700 dark:text-gray-300">{{ _('Enable UK fuel price updates') }}</label>
+                                    </div>
+
+                                    <div>
+                                        <label for="uk_fuel_feed_urls" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ _('Retailer feeds (optional)') }}</label>
+                                        <textarea name="uk_fuel_feed_urls" id="uk_fuel_feed_urls" rows="4"
+                                                  placeholder="Retailer name|https://example.co.uk/fuel_prices_data.json"
+                                                  class="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">{{ uk_fuel_settings.feed_urls or '' }}</textarea>
+                                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                            {{ _('One feed per line. Leave blank to use the built-in list (%(count)s retailers).', count=uk_fuel_settings.retailer_count) }}
+                                        </p>
+                                    </div>
+
+                                    <div class="flex justify-end">
+                                        <button type="submit"
+                                                class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
+                                            {{ _('Save UK Fuel Price Settings') }}
                                         </button>
                                     </div>
                                 </form>

--- a/app/templates/stations/index.html
+++ b/app/templates/stations/index.html
@@ -8,6 +8,18 @@
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Your favorite fuel stations') }}</p>
     </div>
     <div class="flex gap-2">
+        {% if uk_fuel_enabled %}
+        <form method="post" action="{{ url_for('stations.refresh_uk_prices') }}">
+            <button type="submit"
+                    class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    title="{{ _('Fetch live prices from UK retailer feeds') }}">
+                <svg class="-ml-1 mr-2 h-5 w-5 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                </svg>
+                {{ _('Update UK Prices') }}
+            </button>
+        </form>
+        {% endif %}
         <a href="{{ url_for('stations.cheapest') }}"
            class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
             <svg class="-ml-1 mr-2 h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/templates/stations/prices.html
+++ b/app/templates/stations/prices.html
@@ -17,8 +17,20 @@
 </div>
 
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between gap-4">
         <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('Price History') }}</h2>
+        {% if uk_fuel_enabled %}
+        <form method="post" action="{{ url_for('stations.refresh_station_uk_prices', station_id=station.id) }}">
+            <button type="submit"
+                    class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    title="{{ _('Fetch live prices from UK retailer feeds') }}">
+                <svg class="-ml-0.5 mr-2 h-4 w-4 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                </svg>
+                {{ _('Update UK Prices') }}
+            </button>
+        </form>
+        {% endif %}
     </div>
 
     {% if prices %}

--- a/app/templates/vehicles/report_pdf.html
+++ b/app/templates/vehicles/report_pdf.html
@@ -313,6 +313,28 @@
     </table>
     {% endif %}
 
+    {% if parts %}
+    <h3>Parts ({{ parts|length }})</h3>
+    <table>
+        <tr>
+            <th style="width: 25%">Part</th>
+            <th style="width: 20%">Type</th>
+            <th>Specification</th>
+            <th class="text-right">Quantity</th>
+            <th>Part Number</th>
+        </tr>
+        {% for part in parts %}
+        <tr>
+            <td>{{ part.name }}</td>
+            <td>{{ part_type_labels.get(part.part_type, part.part_type) if part_type_labels else part.part_type }}</td>
+            <td>{{ part.specification or '-' }}</td>
+            <td class="text-right">{% if part.quantity %}{{ part.quantity }}{% if part.unit %} {{ part.unit }}{% endif %}{% else %}-{% endif %}</td>
+            <td>{{ part.part_number or '-' }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+
     {% if vehicle.notes %}
     <div class="notes">
         <div class="notes-title">Notes</div>

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.28.0'
+APP_VERSION = '0.29.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_uk_fuel_prices.py
+++ b/tests/test_uk_fuel_prices.py
@@ -1,0 +1,412 @@
+"""Tests for the UK fuel price scheme integration (#258)."""
+
+from datetime import date
+
+import pytest
+
+from app import db
+from app.models import AppSettings, FuelPriceHistory, FuelStation
+from app.services import uk_fuel_prices as ukfp
+from app.services.uk_fuel_prices import (
+    SETTING_ENABLED,
+    SETTING_FEEDS,
+    SETTING_LAST_RUN,
+    UKFuelPriceService,
+)
+
+
+FEED_PAYLOAD = {
+    'last_updated': '01/03/2026 08:00:00',
+    'stations': [
+        {
+            'site_id': 'A1',
+            'brand': 'SHELL',
+            'address': '123 Main St',
+            'postcode': 'SW1A 1AA',
+            'location': {'latitude': '51.5010', 'longitude': '-0.1416'},
+            'prices': {'E10': 139.9, 'B7': 145.9, 'E5': 149.9, 'LPG': 89.9},
+        },
+        {
+            'site_id': 'B2',
+            'brand': 'BP',
+            'address': '9 Other Rd',
+            'postcode': 'M1 1AA',
+            'location': {'latitude': 53.4808, 'longitude': -2.2426},
+            'prices': {'E10': 1.359},
+        },
+    ],
+}
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError('no json')
+        return self._payload
+
+
+@pytest.fixture
+def enabled_single_feed(app):
+    """Enable the integration with one feed URL."""
+    AppSettings.set(SETTING_ENABLED, 'true')
+    AppSettings.set(SETTING_FEEDS, "Test Retailer|https://example.test/fuel.json")
+    return 'https://example.test/fuel.json'
+
+
+@pytest.fixture
+def uk_station(app, test_user):
+    station = FuelStation(
+        user_id=test_user.id,
+        name='Shell Westminster',
+        brand='Shell',
+        address='123 Main St',
+        city='London',
+        postcode='sw1a1aa',
+    )
+    db.session.add(station)
+    db.session.commit()
+    return station
+
+
+@pytest.fixture
+def fake_feed(monkeypatch):
+    """Serve FEED_PAYLOAD to every requests.get call."""
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        return FakeResponse(FEED_PAYLOAD)
+
+    monkeypatch.setattr(ukfp.requests, 'get', fake_get)
+    return calls
+
+
+class TestConfiguration:
+    def test_disabled_by_default(self, app):
+        assert UKFuelPriceService.is_enabled() is False
+
+    def test_enabled_when_set(self, app):
+        AppSettings.set(SETTING_ENABLED, 'true')
+        assert UKFuelPriceService.is_enabled() is True
+
+    def test_default_feeds_used_when_no_override(self, app):
+        assert UKFuelPriceService.get_feeds() == UKFuelPriceService.DEFAULT_FEEDS
+
+    def test_custom_feeds_override_defaults(self, app):
+        AppSettings.set(SETTING_FEEDS, (
+            "Retailer One|https://one.test/data.json\n"
+            "\n"
+            "# a comment\n"
+            "https://two.test/data.json\n"
+        ))
+        feeds = UKFuelPriceService.get_feeds()
+        assert feeds == {
+            'Retailer One': 'https://one.test/data.json',
+            'https://two.test/data.json': 'https://two.test/data.json',
+        }
+
+
+class TestParsing:
+    def test_normalise_postcode(self):
+        assert UKFuelPriceService.normalise_postcode(' sw1a 1aa ') == 'SW1A1AA'
+        assert UKFuelPriceService.normalise_postcode(None) == ''
+
+    def test_normalise_price_from_pence(self):
+        assert UKFuelPriceService.normalise_price(139.9) == 1.399
+
+    def test_normalise_price_already_in_pounds(self):
+        assert UKFuelPriceService.normalise_price(1.359) == 1.359
+
+    def test_normalise_price_rejects_junk(self):
+        assert UKFuelPriceService.normalise_price('n/a') is None
+        assert UKFuelPriceService.normalise_price(None) is None
+        assert UKFuelPriceService.normalise_price(0) is None
+
+    def test_parse_feed_maps_fuel_codes(self):
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD, 'Test Retailer')
+        assert len(forecourts) == 2
+        first = forecourts[0]
+        assert first['prices'] == {
+            'petrol': 1.399,
+            'diesel': 1.459,
+            'petrol_premium': 1.499,
+        }
+        assert first['postcode_key'] == 'SW1A1AA'
+        assert first['latitude'] == pytest.approx(51.5010)
+        assert first['retailer'] == 'Test Retailer'
+
+    def test_parse_feed_skips_entries_without_known_prices(self):
+        payload = {'stations': [
+            {'postcode': 'AB1 2CD', 'prices': {'XYZ': 100.0}},
+            {'postcode': 'AB1 2CD', 'prices': {}},
+            'not a dict',
+        ]}
+        assert UKFuelPriceService.parse_feed(payload) == []
+
+    def test_parse_feed_handles_bad_payload(self):
+        assert UKFuelPriceService.parse_feed(None) == []
+        assert UKFuelPriceService.parse_feed({}) == []
+
+    def test_parse_feed_tolerates_missing_location(self):
+        payload = {'stations': [
+            {'postcode': 'AB1 2CD', 'prices': {'E10': 140.0}},
+        ]}
+        forecourt = UKFuelPriceService.parse_feed(payload)[0]
+        assert forecourt['latitude'] is None
+        assert forecourt['longitude'] is None
+
+
+class TestFetching:
+    def test_fetch_collects_all_feeds(self, app, enabled_single_feed, fake_feed):
+        forecourts, errors = UKFuelPriceService.fetch_forecourts()
+        assert errors == []
+        assert len(forecourts) == 2
+        assert fake_feed == ['https://example.test/fuel.json']
+
+    def test_fetch_records_http_errors(self, app, enabled_single_feed, monkeypatch):
+        monkeypatch.setattr(
+            ukfp.requests, 'get', lambda url, **kw: FakeResponse(None, status_code=503)
+        )
+        forecourts, errors = UKFuelPriceService.fetch_forecourts()
+        assert forecourts == []
+        assert errors == ['Test Retailer: HTTP 503']
+
+    def test_fetch_records_invalid_json(self, app, enabled_single_feed, monkeypatch):
+        monkeypatch.setattr(ukfp.requests, 'get', lambda url, **kw: FakeResponse(None))
+        forecourts, errors = UKFuelPriceService.fetch_forecourts()
+        assert forecourts == []
+        assert errors == ['Test Retailer: invalid JSON']
+
+    def test_fetch_records_connection_errors(self, app, enabled_single_feed, monkeypatch):
+        def boom(url, **kwargs):
+            raise ukfp.requests.exceptions.Timeout()
+
+        monkeypatch.setattr(ukfp.requests, 'get', boom)
+        forecourts, errors = UKFuelPriceService.fetch_forecourts()
+        assert forecourts == []
+        assert errors == ['Test Retailer: request timed out']
+
+
+class TestMatching:
+    def test_matches_on_postcode_ignoring_spacing(self, app, uk_station):
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD)
+        match = UKFuelPriceService.match_forecourt(uk_station, forecourts)
+        assert match['site_id'] == 'A1'
+
+    def test_no_match_without_postcode(self, app, uk_station):
+        uk_station.postcode = None
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD)
+        assert UKFuelPriceService.match_forecourt(uk_station, forecourts) is None
+
+    def test_no_match_for_unknown_postcode(self, app, uk_station):
+        uk_station.postcode = 'ZZ99 9ZZ'
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD)
+        assert UKFuelPriceService.match_forecourt(uk_station, forecourts) is None
+
+    def test_shared_postcode_resolved_by_brand(self, app, test_user):
+        station = FuelStation(
+            user_id=test_user.id, name='Esso Twin', brand='esso', postcode='AB1 2CD'
+        )
+        db.session.add(station)
+        db.session.commit()
+        forecourts = UKFuelPriceService.parse_feed({'stations': [
+            {'site_id': 'X', 'brand': 'BP', 'postcode': 'AB1 2CD',
+             'prices': {'E10': 140.0}},
+            {'site_id': 'Y', 'brand': 'ESSO', 'postcode': 'AB1 2CD',
+             'prices': {'E10': 141.0}},
+        ]})
+        match = UKFuelPriceService.match_forecourt(station, forecourts)
+        assert match['site_id'] == 'Y'
+
+    def test_shared_postcode_resolved_by_proximity(self, app, test_user):
+        station = FuelStation(
+            user_id=test_user.id, name='Corner Garage', postcode='AB1 2CD',
+            latitude=51.5010, longitude=-0.1416,
+        )
+        db.session.add(station)
+        db.session.commit()
+        forecourts = UKFuelPriceService.parse_feed({'stations': [
+            {'site_id': 'far', 'postcode': 'AB1 2CD', 'prices': {'E10': 140.0},
+             'location': {'latitude': 53.4808, 'longitude': -2.2426}},
+            {'site_id': 'near', 'postcode': 'AB1 2CD', 'prices': {'E10': 141.0},
+             'location': {'latitude': 51.5012, 'longitude': -0.1418}},
+        ]})
+        match = UKFuelPriceService.match_forecourt(station, forecourts)
+        assert match['site_id'] == 'near'
+
+
+class TestRefreshPrices:
+    def test_refresh_records_prices(self, app, enabled_single_feed, fake_feed, uk_station):
+        stats = UKFuelPriceService.refresh_prices()
+        assert stats['matched'] == 1
+        assert stats['prices'] == 3
+        assert stats['errors'] == []
+
+        entries = FuelPriceHistory.query.filter_by(station_id=uk_station.id).all()
+        assert {e.fuel_type for e in entries} == {'petrol', 'diesel', 'petrol_premium'}
+        petrol = next(e for e in entries if e.fuel_type == 'petrol')
+        assert petrol.price_per_unit == 1.399
+        assert petrol.date == date.today()
+        assert petrol.user_id == uk_station.user_id
+
+    def test_refresh_is_idempotent_within_a_day(self, app, enabled_single_feed,
+                                                fake_feed, uk_station):
+        UKFuelPriceService.refresh_prices()
+        second = UKFuelPriceService.refresh_prices()
+        assert second['prices'] == 0
+        assert FuelPriceHistory.query.filter_by(station_id=uk_station.id).count() == 3
+
+    def test_refresh_updates_a_changed_price(self, app, enabled_single_feed,
+                                             fake_feed, uk_station):
+        UKFuelPriceService.refresh_prices()
+        entry = FuelPriceHistory.query.filter_by(
+            station_id=uk_station.id, fuel_type='petrol'
+        ).one()
+        entry.price_per_unit = 1.0
+        db.session.commit()
+
+        stats = UKFuelPriceService.refresh_prices()
+        assert stats['prices'] == 1
+        db.session.refresh(entry)
+        assert entry.price_per_unit == 1.399
+
+    def test_refresh_skips_stations_without_postcode(self, app, enabled_single_feed,
+                                                     fake_feed, test_user):
+        station = FuelStation(user_id=test_user.id, name='Nowhere')
+        db.session.add(station)
+        db.session.commit()
+
+        stats = UKFuelPriceService.refresh_prices()
+        assert stats['skipped'] == 1
+        assert stats['matched'] == 0
+        assert FuelPriceHistory.query.count() == 0
+
+    def test_refresh_counts_unmatched_stations(self, app, enabled_single_feed,
+                                               fake_feed, test_user):
+        station = FuelStation(user_id=test_user.id, name='Elsewhere', postcode='ZZ99 9ZZ')
+        db.session.add(station)
+        db.session.commit()
+
+        stats = UKFuelPriceService.refresh_prices()
+        assert stats['unmatched'] == 1
+        assert stats['prices'] == 0
+
+    def test_refresh_records_last_run(self, app, enabled_single_feed, fake_feed, uk_station):
+        assert AppSettings.get(SETTING_LAST_RUN) is None
+        UKFuelPriceService.refresh_prices()
+        assert AppSettings.get(SETTING_LAST_RUN)
+
+    def test_refresh_survives_a_dead_feed(self, app, uk_station, monkeypatch):
+        AppSettings.set(SETTING_ENABLED, 'true')
+        AppSettings.set(SETTING_FEEDS, (
+            "Dead|https://dead.test/data.json\n"
+            "Live|https://live.test/data.json"
+        ))
+
+        def fake_get(url, **kwargs):
+            if 'dead' in url:
+                raise ukfp.requests.exceptions.ConnectionError('nope')
+            return FakeResponse(FEED_PAYLOAD)
+
+        monkeypatch.setattr(ukfp.requests, 'get', fake_get)
+
+        stats = UKFuelPriceService.refresh_prices()
+        assert stats['matched'] == 1
+        assert len(stats['errors']) == 1
+
+
+class TestRefreshIfDue:
+    def test_skipped_when_disabled(self, app, fake_feed, uk_station):
+        assert UKFuelPriceService.refresh_if_due() is None
+        assert fake_feed == []
+
+    def test_runs_when_never_run_before(self, app, enabled_single_feed, fake_feed, uk_station):
+        stats = UKFuelPriceService.refresh_if_due()
+        assert stats['matched'] == 1
+
+    def test_skipped_when_run_recently(self, app, enabled_single_feed, fake_feed, uk_station):
+        UKFuelPriceService.refresh_if_due()
+        fake_feed.clear()
+        assert UKFuelPriceService.refresh_if_due() is None
+        assert fake_feed == []
+
+    def test_runs_again_when_last_run_is_unreadable(self, app, enabled_single_feed,
+                                                    fake_feed, uk_station):
+        AppSettings.set(SETTING_LAST_RUN, 'not-a-timestamp')
+        assert UKFuelPriceService.refresh_if_due() is not None
+
+
+class TestStationRoutes:
+    def test_refresh_requires_auth(self, client):
+        resp = client.post('/stations/uk-prices/refresh', follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_refresh_rejected_when_disabled(self, auth_client, fake_feed, uk_station):
+        resp = auth_client.post('/stations/uk-prices/refresh', follow_redirects=True)
+        assert resp.status_code == 200
+        assert FuelPriceHistory.query.count() == 0
+        assert fake_feed == []
+
+    def test_refresh_all_stations(self, auth_client, enabled_single_feed,
+                                  fake_feed, uk_station):
+        resp = auth_client.post('/stations/uk-prices/refresh', follow_redirects=True)
+        assert resp.status_code == 200
+        assert FuelPriceHistory.query.filter_by(station_id=uk_station.id).count() == 3
+
+    def test_refresh_single_station(self, auth_client, enabled_single_feed,
+                                    fake_feed, uk_station, test_user):
+        other = FuelStation(user_id=test_user.id, name='Other', postcode='M1 1AA')
+        db.session.add(other)
+        db.session.commit()
+
+        resp = auth_client.post(
+            f'/stations/{uk_station.id}/uk-prices/refresh', follow_redirects=True
+        )
+        assert resp.status_code == 200
+        assert FuelPriceHistory.query.filter_by(station_id=uk_station.id).count() == 3
+        assert FuelPriceHistory.query.filter_by(station_id=other.id).count() == 0
+
+    def test_refresh_single_station_404(self, auth_client, enabled_single_feed):
+        resp = auth_client.post('/stations/9999/uk-prices/refresh')
+        assert resp.status_code == 404
+
+    def test_button_hidden_when_disabled(self, auth_client, uk_station):
+        resp = auth_client.get('/stations/')
+        assert b'Update UK Prices' not in resp.data
+
+    def test_button_shown_when_enabled(self, auth_client, enabled_single_feed, uk_station):
+        resp = auth_client.get('/stations/')
+        assert b'Update UK Prices' in resp.data
+
+
+class TestSettingsRoute:
+    def test_requires_admin(self, auth_client):
+        resp = auth_client.post('/auth/uk-fuel-settings', data={
+            'uk_fuel_prices_enabled': 'on',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        assert UKFuelPriceService.is_enabled() is False
+
+    def test_admin_can_enable(self, admin_client):
+        resp = admin_client.post('/auth/uk-fuel-settings', data={
+            'uk_fuel_prices_enabled': 'on',
+            'uk_fuel_feed_urls': 'Test|https://example.test/fuel.json',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        assert UKFuelPriceService.is_enabled() is True
+        assert UKFuelPriceService.get_feeds() == {'Test': 'https://example.test/fuel.json'}
+
+    def test_admin_can_disable(self, admin_client):
+        AppSettings.set(SETTING_ENABLED, 'true')
+        admin_client.post('/auth/uk-fuel-settings', data={}, follow_redirects=True)
+        assert UKFuelPriceService.is_enabled() is False
+
+    def test_settings_page_renders_panel(self, admin_client):
+        resp = admin_client.get('/auth/settings')
+        assert resp.status_code == 200
+        assert b'UK Fuel Prices' in resp.data

--- a/tests/test_vehicles.py
+++ b/tests/test_vehicles.py
@@ -425,3 +425,105 @@ class TestVehicleReportReceipts:
         assert resp.status_code == 200
         assert 'data:image/png;base64,' not in rendered['html']
         assert 'Receipts' not in rendered['html']
+
+
+class TestVehicleReportParts:
+    """#235 — the parts list appears in the vehicle PDF report."""
+
+    @staticmethod
+    def _add_part(vehicle, user, name='Engine Oil', part_type='oil', **kwargs):
+        from app.models import VehiclePart
+        part = VehiclePart(vehicle_id=vehicle.id, user_id=user.id,
+                           name=name, part_type=part_type, **kwargs)
+        db.session.add(part)
+        db.session.commit()
+        return part
+
+    @staticmethod
+    def _render(app, vehicle, user, **overrides):
+        from datetime import datetime
+        from flask import render_template
+        from app.models import AppSettings
+
+        kwargs = dict(
+            vehicle=vehicle, fuel_logs=[], expenses=[], specs=[], parts=[],
+            part_type_labels={},
+            stats={'total_fuel_cost': 0, 'total_expense_cost': 0, 'total_cost': 0,
+                   'total_distance': 0, 'avg_consumption': None,
+                   'fuel_logs_count': 0, 'expenses_count': 0},
+            user=user, branding=AppSettings.get_all_branding(),
+            include_receipts=False, receipts=[], receipts_omitted=[],
+            generated_at=datetime(2024, 3, 1, 12, 0),
+        )
+        kwargs.update(overrides)
+        with app.test_request_context():
+            return render_template('vehicles/report_pdf.html', **kwargs)
+
+    @staticmethod
+    def _fake_weasyprint(monkeypatch):
+        """Swap WeasyPrint for a stub and return the dict it records HTML into."""
+        import sys
+        import types
+
+        rendered = {}
+
+        class FakeHTML:
+            def __init__(self, string, base_url=None):
+                rendered['html'] = string
+
+            def write_pdf(self):
+                return b'%PDF-fake'
+
+        fake = types.ModuleType('weasyprint')
+        fake.HTML = FakeHTML
+        fake.CSS = object
+        monkeypatch.setitem(sys.modules, 'weasyprint', fake)
+        return rendered
+
+    def test_template_renders_parts_table(self, app, sample_vehicle, test_user):
+        part = self._add_part(sample_vehicle, test_user, specification='10W-40',
+                              quantity=3.5, unit='L', part_number='ABC-123')
+
+        html = self._render(app, sample_vehicle, test_user, parts=[part],
+                            part_type_labels={'oil': 'Engine Oil'})
+
+        assert 'Parts (1)' in html
+        assert '10W-40' in html
+        assert '3.5 L' in html
+        assert 'ABC-123' in html
+
+    def test_template_falls_back_to_raw_part_type(self, app, sample_vehicle, test_user):
+        part = self._add_part(sample_vehicle, test_user, part_type='custom')
+
+        html = self._render(app, sample_vehicle, test_user, parts=[part])
+
+        assert 'custom' in html
+
+    def test_template_omits_parts_section_when_none(self, app, sample_vehicle, test_user):
+        html = self._render(app, sample_vehicle, test_user)
+
+        assert 'Parts (' not in html
+
+    def test_report_route_includes_parts(self, auth_client, app, tmp_path,
+                                         monkeypatch, sample_vehicle, test_user):
+        rendered = self._fake_weasyprint(monkeypatch)
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        self._add_part(sample_vehicle, test_user, name='Oil Filter',
+                       part_type='oil_filter', part_number='KN-204')
+
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}/report')
+
+        assert resp.status_code == 200
+        assert resp.mimetype == 'application/pdf'
+        assert 'Oil Filter' in rendered['html']
+        assert 'KN-204' in rendered['html']
+
+    def test_report_route_omits_parts_section_when_none(self, auth_client, app, tmp_path,
+                                                        monkeypatch, sample_vehicle):
+        rendered = self._fake_weasyprint(monkeypatch)
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}/report')
+
+        assert resp.status_code == 200
+        assert 'Parts (' not in rendered['html']


### PR DESCRIPTION
## 0.29.0

Two feature requests from the tracker, both UK-flavoured.

### Features

- **UK fuel prices for saved stations.** An admin switches the integration on in
  **Settings → Integrations → UK Fuel Prices**; saved stations are then matched to
  forecourts by postcode (coordinates, then brand, break ties) and their prices
  recorded, feeding the existing price history and Cheapest Fuel screens. Refreshes
  run in the background every six hours, or on demand with the **Update UK Prices**
  button on the Fuel Stations page or a single station's price history. Prices are
  stored one row per station, fuel type and day, so repeat refreshes update the day's
  entry rather than piling up duplicates; premium grades are kept separate. No API key
  is needed, and the built-in retailer feed list can be overridden from the settings
  panel. ([#258](https://github.com/dannymcc/may/issues/258))
- **Parts and consumables in the vehicle PDF report.** The report now lists each part
  with its type, specification, quantity and part number, alongside the specifications,
  fuel logs and expenses already there. Vehicles with no parts recorded look the same as
  before. ([#235](https://github.com/dannymcc/may/issues/235))

### Fixes

None in this release.

### Other

- README gains a UK fuel prices entry in the feature list, to go with the integration
  section added alongside the feature itself.
- The UK fuel prices changelog entry had been filed under 0.28.0, which had already been
  cut; it now sits under 0.29.0 where it shipped.

Thanks to everyone who raised these on the tracker.
