### PR TITLE
Release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file starts at 0.28.0. Notes for earlier releases are on the
 [GitHub releases page](https://github.com/dannymcc/may/releases).
 
-## [0.29.0] - 2026-08-23
+## [0.30.0] - 2026-08-23
 
 ### Added
 
@@ -21,6 +21,39 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   overwritten, and records already present are skipped rather than duplicated.
   A preview showing exactly what will be added is displayed before anything is
   written. ([#265](https://github.com/dannymcc/may/issues/265))
+- A photo gallery for vehicles. The vehicle page has a "Photos" section that
+  takes as many photos as you like, several at a time; any of them can be made
+  the main photo shown on the dashboard and vehicle list, and the header image
+  steps through the rest with left and right arrows. Photos are stored as
+  attachments against the vehicle, so they are already covered by the full
+  backup export. Deleting a vehicle removes its photos; deleting the main one
+  falls back to another photo, or clears the image if none are left.
+  ([#147](https://github.com/dannymcc/may/issues/147))
+
+### Changed
+
+- Saved fuel stations now remember which forecourt a live price feed matched
+  them to, rather than re-deriving it from postcode and address on every
+  refresh. A station therefore keeps reporting the same forecourt after its
+  postcode is edited, and a forecourt that drops out of the feed is reported as
+  unmatched instead of quietly resolving to a different one. This is
+  groundwork for the Tankerkönig integration; live German prices are not
+  available yet. ([#155](https://github.com/dannymcc/may/issues/155))
+
+### Fixed
+
+- Hybrid fill-ups no longer appear as a "hybrid" series in the fuel station
+  price charts. Hybrid is how a vehicle is driven, not what goes in the tank,
+  so a fill-up is now recorded against petrol by default; the fuel type
+  selector on the fuel form is offered for hybrids and plug-in hybrids so
+  diesel hybrid owners can pick diesel instead. Changing a saved log's fuel
+  type now moves its price history row to match. Existing price history is
+  left as it stands. ([#268](https://github.com/dannymcc/may/issues/268))
+
+## [0.29.0] - 2026-08-23
+
+### Added
+
 - UK fuel prices. Admins can switch on the government fuel price feeds in
   Settings → Integrations → UK Fuel Prices; saved stations are then matched to
   forecourts by postcode and their prices recorded, feeding the existing price
@@ -33,16 +66,6 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   specification, quantity and part number, alongside the existing
   specifications, fuel logs and expenses. Vehicles with no parts recorded are
   unchanged. ([#235](https://github.com/dannymcc/may/issues/235))
-
-### Fixed
-
-- Hybrid fill-ups no longer appear as a "hybrid" series in the fuel station
-  price charts. Hybrid is how a vehicle is driven, not what goes in the tank,
-  so a fill-up is now recorded against petrol by default; the fuel type
-  selector on the fuel form is offered for hybrids and plug-in hybrids so
-  diesel hybrid owners can pick diesel instead. Changing a saved log's fuel
-  type now moves its price history row to match. Existing price history is
-  left as it stands. ([#268](https://github.com/dannymcc/may/issues/268))
 
 ## [0.28.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   specifications, fuel logs and expenses. Vehicles with no parts recorded are
   unchanged. ([#235](https://github.com/dannymcc/may/issues/235))
 
+### Fixed
+
+- Hybrid fill-ups no longer appear as a "hybrid" series in the fuel station
+  price charts. Hybrid is how a vehicle is driven, not what goes in the tank,
+  so a fill-up is now recorded against petrol by default; the fuel type
+  selector on the fuel form is offered for hybrids and plug-in hybrids so
+  diesel hybrid owners can pick diesel instead. Changing a saved log's fuel
+  type now moves its price history row to match. Existing price history is
+  left as it stands. ([#268](https://github.com/dannymcc/may/issues/268))
+
 ## [0.28.0] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ### Added
 
+- Restoring a May backup. Settings → Integrations → Import Data now has a
+  "Restore May Backup" option that accepts both the JSON export and the full
+  backup ZIP produced by the export page, so data can be moved from an old
+  instance into a new one. Documents, attachments and vehicle images come
+  across from a full backup ZIP; a JSON export carries the records only.
+  The restore always merges into the signed-in account: nothing is deleted or
+  overwritten, and records already present are skipped rather than duplicated.
+  A preview showing exactly what will be added is displayed before anything is
+  written. ([#265](https://github.com/dannymcc/may/issues/265))
 - UK fuel prices. Admins can switch on the government fuel price feeds in
   Settings → Integrations → UK Fuel Prices; saved stations are then matched to
   forecourts by postcode and their prices recorded, feeding the existing price

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Add and manage your vehicles with detailed information:
 - Fuel type and tank capacity
 - Custom specifications and notes
 - Photo upload support
+- **Photo Gallery**: Upload as many photos per vehicle as you like from the "Photos" section on the vehicle page. Any of them can be set as the main photo — the one shown on the dashboard and vehicle list — and the vehicle page steps through the rest with left/right arrows
 - **Vehicle Sharing**: Mark a vehicle as "Shared" to make it visible and loggable by all users on the instance
 - **Upcoming Maintenance**: Vehicle detail pages show a live panel of scheduled maintenance tasks, with overdue and due-soon alerts
 - **Parts & Consumables**: Collapsible section on the vehicle page remembers your expand/collapse preference per vehicle

--- a/README.md
+++ b/README.md
@@ -284,10 +284,15 @@ needed.
 To use it:
 
 1. An admin enables it in **Settings → Integrations → UK Fuel Prices**.
-2. Give each saved station its postcode — that is what stations are matched on.
-   Where a postcode covers more than one forecourt, coordinates (if set) and
-   then brand break the tie.
-3. Prices refresh in the background every six hours, and on demand with the
+2. Give each saved station its postcode — that is what stations are matched on
+   the first time. Where a postcode covers more than one forecourt, coordinates
+   (if set) and then brand break the tie.
+3. Once a station has been matched, May remembers which forecourt it stands for
+   and goes straight to it on later refreshes, so a station keeps reporting the
+   same forecourt even if its postcode is edited. A remembered forecourt that
+   drops out of the feed is reported as unmatched rather than quietly resolving
+   to a different one.
+4. Prices refresh in the background every six hours, and on demand with the
    **Update UK Prices** button on the Fuel Stations page or on a single
    station's price history.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ Add and manage your vehicles with detailed information:
 - Make, model, year, and registration
 - Fuel type and tank capacity
 - Custom specifications and notes
-- Photo upload support
 - **Photo Gallery**: Upload as many photos per vehicle as you like from the "Photos" section on the vehicle page. Any of them can be set as the main photo — the one shown on the dashboard and vehicle list — and the vehicle page steps through the rest with left/right arrows
 - **Vehicle Sharing**: Mark a vehicle as "Shared" to make it visible and loggable by all users on the instance
 - **Upcoming Maintenance**: Vehicle detail pages show a live panel of scheduled maintenance tasks, with overdue and due-soon alerts
@@ -249,6 +248,21 @@ Configure your preferred notification method:
 - **ntfy**: Free push notifications via ntfy.sh or self-hosted
 - **Pushover**: iOS/Android push notifications
 - **Webhook**: HTTP POST for Home Assistant, Discord, Slack, etc.
+
+### Import & Restore
+**Settings → Integrations → Import Data** holds the import options, including
+**Restore May Backup** for moving data from another May instance:
+
+- It takes either file the export page produces — the JSON export (`.json`) or
+  the full backup (`.zip`). A full backup also brings across documents,
+  attachments and vehicle images; a JSON export carries the records only.
+- The restore merges into the account you are signed in as. Nothing is deleted
+  or overwritten, and records already present are skipped rather than
+  duplicated, so running the same backup twice is harmless.
+- A preview of exactly what will be added is shown before anything is written,
+  and nothing is saved until you confirm it.
+
+Imports from Hammond and Fuelly live in the same place.
 
 ## 🔧 Admin Settings
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Track every fill-up with:
 - Total cost and price per unit
 - Full tank indicator for accurate consumption calculations
 - Automatic MPG/L per 100km calculations
+- Fuel type selection for vehicles that take more than one fuel, including hybrids (petrol or diesel), so station price charts stay grouped by the fuel actually bought
 
 ### Expenses
 Categorize all vehicle-related costs:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Named after James May, completing the trio of Top Gear presenters (alongside [Cl
 - **🌍 Internationalization**: Available in multiple languages (English, German, Spanish, French, and more)
 - **🎨 Custom Branding**: Personalize with your own logo, colors, and app name
 - **🌙 Dark Mode**: Toggle between light and dark themes
-- **📥 Import/Export**: Import from Fuelly CSV, export all data as JSON or CSV
+- **📥 Import/Export**: Restore a May backup (JSON export or full ZIP) into another instance, import from Fuelly CSV, export all data as JSON or CSV
 - **🇬🇧 DVLA Integration**: Look up UK vehicle MOT and tax status automatically
 - **⛽ UK Fuel Prices**: Pull live forecourt prices for your saved UK stations from the government fuel price feeds, no API key needed
 - **📱 PWA Support**: Install as a mobile app with offline capabilities

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -258,6 +258,27 @@ def _run_schema_migrations(app):
                         f'Could not create {kind.lower()} {index_name}: {e}'
                     )
 
+            # Multi-column indexes declared in __table_args__ are not covered
+            # by the per-column pass above.
+            existing_cols = {col['name'] for col in inspector.get_columns(table.name)}
+            for index in table.indexes:
+                if index.name in existing_indexes:
+                    continue
+                index_cols = [c.name for c in index.columns]
+                if len(index_cols) < 2 or not existing_cols.issuperset(index_cols):
+                    continue
+                kind = 'UNIQUE INDEX' if index.unique else 'INDEX'
+                try:
+                    conn.execute(text(
+                        f'CREATE {kind} {index.name} ON {table.name} '
+                        f'({", ".join(index_cols)})'
+                    ))
+                    app.logger.info(f'Created {kind.lower()} {index.name}')
+                except Exception as e:
+                    app.logger.warning(
+                        f'Could not create {kind.lower()} {index.name}: {e}'
+                    )
+
 
 def get_locale():
     """Select the best language for the user"""

--- a/app/models.py
+++ b/app/models.py
@@ -1297,9 +1297,28 @@ class RecurringExpense(db.Model):
         return today <= self.next_due <= today + timedelta(days=days)
 
 
+#: Price sources a station can be linked to. The key is stored in
+#: ``FuelStation.price_source``; the value is a human-readable label.
+PRICE_SOURCES = {
+    'uk_fuel_prices': 'UK Fuel Price Scheme',
+    'tankerkoenig': 'Tankerkönig',
+}
+
+
 class FuelStation(db.Model):
     """Favorite fuel stations"""
     __tablename__ = 'fuel_stations'
+
+    # A station may be linked to at most one forecourt per price source, and
+    # a forecourt to at most one of a user's stations. NULLs compare as
+    # distinct in SQLite, so unlinked stations are unaffected.
+    __table_args__ = (
+        db.Index(
+            'ix_fuel_stations_source_external_id',
+            'user_id', 'price_source', 'external_id',
+            unique=True,
+        ),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
@@ -1324,6 +1343,14 @@ class FuelStation(db.Model):
 
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
+    # Live price provider this station stands for, if any. ``price_source``
+    # is a key from PRICE_SOURCES and ``external_id`` the provider's own id
+    # for the forecourt (a UK scheme site_id, a Tankerkönig station uuid,
+    # ...). Recording identity as stations are matched avoids having to
+    # re-derive it later from addresses and postcodes.
+    price_source = db.Column(db.String(30))
+    external_id = db.Column(db.String(64))
+
     # Relationships
     user = db.relationship('User', backref=db.backref('fuel_stations', lazy='dynamic'))
 
@@ -1331,6 +1358,48 @@ class FuelStation(db.Model):
         """Increment usage counter when station is used"""
         self.times_used = (self.times_used or 0) + 1
         self.last_used = datetime.utcnow()
+
+    @property
+    def price_source_label(self):
+        """Human-readable name of the linked price source, or None"""
+        if not self.price_source:
+            return None
+        return PRICE_SOURCES.get(self.price_source, self.price_source)
+
+    @classmethod
+    def find_by_external_id(cls, user_id, price_source, external_id):
+        """Return the user's station linked to a provider forecourt, or None"""
+        if not price_source or not external_id:
+            return None
+        return cls.query.filter_by(
+            user_id=user_id,
+            price_source=price_source,
+            external_id=str(external_id),
+        ).first()
+
+    def link_price_source(self, price_source, external_id):
+        """Link this station to a provider forecourt if that is unambiguous.
+
+        Does nothing when the station is already linked or when another of
+        the user's stations holds the same identity, so the unique index can
+        never be tripped by a heuristic match.
+
+        Returns:
+            bool: True if the link was recorded
+        """
+        if not price_source or not external_id:
+            return False
+        if self.price_source or self.external_id:
+            return False
+
+        external_id = str(external_id)
+        clash = self.find_by_external_id(self.user_id, price_source, external_id)
+        if clash is not None and clash is not self:
+            return False
+
+        self.price_source = price_source
+        self.external_id = external_id
+        return True
 
 
 class Document(db.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -1037,6 +1037,28 @@ FUEL_TYPES = [
     ('other', _l('Other'))
 ]
 
+# Some vehicle "fuel types" describe how the vehicle is propelled rather than
+# what goes in the tank. Station price history is charted per fuel type, so a
+# hybrid fill-up has to be recorded against the fuel it actually burns (#268).
+# Diesel hybrids are the rarer case, so petrol is the default; owners of one
+# can pick diesel per fill-up with the fuel type selector on the fuel form.
+PROPULSION_TO_FUEL = {
+    'hybrid': 'petrol',
+    'plugin_hybrid': 'petrol',
+}
+
+
+def resolve_price_fuel_type(log_fuel_type, vehicle_fuel_type):
+    """Return the fuel type to record on a station price history row.
+
+    The fuel type chosen on the log wins; otherwise the vehicle's own fuel
+    type is used. Either way a propulsion type is mapped to the fuel it
+    burns so the station price charts only ever show real fuels.
+    """
+    fuel_type = log_fuel_type or vehicle_fuel_type
+    return PROPULSION_TO_FUEL.get(fuel_type, fuel_type) or 'petrol'
+
+
 # Reminder types
 REMINDER_TYPES = [
     ('mot', _l('MOT/Inspection')),

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -2069,6 +2069,8 @@ def export_json():
             'longitude': station.longitude,
             'notes': station.notes,
             'is_favorite': station.is_favorite,
+            'price_source': station.price_source,
+            'external_id': station.external_id,
             'times_used': station.times_used,
             'last_used': station.last_used.isoformat() if station.last_used else None,
             'created_at': station.created_at.isoformat() if station.created_at else None
@@ -2394,6 +2396,8 @@ def export_full_backup():
             'longitude': station.longitude,
             'notes': station.notes,
             'is_favorite': station.is_favorite,
+            'price_source': station.price_source,
+            'external_id': station.external_id,
             'times_used': station.times_used,
             'last_used': station.last_used.isoformat() if station.last_used else None,
             'created_at': station.created_at.isoformat() if station.created_at else None

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -21,6 +21,9 @@ from app.models import (
     TRIP_PURPOSES, CHARGER_TYPES
 )
 from app.services.tessie import TessieService
+from app.services.backup_restore import (
+    BackupError, SECTION_LABELS, describe_backup, read_backup, restore_backup
+)
 from app.utils import parse_decimal
 from flask_babel import gettext as _
 from config import APP_VERSION
@@ -3604,5 +3607,103 @@ def csv_import_execute():
         flash(_('Import failed: %(error)s') % {'error': str(e)}, 'error')
     finally:
         _cleanup_temp_file(temp_file)
+
+    return redirect(url_for('auth.settings') + '#integrations')
+
+
+# =============================================================================
+# May Backup Restore (JSON export or full ZIP backup)
+# =============================================================================
+
+BACKUP_RESTORE_SESSION_KEY = 'backup_restore_temp_file'
+
+
+def _save_backup_upload(file):
+    """Save an uploaded backup to a temp file and return its path."""
+    suffix = '.zip' if (file.filename or '').lower().endswith('.zip') else '.json'
+    tmp_dir = current_app.instance_path if os.path.isdir(current_app.instance_path) else None
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False, dir=tmp_dir) as tmp:
+        file.save(tmp.name)
+        return tmp.name
+
+
+@bp.route('/import/backup')
+@login_required
+def backup_restore_upload():
+    """Backup restore - step 1: upload form."""
+    return render_template('import/backup_upload.html')
+
+
+@bp.route('/import/backup/preview', methods=['POST'])
+@login_required
+def backup_restore_preview():
+    """Backup restore - step 2: show what would be added before anything is written."""
+    if 'file' not in request.files or not request.files['file'].filename:
+        flash(_('No backup file uploaded.'), 'error')
+        return redirect(url_for('api.backup_restore_upload'))
+
+    # Drop any backup left over from an abandoned restore
+    _cleanup_temp_file(session.pop(BACKUP_RESTORE_SESSION_KEY, None))
+
+    tmp_path = _save_backup_upload(request.files['file'])
+
+    try:
+        data, zip_path = read_backup(tmp_path)
+        summary = restore_backup(
+            data, current_user,
+            zip_path=zip_path,
+            upload_folder=current_app.config['UPLOAD_FOLDER'],
+            dry_run=True
+        )
+    except BackupError as e:
+        _cleanup_temp_file(tmp_path)
+        flash(str(e), 'error')
+        return redirect(url_for('api.backup_restore_upload'))
+    except Exception as e:
+        _cleanup_temp_file(tmp_path)
+        logger.error("Backup restore preview failed: %s\n%s", e, traceback.format_exc())
+        flash(_('Could not read that backup: %(error)s') % {'error': e}, 'error')
+        return redirect(url_for('api.backup_restore_upload'))
+
+    session[BACKUP_RESTORE_SESSION_KEY] = tmp_path
+
+    return render_template('import/backup_preview.html',
+                           summary=summary,
+                           section_labels=SECTION_LABELS,
+                           backup_info=describe_backup(data),
+                           is_full_backup=zip_path is not None)
+
+
+@bp.route('/import/backup/execute', methods=['POST'])
+@login_required
+def backup_restore_execute():
+    """Backup restore - step 3: merge the backup into the current account."""
+    tmp_path = session.pop(BACKUP_RESTORE_SESSION_KEY, None)
+
+    if not tmp_path or not os.path.exists(tmp_path):
+        flash(_('The uploaded backup has expired. Please upload it again.'), 'error')
+        return redirect(url_for('api.backup_restore_upload'))
+
+    try:
+        data, zip_path = read_backup(tmp_path)
+        summary = restore_backup(
+            data, current_user,
+            zip_path=zip_path,
+            upload_folder=current_app.config['UPLOAD_FOLDER'],
+            dry_run=False
+        )
+        logger.info("Backup restore finished for user %s: %s added, %s already present",
+                    current_user.id, summary['total_added'], summary['total_skipped'])
+        flash(_('Backup restored: %(added)s records added, %(skipped)s already present and left alone.') % {
+            'added': summary['total_added'], 'skipped': summary['total_skipped']}, 'success')
+    except BackupError as e:
+        flash(str(e), 'error')
+        return redirect(url_for('api.backup_restore_upload'))
+    except Exception as e:
+        db.session.rollback()
+        logger.error("Backup restore failed: %s\n%s", e, traceback.format_exc())
+        flash(_('Restore failed: %(error)s') % {'error': e}, 'error')
+    finally:
+        _cleanup_temp_file(tmp_path)
 
     return redirect(url_for('auth.settings') + '#integrations')

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -6,7 +6,10 @@ from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
 from app import db
 from app.utils import parse_decimal
-from app.models import Vehicle, FuelLog, Attachment, FuelStation, FuelPriceHistory, FUEL_TYPES
+from app.models import (
+    Vehicle, FuelLog, Attachment, FuelStation, FuelPriceHistory, FUEL_TYPES,
+    resolve_price_fuel_type,
+)
 from app.security import (
     validate_file_upload, secure_filename_with_uuid, validate_positive_number,
     get_safe_redirect_url
@@ -131,7 +134,7 @@ def new():
                     user_id=current_user.id,
                     fuel_log_id=log.id,
                     date=log.date,
-                    fuel_type=log.fuel_type or vehicle.fuel_type or 'petrol',
+                    fuel_type=resolve_price_fuel_type(log.fuel_type, vehicle.fuel_type),
                     price_per_unit=log.price_per_unit
                 )
                 db.session.add(price_history)
@@ -240,6 +243,12 @@ def edit(log_id):
             else:
                 existing_entry.price_per_unit = log.price_per_unit
                 existing_entry.date = log.date
+                # Keep the charted fuel type in step with the log (#268):
+                # changing a fill-up from petrol to diesel has to move the
+                # price row onto the diesel series too.
+                existing_entry.fuel_type = resolve_price_fuel_type(
+                    log.fuel_type, log.vehicle.fuel_type
+                )
                 if station_id and existing_entry.station_id != station_id:
                     new_station = FuelStation.query.get(station_id)
                     if new_station:
@@ -259,7 +268,7 @@ def edit(log_id):
                     user_id=current_user.id,
                     fuel_log_id=log.id,
                     date=log.date,
-                    fuel_type=log.fuel_type or log.vehicle.fuel_type or 'petrol',
+                    fuel_type=resolve_price_fuel_type(log.fuel_type, log.vehicle.fuel_type),
                     price_per_unit=log.price_per_unit,
                 ))
                 new_station.increment_usage()
@@ -445,7 +454,7 @@ def quick():
                 user_id=current_user.id,
                 fuel_log_id=log.id,
                 date=log.date,
-                fuel_type=log.fuel_type or vehicle.fuel_type or 'petrol',
+                fuel_type=resolve_price_fuel_type(log.fuel_type, vehicle.fuel_type),
                 price_per_unit=log.price_per_unit,
             ))
             station.increment_usage()

--- a/app/routes/vehicles.py
+++ b/app/routes/vehicles.py
@@ -28,6 +28,42 @@ def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
 
+def _upload_path(filename):
+    return os.path.join(current_app.config['UPLOAD_FOLDER'], filename)
+
+
+def _delete_upload(filename):
+    """Remove an uploaded file, ignoring one that has already gone."""
+    if not filename:
+        return
+    path = _upload_path(filename)
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def _delete_unused_upload(filename):
+    """Remove an uploaded file unless a gallery photo still points at it.
+
+    The main image and the gallery share the uploads folder, and setting a
+    gallery photo as the main image reuses its file (#147), so a file may be
+    referenced by both.
+    """
+    if not filename:
+        return
+    if Attachment.query.filter_by(filename=filename).first():
+        return
+    _delete_upload(filename)
+
+
+def _vehicle_photos(vehicle):
+    """Gallery photos for a vehicle, oldest first (#147)."""
+    return vehicle.attachments.order_by(Attachment.id).all()
+
+
+def _owns_vehicle(vehicle):
+    return vehicle.owner_id == current_user.id or current_user.is_admin
+
+
 @bp.route('/')
 @login_required
 def index():
@@ -191,6 +227,8 @@ def view(vehicle_id):
                            today=today,
                            dvla_configured=dvla_configured,
                            tessie_configured=tessie_configured,
+                           photos=_vehicle_photos(vehicle),
+                           can_edit=_owns_vehicle(vehicle),
                            annual_mileage_stats=vehicle.get_annual_mileage_stats())
 
 
@@ -235,11 +273,8 @@ def edit(vehicle_id):
         if 'image' in request.files:
             file = request.files['image']
             if file and file.filename and allowed_file(file.filename):
-                # Delete old image
-                if vehicle.image_filename:
-                    old_path = os.path.join(current_app.config['UPLOAD_FOLDER'], vehicle.image_filename)
-                    if os.path.exists(old_path):
-                        os.remove(old_path)
+                # Delete the old image, unless it is also a gallery photo
+                _delete_unused_upload(vehicle.image_filename)
 
                 filename = f"{uuid.uuid4().hex}_{secure_filename(file.filename)}"
                 file.save(os.path.join(current_app.config['UPLOAD_FOLDER'], filename))
@@ -291,16 +326,141 @@ def delete(vehicle_id):
         flash(_('Access denied'), 'error')
         return redirect(url_for('vehicles.index'))
 
-    # Delete image
-    if vehicle.image_filename:
-        old_path = os.path.join(current_app.config['UPLOAD_FOLDER'], vehicle.image_filename)
-        if os.path.exists(old_path):
-            os.remove(old_path)
+    # Delete the main image and every gallery photo (#147)
+    _delete_upload(vehicle.image_filename)
+    for photo in _vehicle_photos(vehicle):
+        _delete_upload(photo.filename)
 
     db.session.delete(vehicle)
     db.session.commit()
     flash(_('Vehicle deleted successfully'), 'success')
     return redirect(url_for('vehicles.index'))
+
+
+@bp.route('/<int:vehicle_id>/photos', methods=['POST'])
+@login_required
+def add_photos(vehicle_id):
+    """Add one or more photos to a vehicle's gallery (#147).
+
+    Photos are stored as attachments against the vehicle, which is the same
+    record type used for fuel and expense receipts, so they are already
+    covered by the backup export.
+    """
+    vehicle = Vehicle.query.get_or_404(vehicle_id)
+
+    if not _owns_vehicle(vehicle):
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('vehicles.index'))
+
+    skipped = []
+    saved = 0
+    for file in request.files.getlist('photo'):
+        if not file or not file.filename:
+            continue
+        if not allowed_file(file.filename):
+            skipped.append(file.filename)
+            continue
+
+        filename = f"{uuid.uuid4().hex}_{secure_filename(file.filename)}"
+        path = _upload_path(filename)
+        file.save(path)
+
+        db.session.add(Attachment(
+            filename=filename,
+            original_filename=file.filename,
+            file_type=file.filename.rsplit('.', 1)[1].lower(),
+            file_size=os.path.getsize(path) if os.path.exists(path) else None,
+            vehicle_id=vehicle.id
+        ))
+        saved += 1
+
+        # A vehicle with no picture yet gets its first photo as the main one
+        if not vehicle.image_filename:
+            vehicle.image_filename = filename
+
+    db.session.commit()
+
+    if skipped:
+        flash(_('These files were not saved because the file type is not '
+                'supported: %(names)s') % {'names': ', '.join(skipped)}, 'warning')
+    if saved == 1:
+        flash(_('Photo added'), 'success')
+    elif saved:
+        flash(_('%(count)s photos added') % {'count': saved}, 'success')
+    elif not skipped:
+        flash(_('No photos were selected'), 'info')
+
+    return redirect(url_for('vehicles.view', vehicle_id=vehicle.id) + '#photos')
+
+
+@bp.route('/<int:vehicle_id>/photos/<int:attachment_id>/primary', methods=['POST'])
+@login_required
+def set_primary_photo(vehicle_id, attachment_id):
+    """Use a gallery photo as the vehicle's main picture (#147)."""
+    vehicle = Vehicle.query.get_or_404(vehicle_id)
+
+    if not _owns_vehicle(vehicle):
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('vehicles.index'))
+
+    photo = Attachment.query.get_or_404(attachment_id)
+    if photo.vehicle_id != vehicle.id:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('vehicles.view', vehicle_id=vehicle.id))
+
+    previous = vehicle.image_filename
+    if previous and previous != photo.filename and not Attachment.query.filter_by(
+            filename=previous).first():
+        # The outgoing main image was uploaded through the vehicle form and is
+        # not in the gallery. Keep it as a photo rather than losing it.
+        original = previous.split('_', 1)[1] if '_' in previous else previous
+        extension = original.rsplit('.', 1)[1].lower() if '.' in original else None
+        path = _upload_path(previous)
+        db.session.add(Attachment(
+            filename=previous,
+            original_filename=original,
+            file_type=extension,
+            file_size=os.path.getsize(path) if os.path.exists(path) else None,
+            vehicle_id=vehicle.id
+        ))
+
+    vehicle.image_filename = photo.filename
+    db.session.commit()
+    flash(_('Main photo updated'), 'success')
+    return redirect(url_for('vehicles.view', vehicle_id=vehicle.id) + '#photos')
+
+
+@bp.route('/<int:vehicle_id>/photos/<int:attachment_id>/delete', methods=['POST'])
+@login_required
+def delete_photo(vehicle_id, attachment_id):
+    """Remove a gallery photo (#147)."""
+    vehicle = Vehicle.query.get_or_404(vehicle_id)
+
+    if not _owns_vehicle(vehicle):
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('vehicles.index'))
+
+    photo = Attachment.query.get_or_404(attachment_id)
+    if photo.vehicle_id != vehicle.id:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('vehicles.view', vehicle_id=vehicle.id))
+
+    was_main = vehicle.image_filename == photo.filename
+    filename = photo.filename
+
+    db.session.delete(photo)
+    db.session.flush()
+
+    if was_main:
+        # Fall back to another photo so the vehicle keeps a picture
+        remaining = _vehicle_photos(vehicle)
+        vehicle.image_filename = remaining[0].filename if remaining else None
+
+    db.session.commit()
+    _delete_unused_upload(filename)
+
+    flash(_('Photo deleted'), 'success')
+    return redirect(url_for('vehicles.view', vehicle_id=vehicle.id) + '#photos')
 
 
 @bp.route('/<int:vehicle_id>/share', methods=['GET', 'POST'])

--- a/app/services/backup_restore.py
+++ b/app/services/backup_restore.py
@@ -1,0 +1,672 @@
+"""Restore a May backup (JSON export or full ZIP backup) into an account.
+
+The restore always *merges*: records are added to the account that is signed
+in, and any record that already matches an existing one on its natural key is
+skipped rather than duplicated. Nothing is ever deleted or overwritten, so a
+restore can never destroy data the user still has.
+
+The two-step flow in the UI (preview, then apply) uses the same code path:
+``restore_backup(..., dry_run=True)`` does the whole thing inside the request's
+transaction and rolls it back, so the preview counts are exactly what a real
+restore would do.
+"""
+import json
+import logging
+import os
+import zipfile
+from datetime import datetime, date, time
+
+from app import db
+from app.models import (
+    Vehicle, FuelLog, Expense, Trip, ChargingSession, Reminder,
+    MaintenanceSchedule, RecurringExpense, Document, VehicleSpec,
+    VehiclePart, FuelStation, FuelPriceHistory, Attachment
+)
+
+logger = logging.getLogger(__name__)
+
+# Sections we know how to restore, in the order they are shown in the summary
+SECTION_LABELS = {
+    'vehicles': 'Vehicles',
+    'specifications': 'Specifications',
+    'fuel_logs': 'Fuel logs',
+    'expenses': 'Expenses',
+    'trips': 'Trips',
+    'charging_sessions': 'Charging sessions',
+    'reminders': 'Reminders',
+    'maintenance_schedules': 'Maintenance schedules',
+    'recurring_expenses': 'Recurring expenses',
+    'documents': 'Documents',
+    'parts': 'Parts',
+    'attachments': 'Attachments',
+    'fuel_stations': 'Fuel stations',
+    'fuel_price_history': 'Fuel price history',
+    'files': 'Uploaded files',
+}
+
+
+class BackupError(Exception):
+    """Raised when a backup file cannot be read or is not a May backup."""
+
+
+# ---------------------------------------------------------------------------
+# Value parsing / normalisation
+# ---------------------------------------------------------------------------
+
+def _parse_date(value):
+    if value in (None, ''):
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    try:
+        return datetime.fromisoformat(str(value).replace('Z', '+00:00')).date()
+    except ValueError:
+        return None
+
+
+def _parse_datetime(value):
+    if value in (None, ''):
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        parsed = datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    # Stored columns are naive UTC
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(tz=None).replace(tzinfo=None)
+    return parsed
+
+
+def _parse_time(value):
+    if value in (None, ''):
+        return None
+    if isinstance(value, time):
+        return value
+    try:
+        return time.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def _parse_bool(value):
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def _parse_float(value):
+    if value in (None, ''):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_int(value):
+    if value in (None, ''):
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_str(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+PARSERS = {
+    'date': _parse_date,
+    'datetime': _parse_datetime,
+    'time': _parse_time,
+    'bool': _parse_bool,
+    'float': _parse_float,
+    'int': _parse_int,
+    'str': _parse_str,
+}
+
+
+def _normalise(value):
+    """Make a value comparable between a backup record and a stored one."""
+    if isinstance(value, str):
+        return value.strip().lower() or None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return round(value, 3)
+    return value
+
+
+def _key(values, key_fields):
+    return tuple(_normalise(values.get(field)) for field in key_fields)
+
+
+class Section:
+    """How one kind of record is read from a backup and matched to existing rows."""
+
+    def __init__(self, name, model, fields, key_fields, needs_file=False):
+        self.name = name
+        self.model = model
+        self.fields = fields          # {column name: parser name}
+        self.key_fields = key_fields  # columns forming the natural key
+        self.needs_file = needs_file  # record is useless without its upload
+
+    def parse(self, record):
+        """Convert one backup record into column values, ignoring unknown keys."""
+        values = {}
+        for column, parser in self.fields.items():
+            if column in record:
+                values[column] = PARSERS[parser](record[column])
+        return values
+
+    def key_of_record(self, values):
+        return _key(values, self.key_fields)
+
+    def key_of_row(self, row):
+        return _key({field: getattr(row, field, None) for field in self.key_fields},
+                    self.key_fields)
+
+
+VEHICLE_SECTION = Section(
+    'vehicles', Vehicle,
+    {
+        'name': 'str', 'vehicle_type': 'str', 'make': 'str', 'model': 'str',
+        'year': 'int', 'registration': 'str', 'vin': 'str',
+        'tracking_unit': 'str', 'odometer_unit': 'str', 'fuel_type': 'str',
+        'secondary_fuel_type': 'str', 'tank_capacity': 'float',
+        'battery_capacity': 'float', 'is_active': 'bool', 'notes': 'str',
+        'image_filename': 'str', 'mot_status': 'str', 'mot_expiry': 'date',
+        'tax_status': 'str', 'tax_due': 'date', 'created_at': 'datetime',
+    },
+    key_fields=('name', 'make', 'model', 'year'),
+)
+
+# Child records, keyed by the section name used in the backup's vehicle blocks
+VEHICLE_SECTIONS = [
+    Section('specifications', VehicleSpec,
+            {'spec_type': 'str', 'label': 'str', 'value': 'str',
+             'created_at': 'datetime'},
+            key_fields=('spec_type', 'label')),
+    Section('fuel_logs', FuelLog,
+            {'date': 'date', 'odometer': 'float', 'volume': 'float',
+             'price_per_unit': 'float', 'discount_per_unit': 'float',
+             'total_cost': 'float', 'fuel_type': 'str', 'is_full_tank': 'bool',
+             'is_missed': 'bool', 'station': 'str', 'notes': 'str',
+             'created_at': 'datetime'},
+            key_fields=('date', 'odometer', 'volume')),
+    Section('expenses', Expense,
+            {'date': 'date', 'category': 'str', 'description': 'str',
+             'cost': 'float', 'odometer': 'float', 'vendor': 'str',
+             'notes': 'str', 'created_at': 'datetime'},
+            key_fields=('date', 'category', 'description', 'cost')),
+    Section('trips', Trip,
+            {'date': 'date', 'start_odometer': 'float', 'end_odometer': 'float',
+             'purpose': 'str', 'description': 'str', 'start_location': 'str',
+             'end_location': 'str', 'notes': 'str', 'created_at': 'datetime'},
+            key_fields=('date', 'start_odometer', 'end_odometer', 'purpose')),
+    Section('charging_sessions', ChargingSession,
+            {'date': 'date', 'start_time': 'time', 'end_time': 'time',
+             'odometer': 'float', 'kwh_added': 'float', 'start_soc': 'int',
+             'end_soc': 'int', 'cost_per_kwh': 'float', 'total_cost': 'float',
+             'charger_type': 'str', 'location': 'str', 'network': 'str',
+             'notes': 'str', 'created_at': 'datetime'},
+            key_fields=('date', 'start_time', 'odometer', 'kwh_added')),
+    Section('reminders', Reminder,
+            {'title': 'str', 'description': 'str', 'reminder_type': 'str',
+             'due_date': 'date', 'recurrence': 'str',
+             'recurrence_interval': 'int', 'notify_days_before': 'int',
+             'notification_sent': 'bool', 'is_completed': 'bool',
+             'completed_at': 'datetime', 'created_at': 'datetime'},
+            key_fields=('title', 'reminder_type', 'due_date')),
+    Section('maintenance_schedules', MaintenanceSchedule,
+            {'name': 'str', 'maintenance_type': 'str', 'description': 'str',
+             'interval_miles': 'int', 'interval_km': 'int',
+             'interval_months': 'int', 'last_performed_date': 'date',
+             'last_performed_odometer': 'float', 'next_due_date': 'date',
+             'next_due_odometer': 'float', 'estimated_cost': 'float',
+             'auto_remind': 'bool', 'remind_days_before': 'int',
+             'remind_miles_before': 'int', 'is_active': 'bool',
+             'created_at': 'datetime'},
+            key_fields=('name', 'maintenance_type')),
+    Section('recurring_expenses', RecurringExpense,
+            {'name': 'str', 'category': 'str', 'description': 'str',
+             'amount': 'float', 'vendor': 'str', 'frequency': 'str',
+             'start_date': 'date', 'end_date': 'date', 'last_generated': 'date',
+             'next_due': 'date', 'auto_create': 'bool',
+             'notify_before_days': 'int', 'is_active': 'bool',
+             'created_at': 'datetime'},
+            key_fields=('name', 'category', 'start_date')),
+    Section('documents', Document,
+            {'title': 'str', 'document_type': 'str', 'description': 'str',
+             'filename': 'str', 'original_filename': 'str', 'file_type': 'str',
+             'file_size': 'int', 'issue_date': 'date', 'expiry_date': 'date',
+             'reference_number': 'str', 'remind_before_expiry': 'bool',
+             'remind_days': 'int', 'created_at': 'datetime'},
+            key_fields=('title', 'document_type', 'filename'),
+            needs_file=True),
+    Section('parts', VehiclePart,
+            {'name': 'str', 'part_type': 'str', 'specification': 'str',
+             'quantity': 'float', 'unit': 'str', 'part_number': 'str',
+             'supplier_url': 'str', 'notes': 'str', 'created_at': 'datetime',
+             'updated_at': 'datetime'},
+            key_fields=('name', 'part_type', 'part_number')),
+]
+
+ATTACHMENT_SECTION = Section(
+    'attachments', Attachment,
+    {'filename': 'str', 'original_filename': 'str', 'file_type': 'str',
+     'file_size': 'int', 'description': 'str', 'created_at': 'datetime'},
+    key_fields=('filename',),
+    needs_file=True,
+)
+
+STATION_SECTION = Section(
+    'fuel_stations', FuelStation,
+    {'name': 'str', 'brand': 'str', 'address': 'str', 'city': 'str',
+     'postcode': 'str', 'latitude': 'float', 'longitude': 'float',
+     'notes': 'str', 'is_favorite': 'bool', 'times_used': 'int',
+     'last_used': 'datetime', 'created_at': 'datetime'},
+    key_fields=('name', 'address', 'postcode'),
+)
+
+PRICE_SECTION = Section(
+    'fuel_price_history', FuelPriceHistory,
+    {'date': 'date', 'fuel_type': 'str', 'price_per_unit': 'float',
+     'created_at': 'datetime'},
+    key_fields=('date', 'fuel_type', 'price_per_unit'),
+)
+
+
+# ---------------------------------------------------------------------------
+# Reading the uploaded file
+# ---------------------------------------------------------------------------
+
+def read_backup(path):
+    """Read a backup from disk.
+
+    Accepts either a JSON export (``may_backup_*.json``) or a full backup
+    ZIP (``may_full_backup_*.zip``) containing ``data.json``.
+
+    Returns ``(data, zip_path)`` where ``zip_path`` is None for JSON backups.
+    Raises :class:`BackupError` if the file is not a May backup.
+    """
+    if zipfile.is_zipfile(path):
+        try:
+            with zipfile.ZipFile(path) as zf:
+                names = zf.namelist()
+                if 'data.json' not in names:
+                    raise BackupError(
+                        'This ZIP does not contain a data.json file, so it is '
+                        'not a May full backup.'
+                    )
+                raw = zf.read('data.json')
+        except zipfile.BadZipFile as exc:
+            raise BackupError('The uploaded ZIP file could not be read.') from exc
+        data = _load_json(raw)
+        return _validate(data), path
+
+    with open(path, 'rb') as handle:
+        raw = handle.read()
+    data = _load_json(raw)
+    return _validate(data), None
+
+
+def _load_json(raw):
+    try:
+        return json.loads(raw.decode('utf-8-sig'))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BackupError('The file is not valid JSON.') from exc
+
+
+def _validate(data):
+    if not isinstance(data, dict):
+        raise BackupError('The file does not contain a May backup.')
+    if 'vehicles' not in data and 'fuel_stations' not in data:
+        raise BackupError(
+            'This does not look like a May backup — no vehicles or fuel '
+            'stations were found. Use the JSON or full backup file produced '
+            'by the export page.'
+        )
+    return data
+
+
+def describe_backup(data):
+    """Human-readable details about where a backup came from."""
+    info = data.get('export_info') or {}
+    return {
+        'exported_at': info.get('exported_at'),
+        'username': info.get('username'),
+        'app_version': info.get('app_version'),
+        'backup_type': info.get('backup_type') or 'json',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Restoring
+# ---------------------------------------------------------------------------
+
+def _new_summary():
+    return {name: {'added': 0, 'skipped': 0} for name in SECTION_LABELS}
+
+
+def _zip_upload_names(zip_path):
+    """Names of the files stored under uploads/ in a full backup ZIP."""
+    if not zip_path:
+        return {}
+    available = {}
+    with zipfile.ZipFile(zip_path) as zf:
+        for name in zf.namelist():
+            if not name.startswith('uploads/') or name.endswith('/'):
+                continue
+            base = name[len('uploads/'):]
+            # The export writes every upload as a plain name directly under
+            # uploads/, so anything with a path in it is not ours to restore.
+            if not base or '/' in base or '\\' in base or base in ('.', '..'):
+                continue
+            available[base] = name
+    return available
+
+
+def restore_backup(data, user, zip_path=None, upload_folder=None, dry_run=False):
+    """Merge a backup into ``user``'s account.
+
+    Existing records are never modified or deleted; a record whose natural key
+    already exists is counted as skipped. With ``dry_run`` the work is done and
+    then rolled back, so the returned summary previews a real restore.
+    """
+    summary = _new_summary()
+    summary['vehicle_details'] = []
+    available_files = _zip_upload_names(zip_path)
+
+    try:
+        _restore_vehicles(data, user, summary, available_files)
+        _restore_stations(data, user, summary)
+        _copy_files(zip_path, available_files, upload_folder, summary,
+                    dry_run=dry_run)
+        if dry_run:
+            db.session.rollback()
+        else:
+            db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    summary['total_added'] = sum(
+        counts['added'] for name, counts in summary.items()
+        if name in SECTION_LABELS
+    )
+    summary['total_skipped'] = sum(
+        counts['skipped'] for name, counts in summary.items()
+        if name in SECTION_LABELS
+    )
+    return summary
+
+
+def _vehicle_match(vehicle_values, existing):
+    """Find an existing vehicle for a backup vehicle.
+
+    VIN and registration are stable identifiers, so they win; otherwise fall
+    back to name/make/model/year.
+    """
+    for field in ('vin', 'registration'):
+        value = _normalise(vehicle_values.get(field))
+        if value:
+            for row in existing:
+                if _normalise(getattr(row, field, None)) == value:
+                    return row
+    key = VEHICLE_SECTION.key_of_record(vehicle_values)
+    for row in existing:
+        if VEHICLE_SECTION.key_of_row(row) == key:
+            return row
+    return None
+
+
+def _restore_vehicles(data, user, summary, available_files):
+    existing_vehicles = list(
+        Vehicle.query.filter_by(owner_id=user.id).all()
+    )
+
+    for raw_vehicle in data.get('vehicles') or []:
+        if not isinstance(raw_vehicle, dict):
+            continue
+        values = VEHICLE_SECTION.parse(raw_vehicle)
+        if not values.get('name'):
+            values['name'] = 'Restored Vehicle'
+        if not values.get('vehicle_type'):
+            values['vehicle_type'] = 'car'
+
+        vehicle = _vehicle_match(values, existing_vehicles)
+        detail = {'name': values['name'], 'sections': {}}
+        if vehicle is None:
+            if not values.get('image_filename') or (
+                    values['image_filename'] not in available_files):
+                values['image_filename'] = None
+            vehicle = Vehicle(owner_id=user.id, **values)
+            db.session.add(vehicle)
+            db.session.flush()
+            existing_vehicles.append(vehicle)
+            summary['vehicles']['added'] += 1
+            detail['status'] = 'new'
+        else:
+            summary['vehicles']['skipped'] += 1
+            detail['status'] = 'existing'
+
+        for section in VEHICLE_SECTIONS:
+            added, skipped, (attach_added, attach_skipped) = _restore_child_records(
+                section, raw_vehicle.get(section.name) or [], vehicle, user,
+                available_files
+            )
+            summary[section.name]['added'] += added
+            summary[section.name]['skipped'] += skipped
+            summary['attachments']['added'] += attach_added
+            summary['attachments']['skipped'] += attach_skipped
+            if added or skipped:
+                detail['sections'][section.name] = {'added': added, 'skipped': skipped}
+
+        added, skipped = _restore_attachments(
+            raw_vehicle.get('attachments') or [], vehicle, user,
+            available_files, owner_field='vehicle_id', owner_id=vehicle.id
+        )
+        summary['attachments']['added'] += added
+        summary['attachments']['skipped'] += skipped
+        if added or skipped:
+            detail['sections']['attachments'] = {'added': added, 'skipped': skipped}
+
+        summary['vehicle_details'].append(detail)
+
+
+def _existing_keys(section, vehicle_id):
+    query = section.model.query.filter_by(vehicle_id=vehicle_id)
+    return {section.key_of_row(row) for row in query.all()}
+
+
+ATTACHMENT_OWNERS = {'fuel_logs': 'fuel_log_id', 'expenses': 'expense_id'}
+
+
+def _restore_child_records(section, records, vehicle, user, available_files):
+    """Add a vehicle's child records, skipping ones that already exist.
+
+    Returns ``(added, skipped, attachments)`` where ``attachments`` is the
+    ``(added, skipped)`` pair for any attachments hanging off these records.
+    """
+    added = skipped = 0
+    attach_added = attach_skipped = 0
+    seen = _existing_keys(section, vehicle.id)
+    owner_field = ATTACHMENT_OWNERS.get(section.name)
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        values = section.parse(record)
+        if section.needs_file:
+            filename = values.get('filename')
+            if not filename or filename not in available_files:
+                # Without the uploaded file the record would point at nothing
+                skipped += 1
+                continue
+        key = section.key_of_record(values)
+        if key in seen:
+            skipped += 1
+            if owner_field:
+                # The record is already here, so its attachments may be too;
+                # they are counted as skipped rather than duplicated.
+                attach_skipped += len(record.get('attachments') or [])
+            continue
+
+        row = section.model(vehicle_id=vehicle.id, **values)
+        if hasattr(section.model, 'user_id'):
+            row.user_id = user.id
+        db.session.add(row)
+        seen.add(key)
+        added += 1
+
+        if owner_field and record.get('attachments'):
+            db.session.flush()
+            sub_added, sub_skipped = _restore_attachments(
+                record['attachments'], vehicle, user, available_files,
+                owner_field=owner_field, owner_id=row.id
+            )
+            attach_added += sub_added
+            attach_skipped += sub_skipped
+
+    return added, skipped, (attach_added, attach_skipped)
+
+
+def _restore_attachments(records, vehicle, user, available_files,
+                         owner_field='vehicle_id', owner_id=None):
+    added = skipped = 0
+    section = ATTACHMENT_SECTION
+    existing = {
+        section.key_of_row(row)
+        for row in Attachment.query.filter_by(**{owner_field: owner_id}).all()
+    }
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        values = section.parse(record)
+        filename = values.get('filename')
+        if not filename or filename not in available_files:
+            skipped += 1
+            continue
+        if not values.get('original_filename'):
+            values['original_filename'] = filename
+        key = section.key_of_record(values)
+        if key in existing:
+            skipped += 1
+            continue
+        db.session.add(Attachment(**{owner_field: owner_id}, **values))
+        existing.add(key)
+        added += 1
+
+    return added, skipped
+
+
+def _restore_stations(data, user, summary):
+    existing = list(FuelStation.query.filter_by(user_id=user.id).all())
+    seen = {STATION_SECTION.key_of_row(row) for row in existing}
+    # Old station id -> station row, so price history can be reattached
+    station_by_old_id = {}
+    station_by_name = {
+        _normalise(row.name): row for row in existing if row.name
+    }
+
+    for record in data.get('fuel_stations') or []:
+        if not isinstance(record, dict):
+            continue
+        values = STATION_SECTION.parse(record)
+        if not values.get('name'):
+            continue
+        key = STATION_SECTION.key_of_record(values)
+        if key in seen:
+            summary['fuel_stations']['skipped'] += 1
+            match = next(
+                (row for row in existing
+                 if STATION_SECTION.key_of_row(row) == key), None
+            )
+            if match is not None and record.get('id') is not None:
+                station_by_old_id[record['id']] = match
+            continue
+        station = FuelStation(user_id=user.id, **values)
+        db.session.add(station)
+        db.session.flush()
+        existing.append(station)
+        seen.add(key)
+        station_by_name.setdefault(_normalise(station.name), station)
+        if record.get('id') is not None:
+            station_by_old_id[record['id']] = station
+        summary['fuel_stations']['added'] += 1
+
+    _restore_price_history(data, user, summary, station_by_old_id, station_by_name)
+
+
+def _restore_price_history(data, user, summary, station_by_old_id, station_by_name):
+    seen_by_station = {}
+
+    for record in data.get('fuel_price_history') or []:
+        if not isinstance(record, dict):
+            continue
+        station = station_by_old_id.get(record.get('station_id'))
+        if station is None:
+            station = station_by_name.get(_normalise(record.get('station_name')))
+        if station is None:
+            summary['fuel_price_history']['skipped'] += 1
+            continue
+
+        if station.id not in seen_by_station:
+            seen_by_station[station.id] = {
+                PRICE_SECTION.key_of_row(row)
+                for row in FuelPriceHistory.query.filter_by(
+                    station_id=station.id).all()
+            }
+        seen = seen_by_station[station.id]
+
+        values = PRICE_SECTION.parse(record)
+        key = PRICE_SECTION.key_of_record(values)
+        if key in seen:
+            summary['fuel_price_history']['skipped'] += 1
+            continue
+        db.session.add(FuelPriceHistory(
+            station_id=station.id, user_id=user.id, **values))
+        seen.add(key)
+        summary['fuel_price_history']['added'] += 1
+
+
+def _copy_files(zip_path, available_files, upload_folder, summary, dry_run=False):
+    """Copy uploaded files out of a full backup ZIP into the uploads folder.
+
+    Files already present are left alone — upload names are UUID-prefixed, so
+    a clash means the same file has been restored before.
+    """
+    if not zip_path or not available_files or not upload_folder:
+        return
+
+    if not dry_run:
+        os.makedirs(upload_folder, exist_ok=True)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        for base, name in available_files.items():
+            target = os.path.join(upload_folder, base)
+            if os.path.exists(target):
+                summary['files']['skipped'] += 1
+                continue
+            if dry_run:
+                summary['files']['added'] += 1
+                continue
+            try:
+                with zf.open(name) as source, open(target, 'wb') as dest:
+                    dest.write(source.read())
+                summary['files']['added'] += 1
+            except (KeyError, OSError) as exc:
+                logger.warning('Backup restore: could not write %s: %s', base, exc)
+                summary['files']['skipped'] += 1

--- a/app/services/uk_fuel_prices.py
+++ b/app/services/uk_fuel_prices.py
@@ -23,6 +23,9 @@ import requests
 from app import db
 from app.models import AppSettings, FuelPriceHistory, FuelStation
 
+#: Value stored in FuelStation.price_source for forecourts from this scheme.
+PRICE_SOURCE = 'uk_fuel_prices'
+
 # Setting keys
 SETTING_ENABLED = 'uk_fuel_prices_enabled'
 SETTING_FEEDS = 'uk_fuel_feed_urls'
@@ -231,10 +234,22 @@ class UKFuelPriceService:
     def match_forecourt(cls, station, forecourts):
         """Find the forecourt matching a saved station, or None.
 
-        Matching is by postcode first. Where a postcode covers more than one
-        forecourt, the nearest one within MATCH_RADIUS_KM wins, falling back
-        to a brand match and finally to the first candidate.
+        A station already linked to a scheme site_id is matched on that id
+        alone: identity beats guesswork, and a link that has dropped out of
+        the feed should read as unmatched rather than silently resolve to a
+        different forecourt.
+
+        Otherwise matching is by postcode. Where a postcode covers more than
+        one forecourt, the nearest one within MATCH_RADIUS_KM wins, falling
+        back to a brand match and finally to the first candidate.
         """
+        if station.price_source == PRICE_SOURCE and station.external_id:
+            for forecourt in forecourts:
+                site_id = forecourt.get('site_id')
+                if site_id is not None and str(site_id) == station.external_id:
+                    return forecourt
+            return None
+
         postcode_key = cls.normalise_postcode(station.postcode)
         if not postcode_key:
             return None
@@ -329,8 +344,13 @@ class UKFuelPriceService:
             'errors': [],
         }
 
-        # Stations without a postcode can't be matched to a forecourt.
-        matchable = [s for s in stations if cls.normalise_postcode(s.postcode)]
+        # Stations without a postcode can't be matched to a forecourt unless
+        # a previous run already linked them to a scheme site_id.
+        matchable = [
+            s for s in stations
+            if cls.normalise_postcode(s.postcode)
+            or (s.price_source == PRICE_SOURCE and s.external_id)
+        ]
         stats['skipped'] = len(stations) - len(matchable)
         if not matchable:
             return stats
@@ -347,6 +367,9 @@ class UKFuelPriceService:
                 stats['unmatched'] += 1
                 continue
             stats['matched'] += 1
+            # Remember which forecourt this was, so later runs go straight
+            # to it instead of re-running the postcode heuristics.
+            station.link_price_source(PRICE_SOURCE, forecourt.get('site_id'))
             stats['prices'] += cls.record_prices(station, forecourt)
 
         db.session.commit()

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -548,11 +548,22 @@
                     <div class="bg-white dark:bg-gray-800 shadow rounded-lg divide-y divide-gray-200 dark:divide-gray-700">
                         <div class="p-6">
                             <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('Import Data') }}</h2>
-                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Import your data from other fuel tracking applications') }}</p>
+                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Restore a May backup, or import your data from other fuel tracking applications') }}</p>
                         </div>
 
                         <div class="p-6 space-y-4">
                             <div class="flex items-center justify-between py-3">
+                                <div>
+                                    <h3 class="text-sm font-medium text-gray-900 dark:text-white">{{ _('Restore May Backup') }}</h3>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ _('Restore a JSON export (.json) or full backup (.zip) from another May instance') }}</p>
+                                </div>
+                                <a href="{{ url_for('api.backup_restore_upload') }}"
+                                   class="w-24 text-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 dark:bg-gray-700 hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600">
+                                    {{ _('Restore') }}
+                                </a>
+                            </div>
+
+                            <div class="flex items-center justify-between py-3 border-t border-gray-200 dark:border-gray-700">
                                 <div>
                                     <h3 class="text-sm font-medium text-gray-900 dark:text-white">Hammond</h3>
                                     <p class="text-sm text-gray-500 dark:text-gray-400">Import from Hammond SQLite database (.db file)</p>

--- a/app/templates/fuel/form.html
+++ b/app/templates/fuel/form.html
@@ -224,10 +224,24 @@ function updateFuelTypeSelector(selectedOption) {
     const primaryFuel = selectedOption.getAttribute('data-primary-fuel') || '';
     const secondaryFuel = selectedOption.getAttribute('data-secondary-fuel') || '';
     const fuelLabels = {{ dict(fuel_types)|tojson }};
+    // A hybrid isn't a fuel, so offer the fuels one can actually burn (#268).
+    // Petrol comes first as the common case; diesel hybrid owners pick diesel
+    // and the station price charts then show the right series.
+    const propulsionFuels = {
+        'hybrid': ['petrol', 'diesel'],
+        'plugin_hybrid': ['petrol', 'diesel']
+    };
 
+    let choices = [];
     if (secondaryFuel) {
-        fuelTypeSelect.innerHTML = '';
-        [primaryFuel, secondaryFuel].forEach(function(value) {
+        choices = [primaryFuel, secondaryFuel];
+    } else if (propulsionFuels[primaryFuel]) {
+        choices = propulsionFuels[primaryFuel];
+    }
+
+    fuelTypeSelect.innerHTML = '';
+    if (choices.length) {
+        choices.forEach(function(value) {
             const opt = document.createElement('option');
             opt.value = value;
             opt.textContent = fuelLabels[value] || value;
@@ -239,7 +253,6 @@ function updateFuelTypeSelector(selectedOption) {
         fuelTypeField.classList.remove('hidden');
     } else {
         fuelTypeField.classList.add('hidden');
-        fuelTypeSelect.innerHTML = '';
     }
 }
 

--- a/app/templates/import/backup_preview.html
+++ b/app/templates/import/backup_preview.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Restore Backup') }}{% endblock %}
+
+{% block content %}
+<div class="max-w-3xl mx-auto">
+    <div class="mb-6">
+        <a href="{{ url_for('api.backup_restore_upload') }}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300">&larr; {{ _('Choose a different file') }}</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">{{ _('Restore Preview') }}</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {{ _('Nothing has been changed yet. This is what will be added to your account.') }}
+        </p>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-6">
+        <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+            <div>
+                <dt class="text-gray-500 dark:text-gray-400">{{ _('Backup type') }}</dt>
+                <dd class="text-gray-900 dark:text-white">{{ _('Full backup (with files)') if is_full_backup else _('JSON export') }}</dd>
+            </div>
+            <div>
+                <dt class="text-gray-500 dark:text-gray-400">{{ _('Exported') }}</dt>
+                <dd class="text-gray-900 dark:text-white">{{ backup_info.exported_at or _('Unknown') }}</dd>
+            </div>
+            <div>
+                <dt class="text-gray-500 dark:text-gray-400">{{ _('Exported by') }}</dt>
+                <dd class="text-gray-900 dark:text-white">{{ backup_info.username or _('Unknown') }}{% if backup_info.app_version %} ({{ backup_info.app_version }}){% endif %}</dd>
+            </div>
+        </dl>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden mb-6">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Data') }}</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Will be added') }}</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Already present') }}</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                {% for key, label in section_labels.items() %}
+                {% set counts = summary[key] %}
+                {% if counts.added or counts.skipped %}
+                <tr>
+                    <td class="px-6 py-3 text-sm text-gray-900 dark:text-white">{{ label }}</td>
+                    <td class="px-6 py-3 text-sm text-right text-gray-900 dark:text-white">{{ counts.added }}</td>
+                    <td class="px-6 py-3 text-sm text-right text-gray-500 dark:text-gray-400">{{ counts.skipped }}</td>
+                </tr>
+                {% endif %}
+                {% endfor %}
+                <tr class="bg-gray-50 dark:bg-gray-700 font-medium">
+                    <td class="px-6 py-3 text-sm text-gray-900 dark:text-white">{{ _('Total') }}</td>
+                    <td class="px-6 py-3 text-sm text-right text-gray-900 dark:text-white">{{ summary.total_added }}</td>
+                    <td class="px-6 py-3 text-sm text-right text-gray-500 dark:text-gray-400">{{ summary.total_skipped }}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    {% if summary.vehicle_details %}
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mb-6">
+        <h2 class="text-sm font-medium text-gray-900 dark:text-white">{{ _('Vehicles in this backup') }}</h2>
+        <ul class="mt-3 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+            {% for vehicle in summary.vehicle_details %}
+            <li>
+                <span class="font-medium text-gray-900 dark:text-white">{{ vehicle.name }}</span>
+                {% if vehicle.status == 'new' %}
+                <span class="text-green-600 dark:text-green-400">{{ _('will be added') }}</span>
+                {% else %}
+                <span class="text-gray-500 dark:text-gray-400">{{ _('already in your account — its records will be merged') }}</span>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
+    {% if summary.total_added == 0 %}
+    <div class="bg-yellow-50 dark:bg-gray-800 border border-yellow-200 dark:border-gray-700 rounded-lg p-4 mb-6">
+        <p class="text-sm text-yellow-800 dark:text-yellow-200">{{ _('Everything in this backup is already in your account. Restoring it will change nothing.') }}</p>
+    </div>
+    {% endif %}
+
+    <form method="POST" action="{{ url_for('api.backup_restore_execute') }}" class="flex justify-end gap-3">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <a href="{{ url_for('auth.settings') }}#integrations"
+           class="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
+            {{ _('Cancel') }}
+        </a>
+        <button type="submit"
+                class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+            {{ _('Restore Backup') }}
+        </button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/import/backup_upload.html
+++ b/app/templates/import/backup_upload.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Restore Backup') }}{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+    <div class="mb-6">
+        <a href="{{ url_for('auth.settings') }}#integrations" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300">&larr; Back to settings</a>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white mt-2">{{ _('Restore a May Backup') }}</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Restore a JSON export or a full backup ZIP produced by May.') }}</p>
+    </div>
+
+    <div class="bg-blue-50 dark:bg-gray-800 border border-blue-200 dark:border-gray-700 rounded-lg p-4 mb-6">
+        <p class="text-sm text-blue-800 dark:text-blue-200">
+            {{ _('The backup is merged into your account. Nothing is deleted or overwritten, and records that are already here are skipped rather than duplicated. You will see a summary of what will be added before anything is written.') }}
+        </p>
+        <p class="mt-2 text-sm text-blue-800 dark:text-blue-200">
+            {{ _('Documents, attachments and vehicle images can only be restored from a full backup ZIP, because a JSON export does not contain the files.') }}
+        </p>
+    </div>
+
+    <form method="POST" action="{{ url_for('api.backup_restore_preview') }}" enctype="multipart/form-data" class="space-y-6">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <label for="file" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Backup File') }} *</label>
+            <input type="file" name="file" id="file" accept=".json,.zip" required
+                   class="mt-1 block w-full text-sm text-gray-500 dark:text-gray-400 file:mr-2 file:py-1.5 file:px-3 file:rounded file:border-0 file:text-sm file:bg-gray-100 dark:file:bg-gray-600 file:text-gray-700 dark:file:text-gray-200 hover:file:bg-gray-200 dark:hover:file:bg-gray-500">
+            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ _('Accepts may_backup_*.json and may_full_backup_*.zip files.') }}</p>
+        </div>
+
+        <div class="flex justify-end">
+            <button type="submit"
+                    class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500">
+                {{ _('Next: Preview') }}
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -11,16 +11,42 @@
     <a href="{{ url_for('vehicles.index') }}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:text-gray-300">&larr; {{ _('Back to vehicles') }}</a>
 </div>
 
+{# Main image first, then the rest of the gallery (#147) #}
+{% set carousel = [] %}
+{% if vehicle.image_filename %}{% set _unused = carousel.append(vehicle.image_filename) %}{% endif %}
+{% for photo in photos %}{% if photo.filename != vehicle.image_filename %}{% set _unused = carousel.append(photo.filename) %}{% endif %}{% endfor %}
+
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden mb-8">
     <div class="md:flex">
-        {% if vehicle.image_filename %}
-        <div class="md:w-1/3">
-            <img src="{{ url_for('api.uploaded_file', filename=vehicle.image_filename) }}"
+        {% if carousel %}
+        <div class="md:w-1/3 relative" id="vehicle-carousel" data-count="{{ carousel|length }}">
+            {% for filename in carousel %}
+            <img src="{{ url_for('api.uploaded_file', filename=filename) }}"
                  alt="{{ vehicle.name }}"
-                 class="w-full h-48 md:h-full object-cover">
+                 data-carousel-index="{{ loop.index0 }}"
+                 class="vehicle-carousel-image w-full h-48 md:h-full object-cover{% if not loop.first %} hidden{% endif %}">
+            {% endfor %}
+            {% if carousel|length > 1 %}
+            <button type="button" onclick="stepVehicleCarousel(-1)"
+                    aria-label="{{ _('Previous photo') }}"
+                    class="absolute left-2 top-1/2 -translate-y-1/2 p-1.5 rounded-full bg-black/40 text-white hover:bg-black/60">
+                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                </svg>
+            </button>
+            <button type="button" onclick="stepVehicleCarousel(1)"
+                    aria-label="{{ _('Next photo') }}"
+                    class="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-full bg-black/40 text-white hover:bg-black/60">
+                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                </svg>
+            </button>
+            <span id="vehicle-carousel-counter"
+                  class="absolute bottom-2 right-2 px-2 py-0.5 rounded text-xs bg-black/40 text-white">1 / {{ carousel|length }}</span>
+            {% endif %}
         </div>
         {% endif %}
-        <div class="p-6 {% if vehicle.image_filename %}md:w-2/3{% endif %}">
+        <div class="p-6 {% if carousel %}md:w-2/3{% endif %}">
             <div class="flex items-start justify-between">
                 <div>
                     <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ vehicle.name }}</h1>
@@ -75,6 +101,25 @@
         </div>
     </div>
 </div>
+
+{% if carousel|length > 1 %}
+<script>
+// Left/right arrows step through the vehicle's photos (#147). One image is
+// visible at a time; the rest stay in the page so there is nothing to fetch
+// when the user moves between them.
+(function() {
+    const images = document.querySelectorAll('#vehicle-carousel .vehicle-carousel-image');
+    const counter = document.getElementById('vehicle-carousel-counter');
+    let current = 0;
+    window.stepVehicleCarousel = function(step) {
+        images[current].classList.add('hidden');
+        current = (current + step + images.length) % images.length;
+        images[current].classList.remove('hidden');
+        if (counter) counter.textContent = (current + 1) + ' / ' + images.length;
+    };
+})();
+</script>
+{% endif %}
 
 <!-- Stats Cards -->
 <div class="grid grid-cols-2 gap-4 sm:grid-cols-5 mb-8">
@@ -220,6 +265,61 @@
         </svg>
         {{ _('Timeline') }}
     </a>
+</div>
+
+<!-- Photos (#147) -->
+<div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8" id="photos">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('Photos') }}</h2>
+        {% if can_edit %}
+        <form method="POST" action="{{ url_for('vehicles.add_photos', vehicle_id=vehicle.id) }}"
+              enctype="multipart/form-data" class="flex items-center gap-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="file" name="photo" accept="image/*" multiple
+                   class="text-sm text-gray-500 dark:text-gray-400 file:mr-2 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-sm file:bg-gray-100 dark:file:bg-gray-700 file:text-gray-700 dark:file:text-gray-300">
+            <button type="submit"
+                    class="inline-flex items-center px-3 py-1.5 border border-transparent rounded-md text-sm font-medium text-white bg-primary-600 hover:bg-primary-700">
+                {{ _('Upload') }}
+            </button>
+        </form>
+        {% endif %}
+    </div>
+    {% if photos %}
+    <div class="p-6 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {% for photo in photos %}
+        <div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <a href="{{ url_for('api.uploaded_file', filename=photo.filename) }}" target="_blank" rel="noopener">
+                <img src="{{ url_for('api.uploaded_file', filename=photo.filename) }}"
+                     alt="{{ photo.original_filename }}"
+                     class="w-full h-32 object-cover hover:opacity-90">
+            </a>
+            <div class="px-2 py-2 flex items-center justify-between gap-2">
+                {% if vehicle.image_filename == photo.filename %}
+                <span class="text-xs px-1.5 py-0.5 rounded bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-200">{{ _('Main') }}</span>
+                {% elif can_edit %}
+                <form method="POST" action="{{ url_for('vehicles.set_primary_photo', vehicle_id=vehicle.id, attachment_id=photo.id) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="text-xs text-primary-600 hover:text-primary-500">{{ _('Set as main') }}</button>
+                </form>
+                {% else %}
+                <span></span>
+                {% endif %}
+                {% if can_edit %}
+                <form method="POST" action="{{ url_for('vehicles.delete_photo', vehicle_id=vehicle.id, attachment_id=photo.id) }}"
+                      onsubmit="return confirm('{{ _('Delete this photo?') }}');">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="text-xs text-red-600 hover:text-red-500">{{ _('Delete') }}</button>
+                </form>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <div class="px-6 py-8 text-center">
+        <p class="text-sm text-gray-500 dark:text-gray-400">{{ _('No photos yet.') }}</p>
+    </div>
+    {% endif %}
 </div>
 
 <!-- DVLA Status Section (UK Vehicles) -->

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.29.0'
+APP_VERSION = '0.30.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/migrations/versions/e5f6a7b8c9d1_add_price_source_to_fuel_stations.py
+++ b/migrations/versions/e5f6a7b8c9d1_add_price_source_to_fuel_stations.py
@@ -1,0 +1,48 @@
+"""Add price_source and external_id to fuel_stations (#155)
+
+Gives saved stations a stable identity with a live price provider (the UK
+fuel price scheme today, Tankerkönig next), so prices can be pulled by id
+rather than re-guessed from postcodes and addresses on every run.
+
+Revision ID: e5f6a7b8c9d1
+Revises: d4e5f6a7b8c0
+Create Date: 2026-08-23
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'e5f6a7b8c9d1'
+down_revision = 'd4e5f6a7b8c0'
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = 'ix_fuel_stations_source_external_id'
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    cols = [c['name'] for c in inspector.get_columns('fuel_stations')]
+
+    if 'price_source' not in cols:
+        op.add_column('fuel_stations',
+                      sa.Column('price_source', sa.String(length=30), nullable=True))
+    if 'external_id' not in cols:
+        op.add_column('fuel_stations',
+                      sa.Column('external_id', sa.String(length=64), nullable=True))
+
+    indexes = [i['name'] for i in inspector.get_indexes('fuel_stations')]
+    if INDEX_NAME not in indexes:
+        op.create_index(
+            INDEX_NAME,
+            'fuel_stations',
+            ['user_id', 'price_source', 'external_id'],
+            unique=True,
+        )
+
+
+def downgrade():
+    op.drop_index(INDEX_NAME, table_name='fuel_stations')
+    op.drop_column('fuel_stations', 'external_id')
+    op.drop_column('fuel_stations', 'price_source')

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,494 @@
+"""Tests for restoring a full May backup (issue #265)."""
+import io
+import json
+import os
+import zipfile
+
+from app.services.backup_restore import read_backup, restore_backup
+from app.models import (
+    Vehicle, FuelLog, Expense, Trip, ChargingSession, FuelStation,
+    FuelPriceHistory, Document, VehiclePart, Reminder
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_backup_data():
+    """A JSON backup in the shape produced by /api/export/json."""
+    return {
+        'export_info': {
+            'exported_at': '2024-06-01T12:00:00',
+            'username': 'olduser',
+            'app_version': '0.9.0',
+        },
+        'user_preferences': {'currency': 'GBP'},
+        'vehicles': [{
+            'id': 7,
+            'name': 'Old Car',
+            'vehicle_type': 'car',
+            'make': 'Honda',
+            'model': 'Civic',
+            'year': 2019,
+            'registration': 'XY19 ZAB',
+            'vin': 'VIN123456',
+            'fuel_type': 'petrol',
+            'tank_capacity': 47.0,
+            'is_active': True,
+            'notes': 'From the old instance',
+            'image_filename': None,
+            'mot_expiry': '2025-03-01',
+            'created_at': '2023-01-01T09:00:00',
+            'specifications': [
+                {'id': 1, 'spec_type': 'tyre', 'label': 'Front tyres', 'value': '205/55 R16'},
+            ],
+            'fuel_logs': [
+                {'id': 1, 'date': '2024-01-15', 'odometer': 10000.0, 'volume': 40.0,
+                 'price_per_unit': 1.5, 'total_cost': 60.0, 'is_full_tank': True,
+                 'is_missed': False, 'station': 'Shell', 'notes': None,
+                 'created_at': '2024-01-15T18:00:00'},
+                {'id': 2, 'date': '2024-02-15', 'odometer': 10500.0, 'volume': 42.0,
+                 'price_per_unit': 1.6, 'total_cost': 67.2, 'is_full_tank': True,
+                 'is_missed': False, 'station': 'BP', 'notes': None,
+                 'created_at': '2024-02-15T18:00:00'},
+            ],
+            'expenses': [
+                {'id': 1, 'date': '2024-01-20', 'category': 'maintenance',
+                 'description': 'Oil change', 'cost': 75.0, 'odometer': 10100.0,
+                 'vendor': 'Local garage', 'notes': None,
+                 'created_at': '2024-01-20T10:00:00'},
+            ],
+            'reminders': [
+                {'id': 1, 'title': 'MOT', 'description': None, 'reminder_type': 'mot',
+                 'due_date': '2025-03-01', 'recurrence': 'yearly',
+                 'notify_days_before': 30, 'is_completed': False},
+            ],
+            'maintenance_schedules': [],
+            'recurring_expenses': [],
+            'documents': [],
+            'trips': [
+                {'id': 1, 'date': '2024-01-25', 'start_odometer': 10000.0,
+                 'end_odometer': 10050.0, 'distance': 50.0, 'purpose': 'business',
+                 'description': 'Client visit', 'notes': None},
+            ],
+            'charging_sessions': [
+                {'id': 1, 'date': '2024-01-30', 'start_time': '08:00:00',
+                 'end_time': '09:00:00', 'odometer': 10100.0, 'kwh_added': 40.0,
+                 'cost_per_kwh': 0.3, 'total_cost': 12.0, 'charger_type': 'home'},
+            ],
+            'parts': [
+                {'id': 1, 'name': 'Oil filter', 'part_type': 'filter',
+                 'part_number': 'OF-123', 'quantity': 1.0},
+            ],
+        }],
+        'fuel_stations': [{
+            'id': 3, 'name': 'Shell Anytown', 'brand': 'Shell',
+            'address': '1 High Street', 'city': 'Anytown', 'postcode': 'AN1 1AN',
+            'is_favorite': True, 'times_used': 4,
+        }],
+        'fuel_price_history': [{
+            'id': 1, 'station_id': 3, 'station_name': 'Shell Anytown',
+            'date': '2024-01-15', 'fuel_type': 'petrol', 'price_per_unit': 1.5,
+        }],
+    }
+
+
+def backup_json_bytes(data=None):
+    return json.dumps(data or make_backup_data()).encode('utf-8')
+
+
+def make_full_backup_zip(data=None, files=None):
+    """Build a full backup ZIP in the shape produced by /api/export/backup."""
+    data = data or make_backup_data()
+    files = files or {}
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr('data.json', json.dumps(data))
+        zf.writestr('manifest.json', json.dumps({'files': []}))
+        for name, content in files.items():
+            zf.writestr(f'uploads/{name}', content)
+    buf.seek(0)
+    return buf.read()
+
+
+def upload(client, payload, filename='may_backup.json', path='/api/import/backup/preview'):
+    return client.post(
+        path,
+        data={'file': (io.BytesIO(payload), filename)},
+        content_type='multipart/form-data',
+    )
+
+
+def restore(client, payload, filename='may_backup.json'):
+    """Upload a backup, then confirm the restore."""
+    resp = upload(client, payload, filename)
+    assert resp.status_code == 200, resp.status_code
+    return client.post('/api/import/backup/execute')
+
+
+# ---------------------------------------------------------------------------
+# Access and validation
+# ---------------------------------------------------------------------------
+
+class TestBackupRestoreAccess:
+    def test_upload_page_requires_auth(self, client):
+        resp = client.get('/api/import/backup')
+        assert resp.status_code in (302, 401)
+
+    def test_preview_requires_auth(self, client):
+        resp = client.post('/api/import/backup/preview')
+        assert resp.status_code in (302, 401)
+
+    def test_execute_requires_auth(self, client):
+        resp = client.post('/api/import/backup/execute')
+        assert resp.status_code in (302, 401)
+
+    def test_upload_page_renders(self, auth_client):
+        resp = auth_client.get('/api/import/backup')
+        assert resp.status_code == 200
+        assert b'Restore' in resp.data
+
+    def test_settings_links_to_restore(self, auth_client):
+        resp = auth_client.get('/auth/settings')
+        assert resp.status_code == 200
+        assert b'/api/import/backup' in resp.data
+
+    def test_no_file_redirects(self, auth_client):
+        resp = auth_client.post('/api/import/backup/preview')
+        assert resp.status_code == 302
+
+    def test_invalid_json_redirects(self, auth_client):
+        resp = upload(auth_client, b'not json at all', 'bad.json')
+        assert resp.status_code == 302
+
+    def test_unrelated_json_redirects(self, auth_client, test_user):
+        resp = upload(auth_client, json.dumps({'hello': 'world'}).encode(), 'other.json')
+        assert resp.status_code == 302
+        assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 0
+
+    def test_zip_without_data_json_redirects(self, auth_client):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('something.txt', 'nope')
+        resp = upload(auth_client, buf.getvalue(), 'bad.zip')
+        assert resp.status_code == 302
+
+    def test_execute_without_upload_redirects(self, auth_client):
+        resp = auth_client.post('/api/import/backup/execute')
+        assert resp.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# Preview
+# ---------------------------------------------------------------------------
+
+class TestBackupRestorePreview:
+    def test_preview_shows_counts_and_writes_nothing(self, auth_client, test_user):
+        resp = upload(auth_client, backup_json_bytes())
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert 'Old Car' in body
+        assert 'Fuel logs' in body
+        # Nothing committed by the preview
+        assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 0
+        assert FuelLog.query.count() == 0
+
+    def test_preview_reports_existing_records_as_present(self, auth_client, test_user):
+        restore(auth_client, backup_json_bytes())
+        resp = upload(auth_client, backup_json_bytes())
+        assert resp.status_code == 200
+        assert 'already in your account' in resp.data.decode()
+
+
+# ---------------------------------------------------------------------------
+# Restoring
+# ---------------------------------------------------------------------------
+
+class TestBackupRestoreJson:
+    def test_restores_vehicle_and_records(self, auth_client, test_user):
+        resp = restore(auth_client, backup_json_bytes())
+        assert resp.status_code == 302
+
+        vehicle = Vehicle.query.filter_by(owner_id=test_user.id).one()
+        assert vehicle.name == 'Old Car'
+        assert vehicle.vin == 'VIN123456'
+        assert vehicle.tank_capacity == 47.0
+        assert vehicle.specs.count() == 1
+
+        assert vehicle.fuel_logs.count() == 2
+        log = vehicle.fuel_logs.order_by(FuelLog.date).first()
+        assert log.odometer == 10000.0
+        assert log.station == 'Shell'
+        assert log.user_id == test_user.id
+        assert str(log.date) == '2024-01-15'
+
+        assert vehicle.expenses.count() == 1
+        assert vehicle.trips.count() == 1
+        assert vehicle.charging_sessions.count() == 1
+        assert vehicle.reminders.count() == 1
+        assert vehicle.parts.count() == 1
+
+        session = vehicle.charging_sessions.first()
+        assert str(session.start_time) == '08:00:00'
+
+    def test_restores_stations_and_price_history(self, auth_client, test_user):
+        restore(auth_client, backup_json_bytes())
+        station = FuelStation.query.filter_by(user_id=test_user.id).one()
+        assert station.name == 'Shell Anytown'
+        assert station.is_favorite is True
+        prices = FuelPriceHistory.query.filter_by(station_id=station.id).all()
+        assert len(prices) == 1
+        assert prices[0].price_per_unit == 1.5
+
+    def test_restore_is_idempotent(self, auth_client, test_user):
+        restore(auth_client, backup_json_bytes())
+        restore(auth_client, backup_json_bytes())
+
+        assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 1
+        assert FuelLog.query.count() == 2
+        assert Expense.query.count() == 1
+        assert Trip.query.count() == 1
+        assert ChargingSession.query.count() == 1
+        assert Reminder.query.count() == 1
+        assert VehiclePart.query.count() == 1
+        assert FuelStation.query.filter_by(user_id=test_user.id).count() == 1
+        assert FuelPriceHistory.query.count() == 1
+
+    def test_merges_into_existing_vehicle_without_duplicating(self, auth_client,
+                                                              test_user, sample_vehicle,
+                                                              sample_fuel_log):
+        """A backup vehicle matching an existing one merges rather than duplicating."""
+        data = make_backup_data()
+        data['vehicles'][0].update({
+            'name': sample_vehicle.name,
+            'make': sample_vehicle.make,
+            'model': sample_vehicle.model,
+            'year': sample_vehicle.year,
+            'registration': None,
+            'vin': None,
+        })
+        # One log matches the existing sample log exactly, one is new
+        data['vehicles'][0]['fuel_logs'][0].update({
+            'date': str(sample_fuel_log.date),
+            'odometer': sample_fuel_log.odometer,
+            'volume': sample_fuel_log.volume,
+        })
+
+        restore(auth_client, backup_json_bytes(data))
+
+        assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 1
+        logs = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).all()
+        assert len(logs) == 2
+
+    def test_existing_data_is_never_removed(self, auth_client, test_user,
+                                            sample_vehicle, sample_expense):
+        """Restoring must not touch data the user already has."""
+        restore(auth_client, backup_json_bytes())
+
+        assert Vehicle.query.get(sample_vehicle.id) is not None
+        assert Expense.query.get(sample_expense.id) is not None
+        assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 2
+
+    def test_documents_without_files_are_skipped(self, auth_client, test_user):
+        """A JSON export has no files, so documents cannot be restored from it."""
+        data = make_backup_data()
+        data['vehicles'][0]['documents'] = [{
+            'id': 1, 'title': 'V5C', 'document_type': 'other',
+            'original_filename': 'v5c.pdf', 'file_type': 'pdf',
+        }]
+        restore(auth_client, backup_json_bytes(data))
+        assert Document.query.count() == 0
+
+    def test_restore_only_affects_the_signed_in_account(self, auth_client, test_user,
+                                                        admin_user):
+        restore(auth_client, backup_json_bytes())
+        assert Vehicle.query.filter_by(owner_id=admin_user.id).count() == 0
+        assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 1
+
+
+class TestBackupRestoreZip:
+    def test_restores_documents_and_files_from_zip(self, auth_client, test_user, app):
+        data = make_backup_data()
+        data['vehicles'][0]['documents'] = [{
+            'id': 1, 'title': 'V5C', 'document_type': 'other',
+            'filename': 'doc_abc123_v5c.pdf', 'original_filename': 'v5c.pdf',
+            'file_type': 'pdf', 'file_size': 5,
+        }]
+        payload = make_full_backup_zip(data, {'doc_abc123_v5c.pdf': b'hello'})
+
+        upload_folder = app.config['UPLOAD_FOLDER']
+        target = os.path.join(upload_folder, 'doc_abc123_v5c.pdf')
+        if os.path.exists(target):
+            os.unlink(target)
+
+        try:
+            resp = restore(auth_client, payload, 'may_full_backup.zip')
+            assert resp.status_code == 302
+
+            document = Document.query.one()
+            assert document.title == 'V5C'
+            assert document.filename == 'doc_abc123_v5c.pdf'
+            assert os.path.exists(target)
+            with open(target, 'rb') as handle:
+                assert handle.read() == b'hello'
+        finally:
+            if os.path.exists(target):
+                os.unlink(target)
+
+    def test_vehicle_attachments_restored_from_zip(self, auth_client, test_user, app):
+        data = make_backup_data()
+        data['vehicles'][0]['attachments'] = [{
+            'id': 1, 'filename': 'att_1.png', 'original_filename': 'photo.png',
+            'file_type': 'image', 'file_size': 3,
+        }]
+        data['vehicles'][0]['fuel_logs'][0]['attachments'] = [{
+            'id': 2, 'filename': 'att_2.png', 'original_filename': 'receipt.png',
+            'file_type': 'image', 'file_size': 3,
+        }]
+        payload = make_full_backup_zip(
+            data, {'att_1.png': b'abc', 'att_2.png': b'def'})
+
+        targets = [os.path.join(app.config['UPLOAD_FOLDER'], name)
+                   for name in ('att_1.png', 'att_2.png')]
+        for target in targets:
+            if os.path.exists(target):
+                os.unlink(target)
+
+        try:
+            restore(auth_client, payload, 'may_full_backup.zip')
+            vehicle = Vehicle.query.filter_by(owner_id=test_user.id).one()
+            assert vehicle.attachments.count() == 1
+            log = vehicle.fuel_logs.order_by(FuelLog.date).first()
+            assert log.attachments.count() == 1
+            assert all(os.path.exists(target) for target in targets)
+        finally:
+            for target in targets:
+                if os.path.exists(target):
+                    os.unlink(target)
+
+    def test_zip_restore_is_idempotent(self, auth_client, test_user, app):
+        data = make_backup_data()
+        data['vehicles'][0]['documents'] = [{
+            'id': 1, 'title': 'V5C', 'document_type': 'other',
+            'filename': 'doc_abc123_v5c.pdf', 'original_filename': 'v5c.pdf',
+            'file_type': 'pdf', 'file_size': 5,
+        }]
+        payload = make_full_backup_zip(data, {'doc_abc123_v5c.pdf': b'hello'})
+        target = os.path.join(app.config['UPLOAD_FOLDER'], 'doc_abc123_v5c.pdf')
+        if os.path.exists(target):
+            os.unlink(target)
+
+        try:
+            restore(auth_client, payload, 'may_full_backup.zip')
+            restore(auth_client, payload, 'may_full_backup.zip')
+            assert Document.query.count() == 1
+            assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 1
+        finally:
+            if os.path.exists(target):
+                os.unlink(target)
+
+    def test_zip_entries_outside_uploads_are_ignored(self, auth_client, app):
+        """Path traversal in a backup ZIP must not write outside the uploads folder."""
+        data = make_backup_data()
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('data.json', json.dumps(data))
+            zf.writestr('uploads/../escaped.txt', b'nope')
+            zf.writestr('/etc/passwd', b'nope')
+        payload = buf.getvalue()
+
+        escaped = os.path.join(os.path.dirname(app.config['UPLOAD_FOLDER']), 'escaped.txt')
+        # A traversing entry must not be written outside the uploads folder,
+        # nor quietly flattened into it
+        landed = os.path.join(app.config['UPLOAD_FOLDER'], 'escaped.txt')
+        for path in (escaped, landed):
+            if os.path.exists(path):
+                os.unlink(path)
+
+        resp = restore(auth_client, payload, 'may_full_backup.zip')
+        assert resp.status_code == 302
+        assert not os.path.exists(escaped)
+        assert not os.path.exists(landed)
+
+
+# ---------------------------------------------------------------------------
+# Round trip through the real export endpoints
+# ---------------------------------------------------------------------------
+
+class TestBackupRoundTrip:
+    """What the real export endpoints produce must feed back into the restore.
+
+    This is the issue's actual scenario: a backup taken off one instance is
+    loaded into another, where it lands in a different account. The restore is
+    driven through its service here rather than through the HTTP routes,
+    because the ``app`` fixture pushes a single long-lived app context, so
+    Flask-Login's per-context ``current_user`` cache cannot be swapped to a
+    second account mid-test.
+    """
+
+    def test_json_export_restores_into_another_account(
+            self, auth_client, admin_user, sample_vehicle, sample_fuel_log,
+            sample_expense):
+        exported = auth_client.get('/api/export/json')
+        assert exported.status_code == 200
+        data = json.loads(exported.data)
+
+        summary = restore_backup(data, admin_user)
+        assert summary['total_added'] > 0
+
+        vehicle = Vehicle.query.filter_by(owner_id=admin_user.id).one()
+        assert vehicle.name == sample_vehicle.name
+        assert vehicle.make == sample_vehicle.make
+        assert vehicle.fuel_logs.count() == 1
+        assert vehicle.expenses.count() == 1
+        assert vehicle.fuel_logs.first().odometer == sample_fuel_log.odometer
+        assert vehicle.expenses.first().cost == sample_expense.cost
+
+    def test_full_backup_export_restores_into_another_account(
+            self, app, auth_client, admin_user, sample_vehicle, sample_fuel_log,
+            tmp_path):
+        exported = auth_client.get('/api/export/backup')
+        assert exported.status_code == 200
+
+        archive = tmp_path / 'may_full_backup.zip'
+        archive.write_bytes(exported.data)
+        data, zip_path = read_backup(str(archive))
+        assert zip_path is not None
+
+        summary = restore_backup(data, admin_user, zip_path=zip_path,
+                                 upload_folder=str(tmp_path / 'uploads'))
+        assert summary['total_added'] > 0
+
+        vehicle = Vehicle.query.filter_by(owner_id=admin_user.id).one()
+        assert vehicle.name == sample_vehicle.name
+        assert vehicle.fuel_logs.count() == 1
+
+    def test_round_trip_restore_is_idempotent(
+            self, auth_client, admin_user, sample_vehicle, sample_fuel_log):
+        data = json.loads(auth_client.get('/api/export/json').data)
+
+        restore_backup(data, admin_user)
+        second = restore_backup(data, admin_user)
+        assert second['total_added'] == 0
+
+        assert Vehicle.query.filter_by(owner_id=admin_user.id).count() == 1
+        vehicle = Vehicle.query.filter_by(owner_id=admin_user.id).one()
+        assert vehicle.fuel_logs.count() == 1
+
+    def test_round_trip_leaves_the_original_account_alone(
+            self, auth_client, test_user, admin_user, sample_vehicle,
+            sample_fuel_log):
+        data = json.loads(auth_client.get('/api/export/json').data)
+        restore_backup(data, admin_user)
+
+        assert Vehicle.query.filter_by(owner_id=test_user.id).count() == 1
+        assert FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+    def test_preview_of_a_real_export_writes_nothing(
+            self, auth_client, admin_user, sample_vehicle, sample_fuel_log):
+        data = json.loads(auth_client.get('/api/export/json').data)
+
+        summary = restore_backup(data, admin_user, dry_run=True)
+        assert summary['total_added'] > 0
+        assert Vehicle.query.filter_by(owner_id=admin_user.id).count() == 0

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -2,7 +2,9 @@ import re
 import pytest
 from datetime import date
 from app import db
-from app.models import FuelLog, FuelStation, FuelPriceHistory, Vehicle
+from app.models import (
+    FuelLog, FuelStation, FuelPriceHistory, Vehicle, resolve_price_fuel_type,
+)
 
 
 class TestFuelIndex:
@@ -783,3 +785,124 @@ class TestFuelStationSync:
         assert '"fuel_type": "diesel"' in html
         # ...and the chart groups by fuel type instead of one flat series.
         assert 'byType' in html
+
+
+@pytest.fixture
+def hybrid_vehicle(app, test_user):
+    vehicle = Vehicle(
+        owner_id=test_user.id,
+        name='Hybrid Car',
+        vehicle_type='car',
+        fuel_type='hybrid',
+        odometer_unit='km',
+    )
+    db.session.add(vehicle)
+    db.session.commit()
+    return vehicle
+
+
+class TestPriceHistoryFuelType:
+    """Issue #268: hybrid is a propulsion type, not a fuel, so it must never
+    become its own series in the station price charts."""
+
+    def test_resolve_price_fuel_type(self):
+        assert resolve_price_fuel_type(None, 'hybrid') == 'petrol'
+        assert resolve_price_fuel_type(None, 'plugin_hybrid') == 'petrol'
+        assert resolve_price_fuel_type(None, 'diesel') == 'diesel'
+        assert resolve_price_fuel_type('diesel', 'hybrid') == 'diesel'
+        # An explicitly logged 'hybrid' is still mapped to a real fuel.
+        assert resolve_price_fuel_type('hybrid', 'hybrid') == 'petrol'
+        # No fuel type anywhere falls back to petrol, as before.
+        assert resolve_price_fuel_type(None, None) == 'petrol'
+
+    def test_hybrid_fill_up_records_petrol(
+            self, auth_client, hybrid_vehicle, sample_station):
+        auth_client.post('/fuel/new', data={
+            'vehicle_id': str(hybrid_vehicle.id),
+            'date': '2024-04-01',
+            'odometer': '20000',
+            'volume': '35',
+            'price_per_unit': '1.55',
+            'total_cost': '54.25',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        history = FuelPriceHistory.query.filter_by(
+            station_id=sample_station.id, price_per_unit=1.55).first()
+        assert history is not None
+        assert history.fuel_type == 'petrol'
+
+    def test_hybrid_quick_log_records_petrol(
+            self, auth_client, hybrid_vehicle, sample_station):
+        auth_client.post('/fuel/quick', data={
+            'vehicle_id': str(hybrid_vehicle.id),
+            'odometer': '21000',
+            'volume': '30',
+            'price_per_unit': '1.58',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        history = FuelPriceHistory.query.filter_by(
+            station_id=sample_station.id, price_per_unit=1.58).first()
+        assert history is not None
+        assert history.fuel_type == 'petrol'
+
+    def test_explicit_fuel_type_wins_for_hybrid(
+            self, auth_client, hybrid_vehicle, sample_station):
+        """A diesel hybrid owner picks diesel on the form and it sticks."""
+        auth_client.post('/fuel/new', data={
+            'vehicle_id': str(hybrid_vehicle.id),
+            'date': '2024-04-02',
+            'odometer': '22000',
+            'volume': '40',
+            'price_per_unit': '1.72',
+            'total_cost': '68.80',
+            'fuel_type': 'diesel',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        history = FuelPriceHistory.query.filter_by(
+            station_id=sample_station.id, price_per_unit=1.72).first()
+        assert history is not None
+        assert history.fuel_type == 'diesel'
+
+    def test_edit_updates_price_history_fuel_type(
+            self, auth_client, hybrid_vehicle, sample_station):
+        auth_client.post('/fuel/new', data={
+            'vehicle_id': str(hybrid_vehicle.id),
+            'date': '2024-04-03',
+            'odometer': '23000',
+            'volume': '38',
+            'price_per_unit': '1.60',
+            'total_cost': '60.80',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        log = FuelLog.query.filter_by(vehicle_id=hybrid_vehicle.id).order_by(
+            FuelLog.id.desc()).first()
+        history = FuelPriceHistory.query.filter_by(fuel_log_id=log.id).first()
+        assert history.fuel_type == 'petrol'
+
+        auth_client.post(f'/fuel/{log.id}/edit', data={
+            'vehicle_id': str(hybrid_vehicle.id),
+            'date': '2024-04-03',
+            'odometer': '23000',
+            'volume': '38',
+            'price_per_unit': '1.60',
+            'total_cost': '60.80',
+            'fuel_type': 'diesel',
+            'station_id': str(sample_station.id),
+            'station': sample_station.name,
+            'is_full_tank': 'on',
+        }, follow_redirects=True)
+
+        db.session.refresh(history)
+        assert history.fuel_type == 'diesel'

--- a/tests/test_schema_recovery.py
+++ b/tests/test_schema_recovery.py
@@ -56,6 +56,14 @@ def _seed_legacy_db(path):
           is_active BOOLEAN DEFAULT 1,
           created_at DATETIME
         );
+        CREATE TABLE fuel_stations (
+          id INTEGER PRIMARY KEY,
+          user_id INTEGER NOT NULL,
+          name VARCHAR(100) NOT NULL,
+          brand VARCHAR(50),
+          postcode VARCHAR(20),
+          created_at DATETIME
+        );
         """
     )
     conn.commit()
@@ -89,6 +97,31 @@ def test_legacy_db_recovers_missing_user_columns(tmp_path):
         assert u.start_page == 'dashboard'  # string default applied
         assert u.show_quick_entry is False
         assert u.default_vehicle_id is None
+
+
+def test_legacy_db_gains_multi_column_indexes(tmp_path):
+    """Issue #155: the station price-source columns come with a composite
+    unique index, which the per-column recovery pass cannot create."""
+    import os
+    os.makedirs('/tmp/may_test_uploads', exist_ok=True)
+
+    db_path = tmp_path / 'legacy_stations.db'
+    _seed_legacy_db(str(db_path))
+
+    app = create_app(_TempDBConfig(str(db_path)))
+    with app.app_context():
+        from sqlalchemy import inspect
+        inspector = inspect(db.engine)
+        cols = {c['name'] for c in inspector.get_columns('fuel_stations')}
+        assert {'price_source', 'external_id'} <= cols
+
+        indexes = {i['name']: i for i in inspector.get_indexes('fuel_stations')}
+        index = indexes.get('ix_fuel_stations_source_external_id')
+        assert index is not None
+        assert index['unique']
+
+        db.session.remove()
+        db.engine.dispose()
 
 
 def test_run_schema_migrations_is_idempotent(tmp_path):
@@ -165,9 +198,10 @@ def test_fresh_db_stamps_head_and_replay_survives(tmp_path):
             rev = conn.execute(
                 text('SELECT version_num FROM alembic_version')
             ).scalar()
-        heads = [s.strip() for s in open('migrations/versions/d4e5f6a7b8c0_add_number_format_prefs_to_users.py')
-                 if s.startswith("revision = ")]
-        head = heads[0].split("'")[1]
+        # Resolve the head from Alembic rather than a filename, so adding a
+        # migration does not break this test.
+        from alembic.script import ScriptDirectory
+        head = ScriptDirectory('migrations').get_current_head()
         assert rev == head, f'fresh db stamped {rev}, expected head {head}'
 
         # Simulate the pre-fix broken state and prove the replay now survives.

--- a/tests/test_station_price_source.py
+++ b/tests/test_station_price_source.py
@@ -1,0 +1,145 @@
+"""Tests for the station price-source identity columns (#155).
+
+Saved stations carry ``(price_source, external_id)`` so a live price
+provider's own id for a forecourt can be recorded once and reused, rather
+than re-derived from postcodes and addresses on every run.
+"""
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+
+from app import db
+from app.models import PRICE_SOURCES, FuelStation, User
+
+
+def _station(user, name, **kwargs):
+    station = FuelStation(user_id=user.id, name=name, **kwargs)
+    db.session.add(station)
+    db.session.commit()
+    return station
+
+
+@pytest.fixture
+def other_user(app):
+    user = User(username='otheruser', email='other@example.com')
+    user.set_password('password123')
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+class TestSchema:
+    def test_columns_exist(self, app):
+        cols = {c['name'] for c in inspect(db.engine).get_columns('fuel_stations')}
+        assert 'price_source' in cols
+        assert 'external_id' in cols
+
+    def test_unique_index_exists(self, app):
+        indexes = {i['name']: i for i in inspect(db.engine).get_indexes('fuel_stations')}
+        index = indexes.get('ix_fuel_stations_source_external_id')
+        assert index is not None
+        assert index['unique']
+        assert index['column_names'] == ['user_id', 'price_source', 'external_id']
+
+    def test_defaults_to_unlinked(self, app, test_user):
+        station = _station(test_user, 'Unlinked')
+        assert station.price_source is None
+        assert station.external_id is None
+        assert station.price_source_label is None
+
+    def test_several_unlinked_stations_are_allowed(self, app, test_user):
+        # NULLs compare as distinct, so the unique index must not stop a user
+        # keeping any number of stations with no provider link.
+        _station(test_user, 'One')
+        _station(test_user, 'Two')
+        assert FuelStation.query.filter_by(price_source=None).count() == 2
+
+    def test_same_forecourt_twice_for_one_user_is_rejected(self, app, test_user):
+        _station(test_user, 'One', price_source='uk_fuel_prices', external_id='A1')
+        with pytest.raises(IntegrityError):
+            _station(test_user, 'Two', price_source='uk_fuel_prices', external_id='A1')
+        db.session.rollback()
+
+    def test_same_forecourt_for_two_users_is_allowed(self, app, test_user, other_user):
+        _station(test_user, 'Mine', price_source='uk_fuel_prices', external_id='A1')
+        _station(other_user, 'Theirs', price_source='uk_fuel_prices', external_id='A1')
+        assert FuelStation.query.filter_by(external_id='A1').count() == 2
+
+    def test_same_id_across_sources_is_allowed(self, app, test_user):
+        _station(test_user, 'UK', price_source='uk_fuel_prices', external_id='A1')
+        _station(test_user, 'DE', price_source='tankerkoenig', external_id='A1')
+        assert FuelStation.query.filter_by(external_id='A1').count() == 2
+
+
+class TestLookupAndLinking:
+    def test_find_by_external_id(self, app, test_user):
+        station = _station(test_user, 'Linked',
+                           price_source='uk_fuel_prices', external_id='A1')
+        found = FuelStation.find_by_external_id(test_user.id, 'uk_fuel_prices', 'A1')
+        assert found is station
+
+    def test_find_ignores_other_users(self, app, test_user, other_user):
+        _station(test_user, 'Mine', price_source='uk_fuel_prices', external_id='A1')
+        assert FuelStation.find_by_external_id(
+            other_user.id, 'uk_fuel_prices', 'A1') is None
+
+    def test_find_ignores_other_sources(self, app, test_user):
+        _station(test_user, 'Mine', price_source='uk_fuel_prices', external_id='A1')
+        assert FuelStation.find_by_external_id(
+            test_user.id, 'tankerkoenig', 'A1') is None
+
+    def test_find_with_missing_arguments(self, app, test_user):
+        assert FuelStation.find_by_external_id(test_user.id, None, 'A1') is None
+        assert FuelStation.find_by_external_id(test_user.id, 'uk_fuel_prices', None) is None
+
+    def test_link_records_identity(self, app, test_user):
+        station = _station(test_user, 'Unlinked')
+        assert station.link_price_source('uk_fuel_prices', 'A1') is True
+        db.session.commit()
+        assert station.price_source == 'uk_fuel_prices'
+        assert station.external_id == 'A1'
+
+    def test_link_stringifies_the_id(self, app, test_user):
+        station = _station(test_user, 'Unlinked')
+        station.link_price_source('uk_fuel_prices', 1234)
+        assert station.external_id == '1234'
+
+    def test_link_leaves_an_existing_link_alone(self, app, test_user):
+        station = _station(test_user, 'Linked',
+                           price_source='uk_fuel_prices', external_id='A1')
+        assert station.link_price_source('uk_fuel_prices', 'B2') is False
+        assert station.external_id == 'A1'
+
+    def test_link_refuses_a_clash_with_another_station(self, app, test_user):
+        _station(test_user, 'First', price_source='uk_fuel_prices', external_id='A1')
+        second = _station(test_user, 'Second')
+        assert second.link_price_source('uk_fuel_prices', 'A1') is False
+        assert second.price_source is None
+        db.session.commit()  # must not trip the unique index
+
+    def test_link_ignores_a_missing_id(self, app, test_user):
+        station = _station(test_user, 'Unlinked')
+        assert station.link_price_source('uk_fuel_prices', None) is False
+        assert station.link_price_source(None, 'A1') is False
+        assert station.price_source is None
+
+    def test_price_source_label(self, app, test_user):
+        station = _station(test_user, 'Linked',
+                           price_source='uk_fuel_prices', external_id='A1')
+        assert station.price_source_label == PRICE_SOURCES['uk_fuel_prices']
+
+    def test_price_source_label_falls_back_to_the_key(self, app, test_user):
+        station = _station(test_user, 'Linked',
+                           price_source='something_new', external_id='A1')
+        assert station.price_source_label == 'something_new'
+
+
+class TestExport:
+    def test_json_export_includes_the_link(self, auth_client, test_user):
+        _station(test_user, 'Linked', price_source='uk_fuel_prices', external_id='A1')
+        resp = auth_client.get('/api/export/json')
+        assert resp.status_code == 200
+        stations = resp.get_json()['fuel_stations']
+        assert stations[0]['price_source'] == 'uk_fuel_prices'
+        assert stations[0]['external_id'] == 'A1'

--- a/tests/test_uk_fuel_prices.py
+++ b/tests/test_uk_fuel_prices.py
@@ -8,6 +8,7 @@ from app import db
 from app.models import AppSettings, FuelPriceHistory, FuelStation
 from app.services import uk_fuel_prices as ukfp
 from app.services.uk_fuel_prices import (
+    PRICE_SOURCE,
     SETTING_ENABLED,
     SETTING_FEEDS,
     SETTING_LAST_RUN,
@@ -237,6 +238,80 @@ class TestMatching:
         ]})
         match = UKFuelPriceService.match_forecourt(station, forecourts)
         assert match['site_id'] == 'near'
+
+
+class TestLinkedMatching:
+    """Stations linked to a scheme site_id match on identity alone (#155)."""
+
+    def test_linked_station_matches_its_site_id(self, app, uk_station):
+        uk_station.price_source = PRICE_SOURCE
+        uk_station.external_id = 'B2'
+        db.session.commit()
+
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD)
+        match = UKFuelPriceService.match_forecourt(uk_station, forecourts)
+        # 'B2' wins even though the station's postcode points at 'A1'.
+        assert match['site_id'] == 'B2'
+
+    def test_linked_station_matches_without_a_postcode(self, app, uk_station):
+        uk_station.postcode = None
+        uk_station.price_source = PRICE_SOURCE
+        uk_station.external_id = 'A1'
+        db.session.commit()
+
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD)
+        match = UKFuelPriceService.match_forecourt(uk_station, forecourts)
+        assert match['site_id'] == 'A1'
+
+    def test_link_that_left_the_feed_is_unmatched(self, app, uk_station):
+        uk_station.price_source = PRICE_SOURCE
+        uk_station.external_id = 'GONE'
+        db.session.commit()
+
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD)
+        assert UKFuelPriceService.match_forecourt(uk_station, forecourts) is None
+
+    def test_link_to_another_source_is_ignored(self, app, uk_station):
+        uk_station.price_source = 'tankerkoenig'
+        uk_station.external_id = 'B2'
+        db.session.commit()
+
+        forecourts = UKFuelPriceService.parse_feed(FEED_PAYLOAD)
+        match = UKFuelPriceService.match_forecourt(uk_station, forecourts)
+        assert match['site_id'] == 'A1'
+
+    def test_refresh_records_the_link(self, app, enabled_single_feed, fake_feed,
+                                      uk_station):
+        UKFuelPriceService.refresh_prices()
+        db.session.refresh(uk_station)
+        assert uk_station.price_source == PRICE_SOURCE
+        assert uk_station.external_id == 'A1'
+
+    def test_refresh_uses_the_link_on_later_runs(self, app, enabled_single_feed,
+                                                 fake_feed, uk_station):
+        UKFuelPriceService.refresh_prices()
+
+        # The postcode now points nowhere, but the recorded site_id still does.
+        uk_station.postcode = 'ZZ99 9ZZ'
+        db.session.commit()
+
+        stats = UKFuelPriceService.refresh_prices()
+        assert stats['matched'] == 1
+        assert stats['skipped'] == 0
+
+    def test_refresh_does_not_link_two_stations_to_one_forecourt(
+            self, app, enabled_single_feed, fake_feed, test_user, uk_station):
+        twin = FuelStation(user_id=test_user.id, name='Shell Westminster (dup)',
+                           postcode='SW1A 1AA')
+        db.session.add(twin)
+        db.session.commit()
+
+        stats = UKFuelPriceService.refresh_prices()
+        assert stats['matched'] == 2
+
+        linked = FuelStation.query.filter_by(
+            price_source=PRICE_SOURCE, external_id='A1').all()
+        assert len(linked) == 1
 
 
 class TestRefreshPrices:

--- a/tests/test_vehicles.py
+++ b/tests/test_vehicles.py
@@ -527,3 +527,283 @@ class TestVehicleReportParts:
 
         assert resp.status_code == 200
         assert 'Parts (' not in rendered['html']
+
+
+class TestVehiclePhotos:
+    """#147 — a vehicle keeps a gallery of photos, stored as attachments."""
+
+    @staticmethod
+    def _file(name='photo.png', content=b'fake-image'):
+        import io
+        return (io.BytesIO(content), name)
+
+    def _upload(self, client, vehicle_id, *files, follow_redirects=True):
+        return client.post(
+            f'/vehicles/{vehicle_id}/photos',
+            data={'photo': list(files) or [self._file()]},
+            content_type='multipart/form-data',
+            follow_redirects=follow_redirects,
+        )
+
+    @staticmethod
+    def _add_photo(vehicle, filename='existing.png', upload_folder=None):
+        from app.models import Attachment
+        if upload_folder:
+            (upload_folder / filename).write_bytes(b'fake-image')
+        photo = Attachment(filename=filename, original_filename=filename,
+                           file_type='png', vehicle_id=vehicle.id)
+        db.session.add(photo)
+        db.session.commit()
+        return photo
+
+    def test_upload_requires_auth(self, client, sample_vehicle):
+        resp = self._upload(client, sample_vehicle.id, follow_redirects=False)
+        assert resp.status_code == 302
+        assert '/auth/login' in resp.headers['Location']
+
+    def test_upload_stores_photos(self, auth_client, app, tmp_path, sample_vehicle):
+        from app.models import Attachment
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+
+        resp = self._upload(auth_client, sample_vehicle.id,
+                            self._file('front.png'), self._file('rear.jpg'))
+
+        assert resp.status_code == 200
+        photos = Attachment.query.filter_by(vehicle_id=sample_vehicle.id).all()
+        assert len(photos) == 2
+        assert {p.original_filename for p in photos} == {'front.png', 'rear.jpg'}
+        for photo in photos:
+            assert (tmp_path / photo.filename).exists()
+        assert b'2 photos added' in resp.data
+
+    def test_upload_without_a_file_says_so(self, auth_client, app, tmp_path,
+                                           sample_vehicle):
+        from app.models import Attachment
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+
+        resp = auth_client.post(f'/vehicles/{sample_vehicle.id}/photos',
+                                data={'photo': []},
+                                content_type='multipart/form-data',
+                                follow_redirects=True)
+
+        assert resp.status_code == 200
+        assert b'No photos were selected' in resp.data
+        assert Attachment.query.filter_by(vehicle_id=sample_vehicle.id).count() == 0
+
+    def test_first_photo_becomes_main_image(self, auth_client, app, tmp_path,
+                                            sample_vehicle):
+        from app.models import Attachment
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        assert sample_vehicle.image_filename is None
+
+        self._upload(auth_client, sample_vehicle.id, self._file('front.png'))
+
+        db.session.refresh(sample_vehicle)
+        photo = Attachment.query.filter_by(vehicle_id=sample_vehicle.id).one()
+        assert sample_vehicle.image_filename == photo.filename
+
+    def test_upload_keeps_existing_main_image(self, auth_client, app, tmp_path,
+                                              sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        sample_vehicle.image_filename = 'chosen.png'
+        db.session.commit()
+
+        self._upload(auth_client, sample_vehicle.id, self._file('front.png'))
+
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.image_filename == 'chosen.png'
+
+    def test_unsupported_file_type_is_skipped(self, auth_client, app, tmp_path,
+                                              sample_vehicle):
+        from app.models import Attachment
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+
+        resp = self._upload(auth_client, sample_vehicle.id,
+                            self._file('manual.pdf'), self._file('front.png'))
+
+        assert resp.status_code == 200
+        photos = Attachment.query.filter_by(vehicle_id=sample_vehicle.id).all()
+        assert [p.original_filename for p in photos] == ['front.png']
+        assert b'manual.pdf' in resp.data
+
+    def test_non_owner_cannot_upload(self, client, app, tmp_path, sample_vehicle):
+        from app.models import Attachment, User
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        sample_vehicle.is_shared = True
+        other = User(username='other_user', email='other@example.com')
+        other.set_password('OtherPass123!')
+        db.session.add(other)
+        db.session.commit()
+        client.post('/auth/login', data={'username': 'other_user',
+                                         'password': 'OtherPass123!'},
+                    follow_redirects=True)
+
+        self._upload(client, sample_vehicle.id, self._file('front.png'))
+
+        assert Attachment.query.filter_by(vehicle_id=sample_vehicle.id).count() == 0
+
+    def test_view_lists_photos(self, auth_client, app, tmp_path, sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        self._add_photo(sample_vehicle, 'existing.png', tmp_path)
+
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+
+        assert resp.status_code == 200
+        assert b'existing.png' in resp.data
+        assert b'Photos' in resp.data
+
+    def test_view_shows_carousel_arrows_for_several_photos(self, auth_client, app,
+                                                           tmp_path, sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        sample_vehicle.image_filename = 'main.png'
+        db.session.commit()
+        self._add_photo(sample_vehicle, 'second.png', tmp_path)
+
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+
+        assert b'stepVehicleCarousel' in resp.data
+        assert b'1 / 2' in resp.data
+
+    def test_view_omits_carousel_arrows_for_single_photo(self, auth_client, app,
+                                                         tmp_path, sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        sample_vehicle.image_filename = 'main.png'
+        db.session.commit()
+
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+
+        assert b'stepVehicleCarousel' not in resp.data
+
+    def test_set_primary_photo(self, auth_client, app, tmp_path, sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        photo = self._add_photo(sample_vehicle, 'gallery.png', tmp_path)
+
+        resp = auth_client.post(
+            f'/vehicles/{sample_vehicle.id}/photos/{photo.id}/primary',
+            follow_redirects=True)
+
+        assert resp.status_code == 200
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.image_filename == 'gallery.png'
+
+    def test_set_primary_keeps_previous_main_image_in_gallery(self, auth_client, app,
+                                                              tmp_path, sample_vehicle):
+        from app.models import Attachment
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        (tmp_path / 'abc123_old.png').write_bytes(b'fake-image')
+        sample_vehicle.image_filename = 'abc123_old.png'
+        db.session.commit()
+        photo = self._add_photo(sample_vehicle, 'gallery.png', tmp_path)
+
+        auth_client.post(f'/vehicles/{sample_vehicle.id}/photos/{photo.id}/primary',
+                         follow_redirects=True)
+
+        kept = Attachment.query.filter_by(filename='abc123_old.png').one()
+        assert kept.vehicle_id == sample_vehicle.id
+        assert kept.original_filename == 'old.png'
+        assert (tmp_path / 'abc123_old.png').exists()
+
+    def test_photo_of_another_vehicle_is_rejected(self, auth_client, app, tmp_path,
+                                                  test_user, sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        other = Vehicle(owner_id=test_user.id, name='Other Car', vehicle_type='car')
+        db.session.add(other)
+        db.session.commit()
+        photo = self._add_photo(other, 'other.png', tmp_path)
+
+        auth_client.post(f'/vehicles/{sample_vehicle.id}/photos/{photo.id}/primary',
+                         follow_redirects=True)
+
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.image_filename is None
+
+    def test_delete_photo_removes_record_and_file(self, auth_client, app, tmp_path,
+                                                  sample_vehicle):
+        from app.models import Attachment
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        photo = self._add_photo(sample_vehicle, 'gallery.png', tmp_path)
+
+        resp = auth_client.post(
+            f'/vehicles/{sample_vehicle.id}/photos/{photo.id}/delete',
+            follow_redirects=True)
+
+        assert resp.status_code == 200
+        assert Attachment.query.get(photo.id) is None
+        assert not (tmp_path / 'gallery.png').exists()
+
+    def test_deleting_main_photo_falls_back_to_another(self, auth_client, app,
+                                                       tmp_path, sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        first = self._add_photo(sample_vehicle, 'first.png', tmp_path)
+        self._add_photo(sample_vehicle, 'second.png', tmp_path)
+        sample_vehicle.image_filename = 'first.png'
+        db.session.commit()
+
+        auth_client.post(f'/vehicles/{sample_vehicle.id}/photos/{first.id}/delete',
+                         follow_redirects=True)
+
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.image_filename == 'second.png'
+
+    def test_deleting_last_photo_clears_main_image(self, auth_client, app, tmp_path,
+                                                   sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        photo = self._add_photo(sample_vehicle, 'only.png', tmp_path)
+        sample_vehicle.image_filename = 'only.png'
+        db.session.commit()
+
+        auth_client.post(f'/vehicles/{sample_vehicle.id}/photos/{photo.id}/delete',
+                         follow_redirects=True)
+
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.image_filename is None
+
+    def test_new_main_image_upload_keeps_gallery_file(self, auth_client, app,
+                                                      tmp_path, sample_vehicle):
+        """Replacing the main image must not delete a file the gallery still uses."""
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        self._add_photo(sample_vehicle, 'gallery.png', tmp_path)
+        sample_vehicle.image_filename = 'gallery.png'
+        db.session.commit()
+
+        auth_client.post(f'/vehicles/{sample_vehicle.id}/edit', data={
+            'name': sample_vehicle.name,
+            'vehicle_type': 'car',
+            'tracking_unit': 'mileage',
+            'image': self._file('new.png'),
+        }, content_type='multipart/form-data', follow_redirects=True)
+
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.image_filename != 'gallery.png'
+        assert (tmp_path / 'gallery.png').exists()
+
+    def test_deleting_vehicle_removes_photo_files(self, auth_client, app, tmp_path,
+                                                  sample_vehicle):
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        self._add_photo(sample_vehicle, 'gallery.png', tmp_path)
+
+        auth_client.post(f'/vehicles/{sample_vehicle.id}/delete',
+                         follow_redirects=True)
+
+        assert not (tmp_path / 'gallery.png').exists()
+
+    def test_viewer_without_edit_rights_sees_no_controls(self, client, app, tmp_path,
+                                                         sample_vehicle):
+        from app.models import User
+        app.config['UPLOAD_FOLDER'] = str(tmp_path)
+        sample_vehicle.is_shared = True
+        db.session.commit()
+        self._add_photo(sample_vehicle, 'gallery.png', tmp_path)
+        other = User(username='other_user', email='other@example.com')
+        other.set_password('OtherPass123!')
+        db.session.add(other)
+        db.session.commit()
+        client.post('/auth/login', data={'username': 'other_user',
+                                         'password': 'OtherPass123!'},
+                    follow_redirects=True)
+
+        resp = client.get(f'/vehicles/{sample_vehicle.id}')
+
+        assert resp.status_code == 200
+        assert b'gallery.png' in resp.data
+        assert b'Set as main' not in resp.data


### PR DESCRIPTION
## May 0.30.0

Two new features, one fix, and some groundwork under the bonnet.

### Features

- **Restore a May backup into an existing account.** Settings → Integrations →
  Import Data has a new "Restore May Backup" option that accepts either file the
  export page produces: the JSON export (`.json`) or the full backup (`.zip`).
  A full backup also brings across documents, attachments and vehicle images; a
  JSON export carries the records only. The restore always merges into the
  account you are signed in as — nothing is deleted or overwritten, and records
  already present are skipped rather than duplicated, so re-running the same
  backup is harmless. A preview of exactly what will be added is shown before
  anything is written. ([#265](https://github.com/dannymcc/may/issues/265))
- **A photo gallery for vehicles.** The vehicle page has a new "Photos" section
  that takes as many photos per vehicle as you like, several at a time. Any of
  them can be made the main photo — the one on the dashboard and vehicle list —
  and the header image steps through the rest with left and right arrows. Photos
  are stored as attachments against the vehicle, so the full backup export
  already covers them. Deleting a vehicle removes its photos; deleting the main
  one falls back to another photo, or clears the image if none are left.
  ([#147](https://github.com/dannymcc/may/issues/147))

### Fixes

- **Hybrid fill-ups are recorded against the fuel actually burnt.** Hybrid is how
  a vehicle is driven, not what goes in the tank, so a "hybrid" series no longer
  appears alongside petrol and diesel in the fuel station price charts. Fill-ups
  default to petrol, and the fuel type selector on the fuel form is now offered
  for hybrids and plug-in hybrids so diesel hybrid owners can pick diesel.
  Changing a saved log's fuel type now moves its price history row to match.
  Existing price history is left as it stands, rather than being rewritten and
  risking mislabelling a diesel hybrid's history.
  ([#268](https://github.com/dannymcc/may/issues/268))

### Other

- **Saved stations remember their forecourt.** A station linked to a live price
  feed now records the provider's own id for that forecourt instead of
  re-deriving it from postcode and address on every refresh. A station therefore
  keeps reporting the same forecourt after its postcode is edited, and a
  forecourt that drops out of the feed reads as unmatched rather than quietly
  resolving to a different one. This is groundwork for the Tankerkönig
  integration ([#155](https://github.com/dannymcc/may/issues/155)); live German
  prices are not available yet and that issue stays open.
- README: the restore and the photo gallery are documented, and there is now a
  short "Import & Restore" section covering the Restore, Hammond and Fuelly
  options in one place.

### Upgrading

No action needed. The new `price_source` / `external_id` columns and their unique
index on saved fuel stations are added automatically on first start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restore May backups from JSON or ZIP files with preview, merge, and file recovery.
  - Add vehicle photo galleries with uploads, carousel navigation, primary-photo selection, and deletion.
  - Support multiple fuel types when recording fuel.
  - Remember matched UK fuel stations for more reliable price updates.

- **Bug Fixes**
  - Correct fuel-price handling for hybrid and plug-in hybrid vehicles.
  - Prevent duplicate station matches and improve handling of unmatched forecourts.

- **Documentation**
  - Updated the README and changelog with backup restoration, galleries, fuel logging, and station matching guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->