### PR TITLE
Release v0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Fixed
+
+- Hungarian is selectable again. The translation was merged but the language
+  was never added to the list the settings picker and Babel read from, so it
+  could not be chosen and never rendered.
+  ([#300](https://github.com/dannymcc/may/issues/300))
+
 ## [0.33.0] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,25 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-08-23
+
 ### Fixed
 
-- Hungarian is selectable again. The translation was merged but the language
-  was never added to the list the settings picker and Babel read from, so it
-  could not be chosen and never rendered.
-  ([#300](https://github.com/dannymcc/may/issues/300))
+- Hungarian can now be chosen. The translation contributed by
+  [@burgatshow](https://github.com/burgatshow) in
+  [#290](https://github.com/dannymcc/may/pull/290) is now complete, but the
+  language code was never added to the list the settings picker and Babel read
+  from, so it did not appear in Settings and was never negotiated for browsers
+  asking for it. ([#300](https://github.com/dannymcc/may/issues/300))
+
+### Changed
+
+- The supported languages table in the README now lists Hungarian, and the
+  README explains that a new catalogue must also be registered in `LANGUAGES`
+  before it can be selected.
+- A test checks that every translation catalogue shipped in
+  `app/translations/` is listed in `LANGUAGES` and that every listed language
+  has a compiled catalogue behind it, so the two cannot drift apart again.
 
 ## [0.33.0] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,19 @@ Translations were generated with AI assistance and may contain inaccuracies. If 
 2. Edit the `msgstr` value for any incorrect entry
 3. Submit a pull request with your fix
 
+### Adding a Language
+
+A new catalogue is not offered until the language is registered:
+
+1. Create `app/translations/<lang>/LC_MESSAGES/messages.po` from
+   `app/translations/messages.pot` and translate it
+2. Compile it with `pybabel compile -d app/translations` so a `messages.mo`
+   sits beside the `.po`
+3. Add the code and its native name to `LANGUAGES` in `app/__init__.py` — this
+   is what the settings picker and the browser language negotiation read, so a
+   catalogue that is not listed there can never be selected
+4. Add the language to the table above
+
 ## 🛠️ Tech Stack
 
 - **Backend**: Python / Flask

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ May is available in the following languages:
 | Portuguese (Português) | `pt` | Korean (한국어) | `ko` |
 | Polish (Polski) | `pl` | Czech (Čeština) | `cs` |
 | Russian (Русский) | `ru` | Turkish (Türkçe) | `tr` |
-| Arabic (العربية) | `ar` | | |
+| Arabic (العربية) | `ar` | Hungarian (Magyar) | `hu` |
 
 You can change your language in **Settings > Units & Values > Language**.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,7 @@ LANGUAGES = {
     'de': 'Deutsch',
     'es': 'Español',
     'fr': 'Français',
+    'hu': 'Magyar',
     'it': 'Italiano',
     'nl': 'Nederlands',
     'pt': 'Português',

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.33.0'
+APP_VERSION = '0.33.1'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,64 @@
+"""Tests for language selection — LANGUAGES vs the shipped catalogues (#300)."""
+import os
+
+from flask_babel import force_locale, gettext
+
+from app import LANGUAGES
+
+TRANSLATIONS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'app', 'translations',
+)
+
+
+def _catalogue_dirs():
+    """Language codes that have a directory under app/translations/."""
+    return sorted(
+        name for name in os.listdir(TRANSLATIONS_DIR)
+        if os.path.isdir(os.path.join(TRANSLATIONS_DIR, name))
+    )
+
+
+class TestLanguageCatalogues:
+    def test_every_translation_dir_is_listed(self):
+        # A merged translation that never reaches LANGUAGES is dead weight:
+        # it cannot be picked in settings and Babel never negotiates it.
+        missing = [code for code in _catalogue_dirs() if code not in LANGUAGES]
+        assert missing == [], (
+            f"translation directories not listed in LANGUAGES: {missing}"
+        )
+
+    def test_every_language_has_a_catalogue(self):
+        # The opposite mismatch: a code offered in the picker with no
+        # catalogue behind it falls back to English without saying so.
+        # 'en' is the Babel default/source locale and has no catalogue.
+        missing = [
+            code for code in LANGUAGES
+            if code != 'en' and not os.path.isfile(
+                os.path.join(TRANSLATIONS_DIR, code, 'LC_MESSAGES', 'messages.mo')
+            )
+        ]
+        assert missing == [], (
+            f"languages listed without a compiled catalogue: {missing}"
+        )
+
+    def test_hungarian_is_listed(self):
+        assert LANGUAGES.get('hu') == 'Magyar'
+
+
+class TestLanguagePicker:
+    def test_hungarian_in_settings_picker(self, auth_client):
+        response = auth_client.get('/auth/settings')
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert 'value="hu"' in body
+        assert 'Magyar' in body
+
+
+class TestHungarianStrings:
+    def test_hungarian_strings_render(self, app):
+        # Assert the translation differs from the English source rather than
+        # pinning the exact wording, so revising the catalogue is not a
+        # breaking change.
+        with force_locale('hu'):
+            assert gettext('Dashboard') != 'Dashboard'


### PR DESCRIPTION
## May 0.33.1

A single fix: Hungarian can now be chosen.

### Fixes

- **Hungarian is selectable.** The Hungarian translation, contributed by
  @burgatshow in #290, had been merged and is now complete, but the language
  code was never added to the list the settings picker and the browser
  language negotiation read from. It therefore never appeared in
  **Settings > Units & Values > Language** and was never served to browsers
  asking for Hungarian. It is now listed, and the catalogue renders. (#300)

### Other

- The supported languages table in the README lists Hungarian, and the README
  now explains that a new catalogue has to be registered in `LANGUAGES` before
  it can be selected — the step that was missed here.
- A test checks that every translation catalogue shipped in
  `app/translations/` is listed in `LANGUAGES`, and that every listed language
  has a compiled catalogue behind it, so the two cannot drift apart again.

Thanks to @burgatshow for the Hungarian translation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hungarian as a selectable application language.
  * Added Hungarian translations to the supported-language listings.

* **Documentation**
  * Updated setup guidance for adding and registering new translations.

* **Bug Fixes**
  * Improved consistency between available translations and language settings.

* **Chores**
  * Updated the application version to 0.33.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->