### PR TITLE
Release v0.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Fixed
+
+- Saving an expense, fuel log or note no longer always lands on the vehicle
+  page. Each now returns to its own list, so several entries can be added one
+  after another. Starting from a vehicle page still returns you to that
+  vehicle, as before. ([#283](https://github.com/dannymcc/may/issues/283))
+
 ## [0.33.1] - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,21 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.33.2] - 2026-08-24
+
 ### Fixed
 
 - Saving an expense, fuel log or note no longer always lands on the vehicle
   page. Each now returns to its own list, so several entries can be added one
   after another. Starting from a vehicle page still returns you to that
   vehicle, as before. ([#283](https://github.com/dannymcc/may/issues/283))
+
+### Changed
+
+- The README describes where saving a fuel log, note or expense leaves you.
+- Tests cover both directions for expenses, fuel logs and notes: adding or
+  editing from a list returns to that list, and doing the same from a vehicle
+  page returns to the vehicle.
 
 ## [0.33.1] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Track every fill-up with:
 - Automatic MPG/L per 100km calculations
 - Fuel type selection for vehicles that take more than one fuel, including hybrids (petrol or diesel), so station price charts stay grouped by the fuel actually bought
 
+Saving a fuel log returns you to the fuel log list, unless you started from a vehicle page, in which case you go back to that vehicle. Notes behave the same way.
+
 ### Expenses
 Categorize all vehicle-related costs:
 - Maintenance & Repairs
@@ -206,7 +208,7 @@ Categorize all vehicle-related costs:
 - Accessories
 - Other expenses
 
-Record odometer readings alongside costs, and expand any expense row to see vendor, notes, and links to any attached receipts inline. An expense can have several receipts — select more than one file when adding or editing it. An odometer recorded against an expense counts towards the vehicle's latest reading, alongside fuel logs, trips and charging sessions.
+Record odometer readings alongside costs, and expand any expense row to see vendor, notes, and links to any attached receipts inline. An expense can have several receipts — select more than one file when adding or editing it. An odometer recorded against an expense counts towards the vehicle's latest reading, alongside fuel logs, trips and charging sessions. Saving an expense returns you to the expenses list, unless you started from a vehicle page, in which case you go back to that vehicle.
 
 ### Trips
 Log journeys for mileage and tax records:

--- a/app/routes/expenses.py
+++ b/app/routes/expenses.py
@@ -180,7 +180,12 @@ def new():
         _flash_skipped_attachments(skipped)
 
         flash(_('Expense added successfully'), 'success')
-        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+        # Redirect back to vehicle page if we came from there (#283)
+        if request.form.get('return_to') == 'vehicle':
+            return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+        return redirect(url_for('expenses.index'))
 
     # Pre-select vehicle if provided
     selected_vehicle_id = request.args.get('vehicle_id', type=int) or current_user.default_vehicle_id
@@ -230,7 +235,12 @@ def edit(expense_id):
         db.session.commit()
         _flash_skipped_attachments(skipped)
         flash(_('Expense updated successfully'), 'success')
-        return redirect(url_for('vehicles.view', vehicle_id=expense.vehicle_id))
+
+        # Redirect back to vehicle page if we came from there (#283)
+        if request.form.get('return_to') == 'vehicle':
+            return redirect(url_for('vehicles.view', vehicle_id=expense.vehicle_id))
+
+        return redirect(url_for('expenses.index'))
 
     return render_template('expenses/form.html',
                            expense=expense,
@@ -261,7 +271,12 @@ def delete(expense_id):
     db.session.delete(expense)
     db.session.commit()
     flash(_('Expense deleted successfully'), 'success')
-    return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+    # Redirect back to vehicle page if we came from there (#283)
+    if request.args.get('return_to') == 'vehicle':
+        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+    return redirect(url_for('expenses.index'))
 
 
 @bp.route('/<int:expense_id>/attachments/<int:attachment_id>/delete', methods=['POST'])

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -158,7 +158,12 @@ def new():
                 db.session.commit()
 
         flash(_('Fuel log added successfully'), 'success')
-        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+        # Redirect back to vehicle page if we came from there (#283)
+        if request.form.get('return_to') == 'vehicle':
+            return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+        return redirect(url_for('fuel.index'))
 
     # Pre-select vehicle: explicit param > default vehicle preference
     selected_vehicle_id = request.args.get('vehicle_id', type=int) or current_user.default_vehicle_id
@@ -290,7 +295,12 @@ def edit(log_id):
 
         db.session.commit()
         flash(_('Fuel log updated successfully'), 'success')
-        return redirect(url_for('vehicles.view', vehicle_id=log.vehicle_id))
+
+        # Redirect back to vehicle page if we came from there (#283)
+        if request.form.get('return_to') == 'vehicle':
+            return redirect(url_for('vehicles.view', vehicle_id=log.vehicle_id))
+
+        return redirect(url_for('fuel.index'))
 
     # Get all fuel stations for dropdown (stations are system-wide)
     stations = FuelStation.query.order_by(

--- a/app/routes/notes.py
+++ b/app/routes/notes.py
@@ -63,7 +63,12 @@ def new():
         db.session.add(note)
         db.session.commit()
         flash(_('Note added successfully'), 'success')
-        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+        # Redirect back to vehicle page if we came from there (#283)
+        if request.form.get('return_to') == 'vehicle':
+            return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+        return redirect(url_for('notes.index'))
 
     selected_vehicle_id = request.args.get('vehicle_id', type=int) or current_user.default_vehicle_id
 
@@ -101,7 +106,12 @@ def edit(note_id):
 
         db.session.commit()
         flash(_('Note updated successfully'), 'success')
-        return redirect(url_for('vehicles.view', vehicle_id=note.vehicle_id))
+
+        # Redirect back to vehicle page if we came from there (#283)
+        if request.form.get('return_to') == 'vehicle':
+            return redirect(url_for('vehicles.view', vehicle_id=note.vehicle_id))
+
+        return redirect(url_for('notes.index'))
 
     return render_template('notes/form.html', note=note, vehicles=vehicles,
                            selected_vehicle_id=note.vehicle_id)
@@ -122,4 +132,9 @@ def delete(note_id):
     db.session.delete(note)
     db.session.commit()
     flash(_('Note deleted successfully'), 'success')
-    return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+    # Redirect back to vehicle page if we came from there (#283)
+    if request.args.get('return_to') == 'vehicle':
+        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
+    return redirect(url_for('notes.index'))

--- a/app/templates/expenses/form.html
+++ b/app/templates/expenses/form.html
@@ -121,6 +121,11 @@
             </div>
         </div>
 
+        <!-- Hidden field for return redirect -->
+        {% if request.args.get('return_to') == 'vehicle' or (request.referrer and '/vehicles/' in request.referrer) %}
+        <input type="hidden" name="return_to" value="vehicle">
+        {% endif %}
+
         <div class="flex justify-end space-x-3">
             <a href="{{ url_for('expenses.index') }}"
                class="px-4 py-2 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">

--- a/app/templates/fuel/form.html
+++ b/app/templates/fuel/form.html
@@ -165,6 +165,11 @@
             </div>
         </div>
 
+        <!-- Hidden field for return redirect -->
+        {% if request.args.get('return_to') == 'vehicle' or (request.referrer and '/vehicles/' in request.referrer) %}
+        <input type="hidden" name="return_to" value="vehicle">
+        {% endif %}
+
         <div class="flex justify-end space-x-3">
             <a href="{{ url_for('fuel.index') }}"
                class="px-4 py-2 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">

--- a/app/templates/notes/form.html
+++ b/app/templates/notes/form.html
@@ -57,6 +57,11 @@
             </div>
         </div>
 
+        <!-- Hidden field for return redirect -->
+        {% if request.args.get('return_to') == 'vehicle' or (request.referrer and '/vehicles/' in request.referrer) %}
+        <input type="hidden" name="return_to" value="vehicle">
+        {% endif %}
+
         <div class="flex justify-end space-x-3">
             <a href="{{ url_for('notes.index') }}"
                class="px-4 py-2 border border-gray-300 dark:border-gray-500 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -218,7 +218,7 @@
 <div class="flex flex-wrap gap-3 mb-8">
     {% if vehicle.uses_fuel() and not vehicle.uses_tessie_odometer() %}
     {% if can_write('fuel') %}
-    <a href="{{ url_for('fuel.new', vehicle_id=vehicle.id) }}"
+    <a href="{{ url_for('fuel.new', vehicle_id=vehicle.id, return_to='vehicle') }}"
        class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-yellow-500 hover:bg-yellow-600">
         <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
@@ -248,7 +248,7 @@
     </a>
     {% endif %}
     {% if can_write('expenses') %}
-    <a href="{{ url_for('expenses.new', vehicle_id=vehicle.id) }}"
+    <a href="{{ url_for('expenses.new', vehicle_id=vehicle.id, return_to='vehicle') }}"
        class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-red-500 hover:bg-red-600">
         <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
@@ -964,7 +964,7 @@
                         </div>
                         <div class="flex items-center gap-1">
                             {% if can_write('fuel') %}
-                            <a href="{{ url_for('fuel.edit', log_id=log.id) }}" class="p-1.5 text-gray-400 hover:text-primary-600 rounded hover:bg-gray-100 dark:hover:bg-gray-600" title="Edit">
+                            <a href="{{ url_for('fuel.edit', log_id=log.id, return_to='vehicle') }}" class="p-1.5 text-gray-400 hover:text-primary-600 rounded hover:bg-gray-100 dark:hover:bg-gray-600" title="Edit">
                                 <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                                 </svg>
@@ -1012,14 +1012,14 @@
                         <p class="text-sm font-medium text-gray-900 dark:text-white whitespace-nowrap">{{ expense.cost|money }} {{ current_user.currency }}</p>
                         <div class="flex items-center gap-1">
                             {% if can_write('expenses') %}
-                            <a href="{{ url_for('expenses.edit', expense_id=expense.id) }}" class="p-1.5 text-gray-400 hover:text-primary-600 rounded hover:bg-gray-100 dark:hover:bg-gray-600" title="Edit">
+                            <a href="{{ url_for('expenses.edit', expense_id=expense.id, return_to='vehicle') }}" class="p-1.5 text-gray-400 hover:text-primary-600 rounded hover:bg-gray-100 dark:hover:bg-gray-600" title="Edit">
                                 <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                                 </svg>
                             </a>
                             {% endif %}
                             {% if can_write('expenses') %}
-                            <form method="POST" action="{{ url_for('expenses.delete', expense_id=expense.id) }}" class="inline" onsubmit="return confirm('{{ _('Delete this expense?') }}');">
+                            <form method="POST" action="{{ url_for('expenses.delete', expense_id=expense.id, return_to='vehicle') }}" class="inline" onsubmit="return confirm('{{ _('Delete this expense?') }}');">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-gray-100 dark:hover:bg-gray-600" title="Delete">
                                     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.33.1'
+APP_VERSION = '0.33.2'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_expenses.py
+++ b/tests/test_expenses.py
@@ -323,3 +323,75 @@ class TestExpenseCategories:
         assert resp.status_code == 200
         assert b'AutoShop Ltd' in resp.data
         assert b'Front brakes replaced' in resp.data
+
+
+class TestExpenseRedirects:
+    """Saving an expense returns to the expenses list unless the user came
+    from a vehicle page (#283)."""
+
+    def _payload(self, vehicle, **overrides):
+        data = {
+            'vehicle_id': str(vehicle.id),
+            'date': '2024-04-01',
+            'category': 'maintenance',
+            'description': 'Redirect test',
+            'cost': '25.00',
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_redirects_to_expenses(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/expenses/new', data=self._payload(sample_vehicle),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/expenses/')
+
+    def test_create_returns_to_vehicle_when_requested(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/expenses/new',
+                                data=self._payload(sample_vehicle, return_to='vehicle'),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{sample_vehicle.id}')
+
+    def test_edit_redirects_to_expenses(self, auth_client, sample_expense):
+        resp = auth_client.post(f'/expenses/{sample_expense.id}/edit',
+                                data=self._payload(sample_expense.vehicle),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/expenses/')
+
+    def test_edit_returns_to_vehicle_when_requested(self, auth_client, sample_expense):
+        vehicle_id = sample_expense.vehicle_id
+        resp = auth_client.post(f'/expenses/{sample_expense.id}/edit',
+                                data=self._payload(sample_expense.vehicle, return_to='vehicle'),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
+
+    def test_delete_redirects_to_expenses(self, auth_client, sample_expense):
+        resp = auth_client.post(f'/expenses/{sample_expense.id}/delete',
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/expenses/')
+
+    def test_delete_returns_to_vehicle_when_requested(self, auth_client, sample_expense):
+        vehicle_id = sample_expense.vehicle_id
+        resp = auth_client.post(f'/expenses/{sample_expense.id}/delete?return_to=vehicle',
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
+
+    def test_vehicle_page_expense_links_carry_return_to(self, auth_client, sample_expense):
+        resp = auth_client.get(f'/vehicles/{sample_expense.vehicle_id}')
+        assert resp.status_code == 200
+        assert b'return_to=vehicle' in resp.data
+
+    def test_form_from_vehicle_page_includes_hidden_field(self, auth_client, sample_vehicle):
+        resp = auth_client.get(f'/expenses/new?vehicle_id={sample_vehicle.id}&return_to=vehicle')
+        assert resp.status_code == 200
+        assert b'name="return_to" value="vehicle"' in resp.data
+
+    def test_form_from_expenses_page_omits_hidden_field(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/expenses/new')
+        assert resp.status_code == 200
+        assert b'name="return_to"' not in resp.data

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -906,3 +906,60 @@ class TestPriceHistoryFuelType:
 
         db.session.refresh(history)
         assert history.fuel_type == 'diesel'
+
+
+class TestFuelRedirects:
+    """Saving a fuel log returns to the fuel log list unless the user came
+    from a vehicle page (#283). Deletion keeps the `next` behaviour of #298."""
+
+    def _payload(self, vehicle, **overrides):
+        data = {
+            'vehicle_id': str(vehicle.id),
+            'date': '2024-05-01',
+            'odometer': '16000',
+            'volume': '40.0',
+            'price_per_unit': '1.50',
+            'total_cost': '60.0',
+            'is_full_tank': 'on',
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_redirects_to_fuel_log(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/fuel/new', data=self._payload(sample_vehicle),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/fuel/')
+
+    def test_create_returns_to_vehicle_when_requested(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/fuel/new',
+                                data=self._payload(sample_vehicle, return_to='vehicle'),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{sample_vehicle.id}')
+
+    def test_edit_redirects_to_fuel_log(self, auth_client, sample_fuel_log):
+        resp = auth_client.post(f'/fuel/{sample_fuel_log.id}/edit',
+                                data=self._payload(sample_fuel_log.vehicle),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/fuel/')
+
+    def test_edit_returns_to_vehicle_when_requested(self, auth_client, sample_fuel_log):
+        vehicle_id = sample_fuel_log.vehicle_id
+        resp = auth_client.post(f'/fuel/{sample_fuel_log.id}/edit',
+                                data=self._payload(sample_fuel_log.vehicle,
+                                                   return_to='vehicle'),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
+
+    def test_form_from_vehicle_page_includes_hidden_field(self, auth_client, sample_vehicle):
+        resp = auth_client.get(f'/fuel/new?vehicle_id={sample_vehicle.id}&return_to=vehicle')
+        assert resp.status_code == 200
+        assert b'name="return_to" value="vehicle"' in resp.data
+
+    def test_form_from_fuel_page_omits_hidden_field(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/fuel/new')
+        assert resp.status_code == 200
+        assert b'name="return_to"' not in resp.data

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -112,3 +112,65 @@ class TestNotesDelete:
         resp = auth_client.post(f'/notes/{note_id}/delete', follow_redirects=True)
         assert resp.status_code == 200
         assert Note.query.get(note_id) is None
+
+
+class TestNoteRedirects:
+    """Saving a note returns to the notes list unless the user came from a
+    vehicle page (#283)."""
+
+    def _payload(self, vehicle, **overrides):
+        data = {
+            'vehicle_id': str(vehicle.id),
+            'date': '2024-05-02',
+            'title': 'Redirect test',
+            'content': 'Checking where we land.',
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_redirects_to_notes(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/notes/new', data=self._payload(sample_vehicle),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/notes/')
+
+    def test_create_returns_to_vehicle_when_requested(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/notes/new',
+                                data=self._payload(sample_vehicle, return_to='vehicle'),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{sample_vehicle.id}')
+
+    def test_edit_redirects_to_notes(self, auth_client, sample_note):
+        resp = auth_client.post(f'/notes/{sample_note.id}/edit',
+                                data=self._payload(sample_note.vehicle),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/notes/')
+
+    def test_edit_returns_to_vehicle_when_requested(self, auth_client, sample_note):
+        vehicle_id = sample_note.vehicle_id
+        resp = auth_client.post(f'/notes/{sample_note.id}/edit',
+                                data=self._payload(sample_note.vehicle,
+                                                   return_to='vehicle'),
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
+
+    def test_delete_redirects_to_notes(self, auth_client, sample_note):
+        resp = auth_client.post(f'/notes/{sample_note.id}/delete',
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith('/notes/')
+
+    def test_delete_returns_to_vehicle_when_requested(self, auth_client, sample_note):
+        vehicle_id = sample_note.vehicle_id
+        resp = auth_client.post(f'/notes/{sample_note.id}/delete?return_to=vehicle',
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
+
+    def test_form_from_notes_page_omits_hidden_field(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/notes/new')
+        assert resp.status_code == 200
+        assert b'name="return_to"' not in resp.data


### PR DESCRIPTION
## 0.33.2

A single fix release.

### Fixed

- Saving an expense, fuel log or note no longer always lands on the vehicle
  page. Each now returns to its own list, so several entries can be added one
  after another. Starting from a vehicle page still returns you to that
  vehicle, as before.
  ([#283](https://github.com/dannymcc/may/issues/283))

### Other

- The README now describes where saving a fuel log, note or expense leaves you.
- Tests cover both directions for expenses, fuel logs and notes: adding or
  editing from a list returns to that list, and doing the same from a vehicle
  page returns to the vehicle.

**Full changelog**: https://github.com/dannymcc/may/compare/v0.33.1...v0.33.2
