### PR TITLE
Release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Added
+
+- Outstanding reminders now carry a "Log expense" action. It opens the expense
+  form pre-filled with the reminder's vehicle, title and a matching category;
+  saving the expense completes the reminder and schedules its next occurrence.
+  The cost is entered at that point rather than stored on the reminder, so fees
+  that change between payments stay accurate.
+  ([#296](https://github.com/dannymcc/may/issues/296))
+
 ## [0.33.2] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-24
+
 ### Added
 
 - Outstanding reminders now carry a "Log expense" action. It opens the expense
@@ -18,6 +20,13 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   The cost is entered at that point rather than stored on the reminder, so fees
   that change between payments stay accurate.
   ([#296](https://github.com/dannymcc/may/issues/296))
+
+### Changed
+
+- The reminders list and the expense form now complete a reminder through the
+  same code, so both roll a recurrence forward identically and keep the
+  duplicate guard added for [#232](https://github.com/dannymcc/may/issues/232).
+- The README's reminders section describes the new action.
 
 ## [0.33.2] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Never miss important dates:
 - Insurance renewals
 - Tax payments
 - Custom reminders with flexible recurrence
+- **Log expense**: record what an outstanding reminder cost. The expense form opens pre-filled with the vehicle, the reminder's title and a matching category; saving it records the expense, ticks the reminder off and schedules its next occurrence. The cost is typed at that point, so reminders for fees that change — registration, for instance — stay accurate.
 
 ### Maintenance Schedules
 Plan regular maintenance tasks:

--- a/app/models.py
+++ b/app/models.py
@@ -987,6 +987,11 @@ class Reminder(db.Model):
         from datetime import date
         return (self.due_date - date.today()).days
 
+    def expense_category(self):
+        """The expense category to pre-select when logging an expense for
+        this reminder (#296). Unmapped types fall back to 'other'."""
+        return REMINDER_EXPENSE_CATEGORIES.get(self.reminder_type, 'other')
+
     def to_dict(self):
         """Serialize reminder to dictionary"""
         return {
@@ -1160,6 +1165,18 @@ REMINDER_TYPES = [
     ('oil_change', _l('Oil Change')),
     ('custom', _l('Custom'))
 ]
+
+# Which expense category to pre-select when an expense is logged against a
+# reminder (#296). Types with no obvious equivalent fall back to 'other'.
+REMINDER_EXPENSE_CATEGORIES = {
+    'mot': 'inspection',
+    'service': 'maintenance',
+    'insurance': 'insurance',
+    'tax': 'tax',
+    'registration': 'registration',
+    'tire_change': 'maintenance',
+    'oil_change': 'maintenance',
+}
 
 # Recurrence options. The legacy values (quarterly, biannual) remain accepted on
 # read so saved reminders keep working; new reminders use a unit + interval pair

--- a/app/routes/expenses.py
+++ b/app/routes/expenses.py
@@ -8,7 +8,8 @@ from flask_babel import gettext as _
 from sqlalchemy import func
 from app import db
 from app.utils import parse_decimal
-from app.models import Vehicle, Expense, Attachment, MaintenanceSchedule, EXPENSE_CATEGORIES
+from app.models import Vehicle, Expense, Attachment, MaintenanceSchedule, Reminder, EXPENSE_CATEGORIES
+from app.routes.reminders import complete_reminder
 
 bp = Blueprint('expenses', __name__, url_prefix='/expenses')
 
@@ -99,6 +100,27 @@ def _active_schedules(vehicle_ids):
     ).order_by(MaintenanceSchedule.name).all()
 
 
+def _open_reminder(reminder_id, vehicle_ids, vehicle_id=None):
+    """The outstanding reminder this expense is being logged against (#296).
+
+    Returns None unless the reminder exists, is still open and belongs to a
+    vehicle the user can see — and, once the expense's vehicle is known, to
+    that same vehicle. Completing a reminder is a write to the reminders
+    area, so an account that may not change reminders never gets the link.
+    """
+    if not reminder_id or not current_user.can_write('reminders'):
+        return None
+
+    reminder = Reminder.query.get(reminder_id)
+    if reminder is None or reminder.is_completed:
+        return None
+    if reminder.vehicle_id not in vehicle_ids:
+        return None
+    if vehicle_id is not None and reminder.vehicle_id != vehicle_id:
+        return None
+    return reminder
+
+
 @bp.route('/')
 @login_required
 def index():
@@ -172,6 +194,12 @@ def new():
                 )
                 schedule.calculate_next_due()
 
+        # Optionally complete the reminder this expense was logged for
+        # (#296), rolling a recurring reminder on to its next occurrence.
+        reminder = _open_reminder(request.form.get('reminder_id', type=int),
+                                  [v.id for v in vehicles], vehicle_id)
+        reminder_message = complete_reminder(reminder) if reminder else None
+
         db.session.commit()
 
         # Handle attachment uploads (one or more)
@@ -180,6 +208,8 @@ def new():
         _flash_skipped_attachments(skipped)
 
         flash(_('Expense added successfully'), 'success')
+        if reminder_message:
+            flash(reminder_message, 'success')
 
         # Redirect back to vehicle page if we came from there (#283)
         if request.form.get('return_to') == 'vehicle':
@@ -191,12 +221,19 @@ def new():
     selected_vehicle_id = request.args.get('vehicle_id', type=int) or current_user.default_vehicle_id
 
     vehicle_ids = [v.id for v in vehicles]
+
+    # Logging the expense for a reminder pre-fills the form from it (#296)
+    reminder = _open_reminder(request.args.get('reminder_id', type=int), vehicle_ids)
+    if reminder:
+        selected_vehicle_id = reminder.vehicle_id
+
     return render_template('expenses/form.html',
                            expense=None,
                            vehicles=vehicles,
                            categories=EXPENSE_CATEGORIES,
                            known_vendors=_known_vendors(vehicle_ids),
                            maintenance_schedules=_active_schedules(vehicle_ids),
+                           reminder=reminder,
                            selected_vehicle_id=selected_vehicle_id)
 
 

--- a/app/routes/reminders.py
+++ b/app/routes/reminders.py
@@ -153,17 +153,13 @@ def edit(reminder_id):
                            recurrence_options=RECURRENCE_OPTIONS)
 
 
-@bp.route('/<int:reminder_id>/complete', methods=['POST'])
-@login_required
-def complete(reminder_id):
-    """Mark a reminder as completed"""
-    reminder = Reminder.query.get_or_404(reminder_id)
-    vehicles = current_user.get_all_vehicles()
+def complete_reminder(reminder):
+    """Mark a reminder completed, rolling any recurrence forward.
 
-    if reminder.vehicle not in vehicles:
-        flash(_('Access denied'), 'error')
-        return redirect(url_for('reminders.index'))
-
+    Shared by the reminders list and the expense form (#296) so both
+    schedule the next occurrence the same way. The caller commits and
+    flashes the returned message.
+    """
     reminder.is_completed = True
     reminder.completed_at = datetime.utcnow()
 
@@ -185,12 +181,10 @@ def complete(reminder_id):
             is_completed=False,
         ).first()
 
-        user_format = getattr(current_user, 'date_format', None) or 'DD/MM/YYYY'
-        fmt = DATE_FORMATS.get(user_format, DATE_FORMATS['DD/MM/YYYY'])['default']
+        if not existing:
+            user_format = getattr(current_user, 'date_format', None) or 'DD/MM/YYYY'
+            fmt = DATE_FORMATS.get(user_format, DATE_FORMATS['DD/MM/YYYY'])['default']
 
-        if existing:
-            flash(_('Reminder marked as completed'), 'success')
-        else:
             new_reminder = Reminder(
                 vehicle_id=reminder.vehicle_id,
                 user_id=reminder.user_id,
@@ -203,9 +197,23 @@ def complete(reminder_id):
                 notify_days_before=reminder.notify_days_before
             )
             db.session.add(new_reminder)
-            flash(_('Reminder completed. Next occurrence created for %(date)s') % {'date': new_due_date.strftime(fmt)}, 'success')
-    else:
-        flash(_('Reminder marked as completed'), 'success')
+            return _('Reminder completed. Next occurrence created for %(date)s') % {'date': new_due_date.strftime(fmt)}
+
+    return _('Reminder marked as completed')
+
+
+@bp.route('/<int:reminder_id>/complete', methods=['POST'])
+@login_required
+def complete(reminder_id):
+    """Mark a reminder as completed"""
+    reminder = Reminder.query.get_or_404(reminder_id)
+    vehicles = current_user.get_all_vehicles()
+
+    if reminder.vehicle not in vehicles:
+        flash(_('Access denied'), 'error')
+        return redirect(url_for('reminders.index'))
+
+    flash(complete_reminder(reminder), 'success')
 
     db.session.commit()
 

--- a/app/templates/expenses/form.html
+++ b/app/templates/expenses/form.html
@@ -10,6 +10,16 @@
 
     <form method="POST" enctype="multipart/form-data" class="space-y-6">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {% if reminder %}
+        <!-- Logging this expense against a reminder (#296) -->
+        <input type="hidden" name="reminder_id" id="reminder_id" value="{{ reminder.id }}" data-vehicle-id="{{ reminder.vehicle_id }}">
+        <div id="reminder-notice" class="rounded-md bg-primary-50 dark:bg-gray-700 p-4 text-sm text-gray-700 dark:text-gray-200">
+            {{ _('Saving this expense will also complete the reminder "%(title)s".', title=reminder.title) }}
+            {% if reminder.recurrence != 'none' %}
+            {{ _('Its next occurrence will be scheduled.') }}
+            {% endif %}
+        </div>
+        {% endif %}
         <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
             <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
                 <div class="sm:col-span-2">
@@ -38,7 +48,7 @@
                     <select name="category" id="category" required
                             class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
                         {% for value, label in categories %}
-                        <option value="{{ value }}" {% if expense and expense.category == value %}selected{% endif %}>{{ label }}</option>
+                        <option value="{{ value }}" {% if (expense and expense.category == value) or (not expense and reminder and reminder.expense_category() == value) %}selected{% endif %}>{{ label }}</option>
                         {% endfor %}
                     </select>
                 </div>
@@ -46,7 +56,7 @@
                 <div class="sm:col-span-2">
                     <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Description') }} *</label>
                     <input type="text" name="description" id="description" required
-                           value="{{ expense.description if expense else '' }}"
+                           value="{% if expense %}{{ expense.description }}{% elif reminder %}{{ reminder.title }}{% endif %}"
                            placeholder="{{ _('e.g., Oil change, Annual service') }}"
                            class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
                 </div>
@@ -179,6 +189,21 @@
             }
             vehicleSelect.addEventListener('change', filterSchedules);
             filterSchedules();
+        }
+
+        // Drop the reminder link if the expense is moved to another vehicle (#296)
+        const reminderInput = document.getElementById('reminder_id');
+        if (reminderInput) {
+            const reminderNotice = document.getElementById('reminder-notice');
+            function syncReminderLink() {
+                const match = vehicleSelect.value === reminderInput.dataset.vehicleId;
+                reminderInput.disabled = !match;
+                if (reminderNotice) {
+                    reminderNotice.style.display = match ? '' : 'none';
+                }
+            }
+            vehicleSelect.addEventListener('change', syncReminderLink);
+            syncReminderLink();
         }
     })();
 </script>

--- a/app/templates/reminders/_reminder_row.html
+++ b/app/templates/reminders/_reminder_row.html
@@ -79,6 +79,15 @@
 
             <!-- Actions -->
             <div class="flex items-center space-x-2">
+                {% if not reminder.is_completed and can_write('reminders') and can_write('expenses') %}
+                <!-- Record what this reminder cost, and complete it (#296) -->
+                <a href="{{ url_for('expenses.new', reminder_id=reminder.id) }}"
+                   class="p-2 text-gray-400 hover:text-gray-600 dark:text-gray-400" title="{{ _('Log expense') }}">
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z"/>
+                    </svg>
+                </a>
+                {% endif %}
                 {% if can_write('reminders') %}
                 <a href="{{ url_for('reminders.edit', reminder_id=reminder.id) }}"
                    class="p-2 text-gray-400 hover:text-gray-600 dark:text-gray-400" title="Edit">

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.33.2'
+APP_VERSION = '0.34.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,6 +1,6 @@
 import pytest
 from app import db
-from app.models import Reminder
+from app.models import Expense, Reminder, User, Vehicle
 from datetime import date
 
 
@@ -216,3 +216,153 @@ class TestReminderRecurrenceDuplicates:
             Reminder.is_completed == False,
         ).all()
         assert len(next_occurrences) == 1
+
+
+class TestLogExpenseForReminder:
+    """#296 — record what a reminder cost, and complete it in one step.
+
+    The reminder deliberately stores no amount: the reporter's registration
+    fee varies, so the cost is typed on the expense form at payment time.
+    """
+
+    def _expense_form(self, vehicle, reminder=None, **overrides):
+        data = {
+            'vehicle_id': str(vehicle.id),
+            'date': '2026-03-01',
+            'category': 'registration',
+            'description': 'Registration',
+            'cost': '210.50',
+        }
+        if reminder is not None:
+            data['reminder_id'] = str(reminder.id)
+        data.update(overrides)
+        return data
+
+    def test_open_reminder_offers_the_action(self, auth_client, sample_reminder):
+        resp = auth_client.get('/reminders/')
+        assert resp.status_code == 200
+        assert f'/expenses/new?reminder_id={sample_reminder.id}'.encode() in resp.data
+
+    def test_completed_reminder_does_not_offer_the_action(self, auth_client, sample_reminder):
+        sample_reminder.is_completed = True
+        db.session.commit()
+
+        resp = auth_client.get('/reminders/?completed=true')
+        assert resp.status_code == 200
+        assert f'/expenses/new?reminder_id={sample_reminder.id}'.encode() not in resp.data
+
+    def test_form_is_prefilled_from_the_reminder(self, auth_client, sample_reminder):
+        resp = auth_client.get(f'/expenses/new?reminder_id={sample_reminder.id}')
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert f'name="reminder_id" id="reminder_id" value="{sample_reminder.id}"' in body
+        # Description from the title, category mapped from the reminder type
+        assert 'value="MOT Due"' in body
+        assert '<option value="inspection" selected>' in body
+
+    def test_unknown_reminder_is_ignored_on_the_form(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/expenses/new?reminder_id=9999')
+        assert resp.status_code == 200
+        assert 'name="reminder_id"' not in resp.data.decode()
+
+    def test_saving_the_expense_completes_the_reminder(self, auth_client, sample_vehicle,
+                                                       sample_reminder, test_user):
+        resp = auth_client.post('/expenses/new',
+                                data=self._expense_form(sample_vehicle, sample_reminder),
+                                follow_redirects=True)
+        assert resp.status_code == 200
+
+        expense = Expense.query.filter_by(description='Registration').first()
+        assert expense is not None
+        assert expense.cost == 210.50
+
+        db.session.refresh(sample_reminder)
+        assert sample_reminder.is_completed is True
+
+    def test_recurring_reminder_rolls_forward(self, auth_client, sample_vehicle, test_user):
+        reminder = Reminder(
+            vehicle_id=sample_vehicle.id, user_id=test_user.id,
+            title='Registration', reminder_type='registration',
+            due_date=date(2026, 3, 1),
+            recurrence='monthly', recurrence_interval=6,
+        )
+        db.session.add(reminder)
+        db.session.commit()
+
+        auth_client.post('/expenses/new',
+                         data=self._expense_form(sample_vehicle, reminder),
+                         follow_redirects=True)
+
+        db.session.refresh(reminder)
+        assert reminder.is_completed is True
+
+        next_occurrences = Reminder.query.filter(
+            Reminder.title == 'Registration',
+            Reminder.is_completed == False,
+        ).all()
+        assert len(next_occurrences) == 1
+        assert next_occurrences[0].due_date == date(2026, 9, 1)
+        assert next_occurrences[0].recurrence_interval == 6
+
+    def test_expense_saves_without_a_reminder(self, auth_client, sample_vehicle):
+        resp = auth_client.post('/expenses/new',
+                                data=self._expense_form(sample_vehicle),
+                                follow_redirects=True)
+        assert resp.status_code == 200
+        assert Expense.query.filter_by(description='Registration').first() is not None
+
+    def test_reminder_on_another_vehicle_is_ignored(self, auth_client, sample_vehicle,
+                                                    sample_reminder, test_user):
+        other = Vehicle(owner_id=test_user.id, name='Second Car', vehicle_type='car')
+        db.session.add(other)
+        db.session.commit()
+
+        auth_client.post('/expenses/new',
+                         data=self._expense_form(other, sample_reminder),
+                         follow_redirects=True)
+
+        db.session.refresh(sample_reminder)
+        assert sample_reminder.is_completed is False
+
+    def test_reminder_the_user_cannot_see_is_ignored(self, auth_client, sample_vehicle):
+        stranger = User(username='stranger', email='stranger@example.com')
+        stranger.set_password('StrangerPass123!')
+        db.session.add(stranger)
+        db.session.commit()
+
+        their_vehicle = Vehicle(owner_id=stranger.id, name='Their Car', vehicle_type='car')
+        db.session.add(their_vehicle)
+        db.session.commit()
+
+        their_reminder = Reminder(
+            vehicle_id=their_vehicle.id, user_id=stranger.id,
+            title='Their MOT', reminder_type='mot',
+            due_date=date(2026, 3, 1), recurrence='none',
+        )
+        db.session.add(their_reminder)
+        db.session.commit()
+
+        auth_client.post('/expenses/new',
+                         data=self._expense_form(sample_vehicle, their_reminder),
+                         follow_redirects=True)
+
+        db.session.refresh(their_reminder)
+        assert their_reminder.is_completed is False
+
+    def test_already_completed_reminder_is_not_rolled_again(self, auth_client, sample_vehicle,
+                                                            test_user):
+        reminder = Reminder(
+            vehicle_id=sample_vehicle.id, user_id=test_user.id,
+            title='Registration', reminder_type='registration',
+            due_date=date(2026, 3, 1),
+            recurrence='monthly', recurrence_interval=6,
+            is_completed=True,
+        )
+        db.session.add(reminder)
+        db.session.commit()
+
+        auth_client.post('/expenses/new',
+                         data=self._expense_form(sample_vehicle, reminder),
+                         follow_redirects=True)
+
+        assert Reminder.query.filter_by(title='Registration', is_completed=False).count() == 0


### PR DESCRIPTION
## Features

- **Log an expense against a reminder.** Outstanding reminders now carry a "Log expense" action. It opens the expense form pre-filled with the reminder's vehicle, its title and a matching category; saving the expense completes the reminder and schedules its next occurrence. The cost is entered at that point rather than stored on the reminder, so fees that change between payments — registration, for instance — stay accurate. ([#296](https://github.com/dannymcc/may/issues/296))

## Other

- The reminders list and the expense form now complete a reminder through the same code, so both roll a recurrence forward identically and keep the duplicate guard added for [#232](https://github.com/dannymcc/may/issues/232).
- The README's reminders section describes the new action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Log expense” action for outstanding reminders.
  - Expense forms can be pre-filled with the relevant vehicle, description and category.
  - Saving a linked expense completes the reminder and schedules its next occurrence where applicable.
  - Added safeguards to prevent duplicate recurring reminders and invalid reminder links.

- **Documentation**
  - Updated the reminders documentation with the new expense-logging workflow.

- **Chores**
  - Updated the application version to 0.34.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->