### PR TITLE
Release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-08-24
+
 ### Changed
 
 - Deleting a fuel log accepts the same `return_to=vehicle` parameter the new
@@ -17,6 +19,7 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   sent back to rather than relying on the default. The older `next` parameter
   still works exactly as before, so existing links and bookmarks are
   unaffected. ([#312](https://github.com/dannymcc/may/issues/312))
+- The README's fuel logs section says where deleting a log leaves you.
 
 ## [0.34.1] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Changed
+
+- Deleting a fuel log accepts the same `return_to=vehicle` parameter the new
+  and edit fuel routes take, so the vehicle page now says where it wants to be
+  sent back to rather than relying on the default. The older `next` parameter
+  still works exactly as before, so existing links and bookmarks are
+  unaffected. ([#312](https://github.com/dannymcc/may/issues/312))
+
 ## [0.34.1] - 2026-08-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Track every fill-up with:
 - Automatic MPG/L per 100km calculations
 - Fuel type selection for vehicles that take more than one fuel, including hybrids (petrol or diesel), so station price charts stay grouped by the fuel actually bought
 
-Saving a fuel log returns you to the fuel log list, unless you started from a vehicle page, in which case you go back to that vehicle. Notes behave the same way.
+Saving a fuel log returns you to the fuel log list, unless you started from a vehicle page, in which case you go back to that vehicle. Deleting one does the same: from the fuel log list you stay on the list, from a vehicle page you return to that vehicle. Notes behave the same way.
 
 ### Expenses
 Categorize all vehicle-related costs:

--- a/app/routes/fuel.py
+++ b/app/routes/fuel.py
@@ -359,8 +359,15 @@ def delete(log_id):
     db.session.delete(log)
     db.session.commit()
     flash(_('Fuel log deleted successfully'), 'success')
+    # Redirect back to vehicle page if we came from there (#283), using the
+    # same `return_to` token the new and edit routes take (#312).
+    return_to = request.form.get('return_to') or request.args.get('return_to')
+    if return_to == 'vehicle':
+        return redirect(url_for('vehicles.view', vehicle_id=vehicle_id))
+
     # Return to wherever the delete came from (#298): deleting from the fuel
-    # log should stay there rather than bouncing to the vehicle page.
+    # log should stay there rather than bouncing to the vehicle page. `next`
+    # stays supported so existing links and bookmarks keep working.
     next_url = get_safe_redirect_url(request.form.get('next'), default=None)
     return redirect(next_url or url_for('vehicles.view', vehicle_id=vehicle_id))
 

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -973,6 +973,7 @@
                             {% if can_write('fuel') %}
                             <form method="POST" action="{{ url_for('fuel.delete', log_id=log.id) }}" class="inline" onsubmit="return confirm('{{ _('Delete this fuel log?') }}');">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <input type="hidden" name="return_to" value="vehicle">
                                 <button type="submit" class="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-gray-100 dark:hover:bg-gray-600" title="Delete">
                                     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.34.1'
+APP_VERSION = '0.35.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -175,6 +175,39 @@ class TestFuelDelete:
         assert 'evil.example' not in resp.headers['Location']
         assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
 
+    def test_delete_return_to_vehicle(self, auth_client, sample_fuel_log):
+        """#312 — delete takes the same return_to token as new and edit."""
+        log_id = sample_fuel_log.id
+        vehicle_id = sample_fuel_log.vehicle_id
+        resp = auth_client.post(f'/fuel/{log_id}/delete',
+                                data={'return_to': 'vehicle'},
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
+        assert FuelLog.query.get(log_id) is None
+
+    def test_delete_return_to_vehicle_in_query(self, auth_client, sample_fuel_log):
+        """return_to is read from the query string too, as on the other deletes."""
+        log_id = sample_fuel_log.id
+        vehicle_id = sample_fuel_log.vehicle_id
+        resp = auth_client.post(f'/fuel/{log_id}/delete?return_to=vehicle',
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers['Location'].endswith(f'/vehicles/{vehicle_id}')
+        assert FuelLog.query.get(log_id) is None
+
+    def test_delete_ignores_unknown_return_to(self, auth_client, sample_fuel_log):
+        """Only the known token is honoured; anything else falls through to next."""
+        log_id = sample_fuel_log.id
+        resp = auth_client.post(f'/fuel/{log_id}/delete',
+                                data={'return_to': 'http://evil.example/',
+                                      'next': '/fuel/'},
+                                follow_redirects=False)
+        assert resp.status_code == 302
+        assert 'evil.example' not in resp.headers['Location']
+        assert resp.headers['Location'].endswith('/fuel/')
+        assert FuelLog.query.get(log_id) is None
+
 
 class TestPartialFillConsumption:
     """#194 — partial fills return no consumption; the next full fill


### PR DESCRIPTION
## May 0.35.0

### Features

- Deleting a fuel log now accepts the same `return_to=vehicle` parameter the new
  and edit fuel routes already take. The vehicle page says where it wants to be
  sent back to rather than relying on the route's default, so the three fuel
  actions behave consistently. ([#312](https://github.com/dannymcc/may/issues/312))

### Other

- The older `next` parameter on the fuel delete route still works exactly as
  before, so existing links and bookmarks are unaffected. Deleting from the fuel
  log list continues to leave you on the list.
- The README's fuel logs section now says where deleting a log leaves you, not
  just where saving one does.

**Full changelog:** https://github.com/dannymcc/may/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fuel-log deletion now supports returning directly to the associated vehicle page.
  * Existing navigation options remain available, including safe return destinations.
* **Documentation**
  * Updated guidance to clarify that deleting a fuel log follows the same return-navigation behaviour as saving.
* **Chores**
  * Updated the application version to 0.35.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->