### PR TITLE
Release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Fixed
+
+- Several pages ran off the right-hand side on a phone. The rows of action
+  buttons at the top of the vehicle, trips, stations and document pages now
+  wrap onto a second line instead of dragging the page wider than the screen,
+  and the tyre fitting history, expenses spend-by-vendor, user management and
+  backup preview tables scroll sideways like every other table rather than
+  overflowing or being clipped.
+  ([#314](https://github.com/dannymcc/may/issues/314))
+
 ## [0.35.0] - 2026-08-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-08-24
+
 ### Fixed
 
 - Several pages ran off the right-hand side on a phone. The rows of action

--- a/app/templates/auth/users.html
+++ b/app/templates/auth/users.html
@@ -11,55 +11,57 @@
 </div>
 
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-        <thead class="bg-gray-50 dark:bg-gray-700">
-            <tr>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Username</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Email</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Admin</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Role') }}</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Joined</th>
-                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
-            </tr>
-        </thead>
-        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-            {% for user in users %}
-            <tr>
-                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
-                    {{ user.username }}
-                    {% if user.id == current_user.id %}
-                    <span class="ml-2 text-xs text-gray-400">(you)</span>
-                    {% endif %}
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.email }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                    {% if user.is_admin %}
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Yes</span>
-                    {% else %}
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-600 text-gray-800">No</span>
-                    {% endif %}
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.role_label }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.created_at|format_date }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    <a href="{{ url_for('auth.edit_user', user_id=user.id) }}" class="text-primary-600 hover:text-primary-900 mr-4">Edit</a>
-                    {% if user.id != current_user.id %}
-                    <form method="POST" action="{{ url_for('auth.toggle_admin', user_id=user.id) }}" class="inline">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="text-primary-600 hover:text-primary-900 mr-4">
-                            {% if user.is_admin %}Remove Admin{% else %}Make Admin{% endif %}
-                        </button>
-                    </form>
-                    <form method="POST" action="{{ url_for('auth.delete_user', user_id=user.id) }}" class="inline"
-                          onsubmit="return confirm('Are you sure you want to delete this user?');">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="text-red-600 hover:text-red-900">Delete</button>
-                    </form>
-                    {% endif %}
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Username</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Email</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Admin</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Role') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Joined</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                {% for user in users %}
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                        {{ user.username }}
+                        {% if user.id == current_user.id %}
+                        <span class="ml-2 text-xs text-gray-400">(you)</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.email }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                        {% if user.is_admin %}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Yes</span>
+                        {% else %}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-600 text-gray-800">No</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.role_label }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ user.created_at|format_date }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <a href="{{ url_for('auth.edit_user', user_id=user.id) }}" class="text-primary-600 hover:text-primary-900 mr-4">Edit</a>
+                        {% if user.id != current_user.id %}
+                        <form method="POST" action="{{ url_for('auth.toggle_admin', user_id=user.id) }}" class="inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="text-primary-600 hover:text-primary-900 mr-4">
+                                {% if user.is_admin %}Remove Admin{% else %}Make Admin{% endif %}
+                            </button>
+                        </form>
+                        <form method="POST" action="{{ url_for('auth.delete_user', user_id=user.id) }}" class="inline"
+                              onsubmit="return confirm('Are you sure you want to delete this user?');">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <button type="submit" class="text-red-600 hover:text-red-900">Delete</button>
+                        </form>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 </div>
 {% endblock %}

--- a/app/templates/documents/view.html
+++ b/app/templates/documents/view.html
@@ -9,7 +9,7 @@
 <div class="max-w-2xl mx-auto">
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden">
         <div class="p-6 border-b border-gray-200 dark:border-gray-700">
-            <div class="flex items-start justify-between">
+            <div class="flex flex-wrap items-start justify-between gap-4">
                 <div>
                     <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ document.title }}</h1>
                     <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
@@ -17,7 +17,7 @@
                         {{ dict(document_types).get(document.document_type, document.document_type) }}
                     </p>
                 </div>
-                <div class="flex gap-2">
+                <div class="flex flex-wrap gap-2">
                     <a href="{{ url_for('documents.download', document_id=document.id) }}"
                        class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 dark:bg-gray-700 hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600">
                         <svg class="-ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/templates/expenses/index.html
+++ b/app/templates/expenses/index.html
@@ -135,24 +135,26 @@
     <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
         <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('Spend by Vendor') }}</h2>
     </div>
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-        <thead class="bg-gray-50 dark:bg-gray-700">
-            <tr>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Vendor') }}</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Expenses') }}</th>
-                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Total') }}</th>
-            </tr>
-        </thead>
-        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-            {% for vendor, total, count in vendor_totals %}
-            <tr>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ vendor }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ count }}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900 dark:text-white">{{ total|money }} {{ current_user.currency }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Vendor') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Expenses') }}</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Total') }}</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                {% for vendor, total, count in vendor_totals %}
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">{{ vendor }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ count }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900 dark:text-white">{{ total|money }} {{ current_user.currency }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 </div>
 {% endif %}
 

--- a/app/templates/import/backup_preview.html
+++ b/app/templates/import/backup_preview.html
@@ -29,32 +29,34 @@
     </div>
 
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden mb-6">
-        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead class="bg-gray-50 dark:bg-gray-700">
-                <tr>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Data') }}</th>
-                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Will be added') }}</th>
-                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Already present') }}</th>
-                </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                {% for key, label in section_labels.items() %}
-                {% set counts = summary[key] %}
-                {% if counts.added or counts.skipped %}
-                <tr>
-                    <td class="px-6 py-3 text-sm text-gray-900 dark:text-white">{{ label }}</td>
-                    <td class="px-6 py-3 text-sm text-right text-gray-900 dark:text-white">{{ counts.added }}</td>
-                    <td class="px-6 py-3 text-sm text-right text-gray-500 dark:text-gray-400">{{ counts.skipped }}</td>
-                </tr>
-                {% endif %}
-                {% endfor %}
-                <tr class="bg-gray-50 dark:bg-gray-700 font-medium">
-                    <td class="px-6 py-3 text-sm text-gray-900 dark:text-white">{{ _('Total') }}</td>
-                    <td class="px-6 py-3 text-sm text-right text-gray-900 dark:text-white">{{ summary.total_added }}</td>
-                    <td class="px-6 py-3 text-sm text-right text-gray-500 dark:text-gray-400">{{ summary.total_skipped }}</td>
-                </tr>
-            </tbody>
-        </table>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Data') }}</th>
+                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Will be added') }}</th>
+                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">{{ _('Already present') }}</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for key, label in section_labels.items() %}
+                    {% set counts = summary[key] %}
+                    {% if counts.added or counts.skipped %}
+                    <tr>
+                        <td class="px-6 py-3 text-sm text-gray-900 dark:text-white">{{ label }}</td>
+                        <td class="px-6 py-3 text-sm text-right text-gray-900 dark:text-white">{{ counts.added }}</td>
+                        <td class="px-6 py-3 text-sm text-right text-gray-500 dark:text-gray-400">{{ counts.skipped }}</td>
+                    </tr>
+                    {% endif %}
+                    {% endfor %}
+                    <tr class="bg-gray-50 dark:bg-gray-700 font-medium">
+                        <td class="px-6 py-3 text-sm text-gray-900 dark:text-white">{{ _('Total') }}</td>
+                        <td class="px-6 py-3 text-sm text-right text-gray-900 dark:text-white">{{ summary.total_added }}</td>
+                        <td class="px-6 py-3 text-sm text-right text-gray-500 dark:text-gray-400">{{ summary.total_skipped }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 
     {% if summary.vehicle_details %}

--- a/app/templates/stations/index.html
+++ b/app/templates/stations/index.html
@@ -7,7 +7,7 @@
         <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ _('Fuel Stations') }}</h1>
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Your favorite fuel stations') }}</p>
     </div>
-    <div class="flex gap-2">
+    <div class="flex flex-wrap gap-2">
         {% if uk_fuel_enabled %}
         <form method="post" action="{{ url_for('stations.refresh_uk_prices') }}">
             <button type="submit"

--- a/app/templates/tires/index.html
+++ b/app/templates/tires/index.html
@@ -118,36 +118,38 @@
         {% if fitments %}
         <details class="mt-4">
             <summary class="text-sm text-primary-600 hover:text-primary-500 cursor-pointer">{{ _('Fitting history') }}</summary>
-            <table class="mt-3 min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
-                <thead>
-                    <tr>
-                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('On') }}</th>
-                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Off') }}</th>
-                        <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Distance') }}</th>
-                        <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Actions') }}</th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                    {% for f in fitments %}
-                    <tr>
-                        <td class="px-3 py-2 whitespace-nowrap text-gray-900 dark:text-white">{{ f.fitted_date|format_date }} &middot; {{ f.fitted_odometer|groupnum }} {{ unit }}</td>
-                        <td class="px-3 py-2 whitespace-nowrap text-gray-900 dark:text-white">
-                            {% if f.removed_odometer is not none %}{{ f.removed_date|format_date }} &middot; {{ f.removed_odometer|groupnum }} {{ unit }}{% else %}{{ _('Still on') }}{% endif %}
-                        </td>
-                        <td class="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-gray-400">{{ f.get_distance(current_odometer)|groupnum }} {{ unit }}</td>
-                        <td class="px-3 py-2 whitespace-nowrap text-right">
-                            {% if can_write('tires') %}
-                            <form method="POST" action="{{ url_for('tires.delete_fitment', fitment_id=f.id) }}" class="inline"
-                                  onsubmit="return confirm('{{ _('Delete this fitting record?') }}');">
-                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                <button type="submit" class="text-red-600 hover:text-red-900">{{ _('Delete') }}</button>
-                            </form>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            <div class="mt-3 overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                    <thead>
+                        <tr>
+                            <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('On') }}</th>
+                            <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Off') }}</th>
+                            <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Distance') }}</th>
+                            <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Actions') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                        {% for f in fitments %}
+                        <tr>
+                            <td class="px-3 py-2 whitespace-nowrap text-gray-900 dark:text-white">{{ f.fitted_date|format_date }} &middot; {{ f.fitted_odometer|groupnum }} {{ unit }}</td>
+                            <td class="px-3 py-2 whitespace-nowrap text-gray-900 dark:text-white">
+                                {% if f.removed_odometer is not none %}{{ f.removed_date|format_date }} &middot; {{ f.removed_odometer|groupnum }} {{ unit }}{% else %}{{ _('Still on') }}{% endif %}
+                            </td>
+                            <td class="px-3 py-2 whitespace-nowrap text-gray-500 dark:text-gray-400">{{ f.get_distance(current_odometer)|groupnum }} {{ unit }}</td>
+                            <td class="px-3 py-2 whitespace-nowrap text-right">
+                                {% if can_write('tires') %}
+                                <form method="POST" action="{{ url_for('tires.delete_fitment', fitment_id=f.id) }}" class="inline"
+                                      onsubmit="return confirm('{{ _('Delete this fitting record?') }}');">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="text-red-600 hover:text-red-900">{{ _('Delete') }}</button>
+                                </form>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </details>
         {% endif %}
 

--- a/app/templates/trips/index.html
+++ b/app/templates/trips/index.html
@@ -7,7 +7,7 @@
         <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ _('Trips') }}</h1>
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _('Track your trips for mileage and tax deductions') }}</p>
     </div>
-    <div class="flex gap-2">
+    <div class="flex flex-wrap gap-2">
         <a href="{{ url_for('trips.templates_index') }}"
            class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
             <svg class="-ml-1 mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -47,12 +47,12 @@
         </div>
         {% endif %}
         <div class="p-6 {% if carousel %}md:w-2/3{% endif %}">
-            <div class="flex items-start justify-between">
+            <div class="flex flex-wrap items-start justify-between gap-4">
                 <div>
                     <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ vehicle.name }}</h1>
                     <p class="text-gray-500 dark:text-gray-400">{{ vehicle.make or '' }} {{ vehicle.model or '' }} {% if vehicle.year %}({{ vehicle.year }}){% endif %}</p>
                 </div>
-                <div class="flex space-x-2">
+                <div class="flex flex-wrap gap-2">
                     <a href="{{ url_for('vehicles.report', vehicle_id=vehicle.id) }}"
                        class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:bg-gray-700"
                        title="{{ _('Download PDF Report') }}">
@@ -283,7 +283,7 @@
 
 <!-- Photos (#147) -->
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8" id="photos">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
         <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('Photos') }}</h2>
         {% if can_edit %}
         {% if can_write('vehicles') %}
@@ -345,7 +345,7 @@
 <!-- DVLA Status Section (UK Vehicles) -->
 {% if vehicle.registration and dvla_configured %}
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8" id="dvla-section">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center">
             <svg class="h-5 w-5 text-blue-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
@@ -443,7 +443,7 @@
 <!-- Tessie Status Section (Tesla Vehicles) -->
 {% if vehicle.tessie_enabled and vehicle.tessie_vin and tessie_configured %}
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8" id="tessie-section">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center">
             <svg class="h-5 w-5 text-red-500 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
@@ -453,7 +453,7 @@
                 {{ _('Live') }}
             </span>
         </div>
-        <div class="flex gap-2">
+        <div class="flex flex-wrap gap-2">
             <button onclick="importTessieCharges({{ vehicle.id }})" id="tessie-import-btn"
                     class="inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-600">
                 <svg class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -557,7 +557,7 @@
 {% if annual_mileage_stats %}
 {% set ms = annual_mileage_stats %}
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center">
             <svg class="h-5 w-5 text-gray-400 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
@@ -635,7 +635,7 @@
 <!-- Reminders Section -->
 {% if reminders %}
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center">
             <svg class="h-5 w-5 text-gray-400 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
@@ -749,7 +749,7 @@
 {% if maintenance_schedules %}
 <!-- Upcoming Maintenance -->
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center">
             <svg class="h-5 w-5 text-gray-400 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
@@ -802,7 +802,7 @@
 
 <!-- Parts & Consumables -->
 <div class="bg-white dark:bg-gray-800 shadow rounded-lg mb-8" id="parts-section">
-    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center gap-2">
             <button onclick="toggleParts()" class="flex items-center gap-2 text-left" title="{{ _('Toggle section') }}">
                 <svg id="parts-chevron" class="h-4 w-4 text-gray-400 transition-transform duration-150" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -936,7 +936,7 @@
 <!-- Recent Activity -->
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg">
-        <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
             <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('Fuel Logs') }}</h2>
             <span class="text-sm text-gray-500 dark:text-gray-400">{{ stats.fuel_logs_count }} total</span>
         </div>
@@ -993,7 +993,7 @@
     </div>
 
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg">
-        <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap items-center justify-between gap-2">
             <h2 class="text-lg font-medium text-gray-900 dark:text-white">{{ _('Expenses') }}</h2>
             <span class="text-sm text-gray-500 dark:text-gray-400">{{ stats.expenses_count }} total</span>
         </div>

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.35.0'
+APP_VERSION = '0.35.1'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1,0 +1,258 @@
+"""Checks that guard against horizontal overflow on narrow (mobile) screens.
+
+Issue #314: several pages ran off the right-hand side on a phone. There is no
+browser in the test environment, so instead of measuring pixels we assert the
+two structural invariants that caused it:
+
+1. Every ``<table>`` sits inside an element that can scroll horizontally.
+   Data tables are far wider than a phone, so without a scroll wrapper they
+   either push the page sideways or get clipped by the card around them.
+
+2. Every flex row holding two or more buttons is allowed to wrap. A row of
+   action buttons cannot shrink below its content, so a row that cannot wrap
+   drags the page wider than the viewport.
+
+Elements hidden at phone width (``hidden`` with a breakpoint prefix to reveal
+them, such as the desktop nav bar) are ignored — they are not on screen.
+"""
+
+import re
+from datetime import date
+from html.parser import HTMLParser
+
+import pytest
+
+from app import db
+from app.models import (
+    ChargingSession,
+    Document,
+    Expense,
+    FuelLog,
+    MaintenanceSchedule,
+    Note,
+    Reminder,
+    TireFitment,
+    TireSet,
+    Trip,
+)
+
+
+# Tailwind classes that let a box scroll sideways rather than overflow the page.
+SCROLLABLE = {'overflow-x-auto', 'overflow-x-scroll', 'overflow-auto', 'overflow-scroll'}
+
+# A button-shaped link or button: inline-flex with horizontal padding.
+BUTTON_PADDING = re.compile(r'\bpx-\d')
+
+
+def _classes(attrs):
+    for name, value in attrs:
+        if name == 'class':
+            return set((value or '').split())
+    return set()
+
+
+def _is_flex_row(classes):
+    """True for an element laying its children out in a horizontal flex row."""
+    if 'flex' not in classes or 'hidden' in classes:
+        return False
+    return 'flex-col' not in classes
+
+
+def _is_button_like(tag, classes):
+    if tag not in ('a', 'button'):
+        return False
+    if 'inline-flex' not in classes:
+        return False
+    return bool(BUTTON_PADDING.search(' '.join(classes)))
+
+
+class LayoutScanner(HTMLParser):
+    """Collects tables without a scroll wrapper and button rows that cannot wrap."""
+
+    VOID = {'br', 'hr', 'img', 'input', 'meta', 'link', 'source', 'path', 'area', 'col'}
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._stack = []
+        self.unscrollable_tables = []
+        self._flex_rows = {}
+
+    def handle_starttag(self, tag, attrs):
+        classes = _classes(attrs)
+
+        # `hidden` with a breakpoint prefix to reveal it (e.g. the desktop nav
+        # bar) means the element is not on screen at phone width at all.
+        hidden = 'hidden' in classes or any('hidden' in c for _, c, _ in self._stack)
+
+        if tag == 'table' and not hidden and not any(
+            c & SCROLLABLE for _, c, _ in self._stack
+        ):
+            self.unscrollable_tables.append(self.getpos()[0])
+
+        if not hidden and _is_button_like(tag, classes):
+            for entry in reversed(self._stack):
+                if _is_flex_row(entry[1]):
+                    entry[2].append(tag)
+                    break
+
+        if tag not in self.VOID:
+            entry = [tag, classes, []]
+            self._stack.append(entry)
+            if _is_flex_row(classes):
+                self._flex_rows[id(entry)] = entry
+
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs)
+        if tag not in self.VOID:
+            self.handle_endtag(tag)
+
+    def handle_endtag(self, tag):
+        for i in range(len(self._stack) - 1, -1, -1):
+            if self._stack[i][0] == tag:
+                del self._stack[i:]
+                return
+
+    @property
+    def rigid_button_rows(self):
+        """Flex rows holding 2+ buttons that neither wrap nor scroll."""
+        rows = []
+        for _tag, classes, buttons in self._flex_rows.values():
+            if len(buttons) < 2:
+                continue
+            if 'flex-wrap' in classes or classes & SCROLLABLE:
+                continue
+            rows.append(' '.join(sorted(classes)))
+        return rows
+
+
+def scan(html):
+    scanner = LayoutScanner()
+    scanner.feed(html)
+    return scanner
+
+
+@pytest.fixture
+def populated(app, test_user, sample_vehicle, sample_fuel_log, sample_expense,
+              sample_trip, sample_charging_session):
+    """A user with at least one row on every list page worth checking."""
+    db.session.add_all([
+        FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                date=date(2024, 2, 15), odometer=10500.0, volume=42.0,
+                price_per_unit=1.55, total_cost=65.1, is_full_tank=True),
+        Expense(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                date=date(2024, 2, 20), category='service',
+                description='Annual service', vendor='A Very Long Garage Name Ltd',
+                cost=350.0),
+        ChargingSession(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                        date=date(2024, 2, 25), odometer=10600.0, kwh_added=35.0,
+                        cost_per_kwh=0.28, total_cost=9.8, charger_type='public'),
+        Trip(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+             date=date(2024, 2, 26), start_odometer=10600.0, end_odometer=10700.0,
+             purpose='business', description='Site visit'),
+        Note(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+             date=date(2024, 2, 27), title='Winter check',
+             content='Check the tyre pressures.'),
+        Reminder(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                 title='MOT', reminder_type='mot', due_date=date(2024, 6, 1),
+                 recurrence='none'),
+        MaintenanceSchedule(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                            name='Oil change', maintenance_type='oil_change',
+                            interval_months=6, estimated_cost=50.0),
+        Document(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                 title='Insurance certificate', document_type='insurance',
+                 filename='cert.pdf', original_filename='cert.pdf',
+                 file_type='pdf', file_size=20),
+    ])
+
+    tire_set = TireSet(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                       name='Winter set', tire_type='winter', size='205/55 R16')
+    db.session.add(tire_set)
+    db.session.commit()
+
+    db.session.add(TireFitment(tire_set_id=tire_set.id,
+                               fitted_date=date(2024, 1, 1), fitted_odometer=10000.0,
+                               removed_date=date(2024, 3, 1), removed_odometer=10800.0))
+    db.session.commit()
+
+    return sample_vehicle
+
+
+def _pages(vehicle):
+    document = Document.query.filter_by(vehicle_id=vehicle.id).first()
+    return [
+        '/dashboard',
+        '/vehicles/',
+        f'/vehicles/{vehicle.id}',
+        f'/documents/{document.id}',
+        '/fuel/',
+        '/expenses/',
+        '/trips/',
+        '/trips/report',
+        '/charging/',
+        '/maintenance/',
+        '/reminders/',
+        '/documents/',
+        '/notes/',
+        '/tires/',
+        '/allowance/',
+        '/stations/',
+        '/recurring/',
+        f'/timeline/{vehicle.id}',
+        '/auth/settings',
+        '/api/docs',
+    ]
+
+
+def test_every_table_can_scroll_sideways(auth_client, populated):
+    """A table wider than the phone must scroll, not overflow or get clipped."""
+    offenders = {}
+    for path in _pages(populated):
+        response = auth_client.get(path)
+        assert response.status_code == 200, path
+        lines = scan(response.get_data(as_text=True)).unscrollable_tables
+        if lines:
+            offenders[path] = lines
+    assert not offenders, f'tables with no horizontal scroll wrapper: {offenders}'
+
+
+def test_button_rows_can_wrap(auth_client, populated):
+    """A row of action buttons must wrap rather than widen the page."""
+    offenders = {}
+    for path in _pages(populated):
+        response = auth_client.get(path)
+        assert response.status_code == 200, path
+        rows = scan(response.get_data(as_text=True)).rigid_button_rows
+        if rows:
+            offenders[path] = rows
+    assert not offenders, f'button rows that cannot wrap: {offenders}'
+
+
+def test_admin_user_table_can_scroll_sideways(admin_client):
+    response = admin_client.get('/auth/users')
+    assert response.status_code == 200
+    assert not scan(response.get_data(as_text=True)).unscrollable_tables
+
+
+def test_scanner_spots_a_bare_table():
+    """The scanner itself: a table with no scrollable ancestor is reported."""
+    assert scan('<div class="p-6"><table><tr><td>x</td></tr></table></div>').unscrollable_tables
+    assert not scan(
+        '<div class="overflow-x-auto"><table><tr><td>x</td></tr></table></div>'
+    ).unscrollable_tables
+    assert not scan(
+        '<div class="hidden sm:block"><table><tr><td>x</td></tr></table></div>'
+    ).unscrollable_tables
+
+
+def test_scanner_spots_a_rigid_button_row():
+    """The scanner itself: two buttons in a row that cannot wrap is reported."""
+    row = (
+        '<div class="{cls}">'
+        '<a class="inline-flex items-center px-4 py-2">One</a>'
+        '<a class="inline-flex items-center px-4 py-2">Two</a>'
+        '</div>'
+    )
+    assert scan(row.format(cls='flex gap-2')).rigid_button_rows
+    assert not scan(row.format(cls='flex flex-wrap gap-2')).rigid_button_rows
+    assert not scan(row.format(cls='flex flex-col gap-2')).rigid_button_rows
+    assert not scan(row.format(cls='flex gap-2 overflow-x-auto')).rigid_button_rows


### PR DESCRIPTION
## 0.35.1

A small fix for phone screens.

### Fixes

- Several pages ran off the right-hand side on a phone. The rows of action buttons at the top of the vehicle, trips, stations and document pages now wrap onto a second line instead of dragging the page wider than the screen, and the tyre fitting history, expenses spend-by-vendor, user management and backup preview tables scroll sideways like every other table rather than overflowing or being clipped. ([#314](https://github.com/dannymcc/may/issues/314))

### Other

- Adds `tests/test_mobile_layout.py`, which checks the rendered HTML of 20 pages to make sure every visible table can scroll sideways and every row of two or more buttons can wrap.

Upgrading is straightforward: there are no database migrations and no configuration changes.