### PR TITLE
Release v0.35.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,9 @@
 # Keep .env next to config.py; it is read when May starts.
 # Variables set in the real environment take precedence over this file.
 
-# Secret key for session encryption (generate a random string for production)
-SECRET_KEY=your-secret-key-here
+# Secret key for session encryption (optional: if unset, May generates one on
+# first start and saves it to .secret_key in its data folder)
+# SECRET_KEY=your-secret-key-here
 
 # Database URL (default: SQLite in the app's own data folder)
 # Uncomment and set an absolute path to move the database elsewhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Fixed
+
+- Running without `SECRET_KEY` set no longer bounces you back to the login page
+  on every page change. May now generates a key on first start and saves it to
+  `.secret_key` in its data folder, so all of its worker processes sign
+  sessions with the same key and logins survive a restart. Setting `SECRET_KEY`
+  yourself still takes precedence, and if the key file cannot be written May
+  starts as before with a warning.
+  ([#317](https://github.com/dannymcc/may/issues/317))
+
 ## [0.35.1] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.35.2] - 2026-08-24
+
 ### Fixed
 
 - Running without `SECRET_KEY` set no longer bounces you back to the login page
@@ -19,6 +21,12 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   yourself still takes precedence, and if the key file cannot be written May
   starts as before with a warning.
   ([#317](https://github.com/dannymcc/may/issues/317))
+
+### Changed
+
+- The README's configuration section notes that the supplied
+  `docker-compose.yml` passes a placeholder `SECRET_KEY`, so Compose users get
+  that rather than a generated key until they set or remove it.
 
 ## [0.35.1] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ python run.py
 Copy `.env.example` to `.env` and configure:
 
 ```bash
-# Secret key for session encryption
+# Secret key for session encryption (optional)
 SECRET_KEY=your-secure-random-string
 
 # Database location (optional, defaults to SQLite in the app's data folder)
@@ -141,6 +141,11 @@ DATABASE_URL=sqlite:////srv/may/data/may.db
 # Upload folder for attachments (optional)
 UPLOAD_FOLDER=/srv/may/data/uploads
 ```
+
+If you don't set `SECRET_KEY`, May generates one on first start and saves it to
+`.secret_key` in its data folder, so logins survive restarts. Set it yourself if
+you'd rather manage the key, or if you run more than one instance behind a load
+balancer and want them to share sessions.
 
 The `.env` file must sit next to `config.py` in the application directory, and
 it is read when May starts. Variables set in the real environment take
@@ -155,7 +160,7 @@ in `.env` has no effect — edit `docker-compose.yml` instead.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SECRET_KEY` | Session encryption key | Random |
+| `SECRET_KEY` | Session encryption key | Generated on first start and saved to `data/.secret_key` |
 | `DATABASE_URL` | Database connection string (SQLite or PostgreSQL) | SQLite at `data/may.db` inside the application directory (`/app/data/may.db` in Docker) |
 | `UPLOAD_FOLDER` | Path for file uploads | `data/uploads` inside the application directory (`/app/data/uploads` in Docker) |
 | `PUID` | User ID the container runs as (linuxserver.io convention) | `1000` |

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ If you don't set `SECRET_KEY`, May generates one on first start and saves it to
 you'd rather manage the key, or if you run more than one instance behind a load
 balancer and want them to share sessions.
 
+The supplied `docker-compose.yml` passes a placeholder `SECRET_KEY` when you
+haven't set one of your own, so under Compose May signs sessions with that
+rather than generating a key. Set `SECRET_KEY` in `.env` next to
+`docker-compose.yml`, or remove the line from the compose file to let May
+generate and keep its own.
+
 The `.env` file must sit next to `config.py` in the application directory, and
 it is read when May starts. Variables set in the real environment take
 precedence over `.env`.

--- a/config.py
+++ b/config.py
@@ -33,6 +33,60 @@ else:
     DISPLAY_VERSION = APP_VERSION
 
 
+SECRET_KEY_FILE = basedir / 'data' / '.secret_key'
+
+
+def _load_or_create_secret_key(path=SECRET_KEY_FILE):
+    """Return a session-signing key, generating and persisting one if needed.
+
+    A generated key has to be stable across processes as well as restarts:
+    gunicorn runs several workers, each importing this module separately, so a
+    key held only in memory differs per worker. A session cookie signed by one
+    worker then fails validation on another and the user is bounced back to
+    the login page on the next request (#317). Keeping the key in a file under
+    the data directory gives every worker the same key, and sessions survive a
+    restart too.
+
+    If the file cannot be written (a read-only filesystem, say) this falls
+    back to the previous behaviour: an in-memory key, with a warning.
+    """
+    import secrets
+
+    try:
+        key = path.read_text().strip()
+        if key:
+            return key
+    except OSError:
+        pass
+
+    key = secrets.token_hex(32)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            # Exclusive create so two workers booting together cannot clobber
+            # each other's key; the loser reads the winner's instead.
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            existing = path.read_text().strip()
+            if existing:
+                return existing
+            raise
+        try:
+            os.write(fd, key.encode())
+        finally:
+            os.close(fd)
+    except OSError:
+        import warnings
+        warnings.warn(
+            "SECRET_KEY environment variable not set and the generated key "
+            f"could not be saved to {path}. Sessions will not persist across "
+            "restarts, and will break between worker processes. "
+            "Set SECRET_KEY for production.",
+            RuntimeWarning
+        )
+    return key
+
+
 class Config:
     APP_VERSION = APP_VERSION
     DISPLAY_VERSION = DISPLAY_VERSION
@@ -47,17 +101,7 @@ class Config:
     FLATPICKR_JS_CDN_URL = FLATPICKR_JS_CDN_URL
     FLATPICKR_CSS_ASSET_URL = FLATPICKR_CSS_ASSET_URL
     FLATPICKR_CSS_CDN_URL = FLATPICKR_CSS_CDN_URL
-    SECRET_KEY = os.environ.get('SECRET_KEY')
-    if not SECRET_KEY:
-        import secrets
-        # Generate a random key for development, but warn about it
-        SECRET_KEY = secrets.token_hex(32)
-        import warnings
-        warnings.warn(
-            "SECRET_KEY environment variable not set. Using randomly generated key. "
-            "Sessions will not persist across restarts. Set SECRET_KEY for production.",
-            RuntimeWarning
-        )
+    SECRET_KEY = os.environ.get('SECRET_KEY') or _load_or_create_secret_key()
     _database_url = os.environ.get('DATABASE_URL') or f'sqlite:///{basedir}/data/may.db'
     # SQLAlchemy 2.x dropped the legacy 'postgres://' scheme still emitted by
     # some hosting providers; normalise it so those URLs keep working (#239).

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.35.1'
+APP_VERSION = '0.35.2'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_secret_key_persistence.py
+++ b/tests/test_secret_key_persistence.py
@@ -1,0 +1,109 @@
+"""Repro for #317: with no SECRET_KEY set, gunicorn's multiple worker
+processes each generate their own random key, so a session cookie signed by
+one worker fails to validate on another and the user is bounced back to the
+login page on the very next request.
+
+config.py generates SECRET_KEY at import time (see tests/test_config_dotenv.py
+for why these tests spawn a child interpreter rather than importing directly).
+Each `run_config()` call below is a fresh Python process reading the same
+config.py in the same directory with no SECRET_KEY / .env present -- exactly
+what happens when two gunicorn workers fork and separately import the app
+without SECRET_KEY configured. Today each process invents its own key, so the
+two calls disagree; once the generated key is persisted to disk on first boot
+and reused, they must agree.
+"""
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+CONFIG_PY = Path(__file__).resolve().parent.parent / 'config.py'
+
+PROBE = 'import json, config; print(json.dumps({"SECRET_KEY": config.Config.SECRET_KEY}))'
+
+
+def run_config(tmp_path, env=None):
+    """Import a fresh copy of config.py in a brand new child process and
+    return its settings, simulating one gunicorn worker's boot-time import."""
+    shutil.copy(CONFIG_PY, tmp_path / 'config.py')
+    child_env = {'PATH': '/usr/bin:/bin', 'PYTHONPATH': str(tmp_path)}
+    child_env.update(env or {})
+    result = subprocess.run(
+        [sys.executable, '-c', PROBE],
+        cwd=tmp_path,
+        env=child_env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def run_config_raw(tmp_path, env=None):
+    """As run_config, but return the CompletedProcess so a test can inspect
+    warnings on stderr."""
+    shutil.copy(CONFIG_PY, tmp_path / 'config.py')
+    child_env = {'PATH': '/usr/bin:/bin', 'PYTHONPATH': str(tmp_path)}
+    child_env.update(env or {})
+    return subprocess.run(
+        [sys.executable, '-c', PROBE],
+        cwd=tmp_path,
+        env=child_env,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestSecretKeyPersistsAcrossProcesses:
+    def test_generated_secret_key_is_shared_across_worker_processes(self, tmp_path):
+        """Two 'workers' (fresh processes, no SECRET_KEY/.env) booting against
+        the same data directory must end up with the same session-signing
+        key, or sessions break every time a request lands on the other
+        worker (#317)."""
+        first_worker = run_config(tmp_path)['SECRET_KEY']
+        second_worker = run_config(tmp_path)['SECRET_KEY']
+
+        assert first_worker == second_worker, (
+            "SECRET_KEY differs between two process boots with no explicit "
+            "SECRET_KEY set -- session cookies signed by one gunicorn worker "
+            "will be rejected by the other, forcing users back to the login "
+            "page on the next request."
+        )
+
+    def test_generated_key_is_saved_to_the_data_directory(self, tmp_path):
+        """The generated key is written to data/.secret_key, so it also
+        survives a restart."""
+        key = run_config(tmp_path)['SECRET_KEY']
+
+        key_file = tmp_path / 'data' / '.secret_key'
+        assert key_file.read_text().strip() == key
+
+    def test_existing_key_file_is_reused(self, tmp_path):
+        """A key already on disk is used as-is rather than replaced."""
+        key_file = tmp_path / 'data' / '.secret_key'
+        key_file.parent.mkdir()
+        key_file.write_text('previously-generated-key\n')
+
+        assert run_config(tmp_path)['SECRET_KEY'] == 'previously-generated-key'
+
+    def test_explicit_secret_key_is_not_persisted(self, tmp_path):
+        """A key set in the environment wins and nothing is written to disk."""
+        settings = run_config(tmp_path, env={'SECRET_KEY': 'from-real-env'})
+
+        assert settings['SECRET_KEY'] == 'from-real-env'
+        assert not (tmp_path / 'data' / '.secret_key').exists()
+
+    def test_unwritable_data_directory_falls_back_with_a_warning(self, tmp_path):
+        """If the key cannot be saved (read-only filesystem, say) May still
+        starts with an in-memory key and says so."""
+        # A plain file where the data directory should be makes every attempt
+        # to create data/.secret_key fail, whatever the process's privileges.
+        (tmp_path / 'data').write_text('not a directory')
+
+        result = run_config_raw(tmp_path)
+
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)['SECRET_KEY']
+        assert 'RuntimeWarning' in result.stderr
+        assert 'Set SECRET_KEY for production' in result.stderr


### PR DESCRIPTION
## 0.35.2

A single fix, for sessions dropping when no `SECRET_KEY` is configured.

### Fixed

- Running without `SECRET_KEY` set no longer bounces you back to the login page on every page change. May generates a key on first start and saves it to `.secret_key` in its data folder, so all of its worker processes sign sessions with the same key and logins survive a restart. Setting `SECRET_KEY` yourself still takes precedence and is never written to disk; if the key file cannot be written, May starts as before with a warning. ([#317](https://github.com/dannymcc/may/issues/317))

### Other

- The README's configuration section now notes that the supplied `docker-compose.yml` passes a placeholder `SECRET_KEY`, so Compose users get that rather than a generated key until they set one of their own or remove the line.
- `.env.example` shows `SECRET_KEY` as optional and commented out.

Thanks to the reporter of [#317](https://github.com/dannymcc/may/issues/317) for the details that pinned this to gunicorn's separate worker processes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `SECRET_KEY` is now optional and generated automatically on first start when not configured.
  * Generated keys are securely persisted and reused across restarts and workers.
  * Explicitly configured keys continue to take precedence.
  * The application now falls back to an in-memory key with a warning if persistence is unavailable.

* **Documentation**
  * Updated configuration guidance, Docker Compose instructions, and changelog details for automatic key generation and storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->