### PR TITLE
fix: separate consumption by fuel type

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -404,7 +404,7 @@ class Vehicle(db.Model):
             return _distance_in(raw_distance, self.get_effective_odometer_unit(), distance_unit)
         return raw_distance
 
-    def _valid_consumption_segments(self):
+    def _valid_consumption_segments(self, fuel_type=None):
         """Collect (distance, fuel) spans usable for the consumption average.
 
         Each span runs between consecutive full-tank fill-ups, counting every
@@ -417,13 +417,25 @@ class Vehicle(db.Model):
         Returns ``None`` when there are fewer than two full-tank anchors,
         otherwise a (possibly empty) list of ``(distance, fuel)`` tuples.
         """
-        full_logs = self.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.odometer).all()
+        # Keep each fuel or auxiliary fluid in its own consumption series.
+        # By default, vehicle summary figures describe the primary fuel only.
+        target_fuel_type = fuel_type or self.fuel_type
+        same_fuel_type = FuelLog.fuel_type == target_fuel_type
+        if target_fuel_type == self.fuel_type:
+            # Older primary-fuel records predate the per-log fuel type field.
+            same_fuel_type = same_fuel_type | FuelLog.fuel_type.is_(None)
+
+        full_logs = self.fuel_logs.filter(
+            FuelLog.is_full_tank == True,
+            same_fuel_type,
+        ).order_by(FuelLog.odometer).all()
         if len(full_logs) < 2:
             return None
 
         range_logs = self.fuel_logs.filter(
             FuelLog.odometer > full_logs[0].odometer,
             FuelLog.odometer <= full_logs[-1].odometer,
+            same_fuel_type,
         ).order_by(FuelLog.odometer).all()
 
         segments = []
@@ -438,7 +450,7 @@ class Vehicle(db.Model):
                 segments.append((distance, fuel))
         return segments
 
-    def get_average_consumption(self, consumption_unit=None, volume_unit='L'):
+    def get_average_consumption(self, consumption_unit=None, volume_unit='L', fuel_type=None):
         """Calculate average fuel consumption across full-tank fill-up spans.
 
         Spans contaminated by a missed fill-up are excluded rather than
@@ -446,7 +458,7 @@ class Vehicle(db.Model):
         remaining span, partial fills included (issue #169). Returns None
         when no honest span exists.
         """
-        segments = self._valid_consumption_segments()
+        segments = self._valid_consumption_segments(fuel_type)
         if not segments:
             return None
 
@@ -813,10 +825,20 @@ class FuelLog(db.Model):
         if not self.volume or not self.is_full_tank:
             return None
 
+        # Secondary fluids (for example AdBlue) must never be mixed into the
+        # primary fuel consumption. Compare this fill only with records of the
+        # same effective fuel type. Legacy NULL values count as the vehicle's
+        # primary fuel type.
+        effective_fuel_type = self.fuel_type or self.vehicle.fuel_type
+        same_fuel_type = FuelLog.fuel_type == effective_fuel_type
+        if effective_fuel_type == self.vehicle.fuel_type:
+            same_fuel_type = same_fuel_type | FuelLog.fuel_type.is_(None)
+
         prev_full = FuelLog.query.filter(
             FuelLog.vehicle_id == self.vehicle_id,
             FuelLog.odometer < self.odometer,
             FuelLog.is_full_tank == True,
+            same_fuel_type,
         ).order_by(FuelLog.odometer.desc()).first()
         if not prev_full:
             return None
@@ -825,6 +847,7 @@ class FuelLog(db.Model):
             FuelLog.vehicle_id == self.vehicle_id,
             FuelLog.odometer > prev_full.odometer,
             FuelLog.odometer <= self.odometer,
+            same_fuel_type,
         ).all()
         if any(log.is_missed for log in between):
             return None
@@ -859,6 +882,7 @@ class FuelLog(db.Model):
             'price_per_unit': self.price_per_unit,
             'discount_per_unit': self.discount_per_unit,
             'total_cost': self.total_cost,
+            'fuel_type': self.fuel_type or self.vehicle.fuel_type,
             'is_full_tank': self.is_full_tank,
             'is_missed': self.is_missed,
             'station': self.station,
@@ -1128,6 +1152,7 @@ FUEL_TYPES = [
     ('cng', _l('CNG')),
     ('hydrogen', _l('Hydrogen')),
     ('e85', _l('E85/Flex Fuel')),
+    ('adblue', _l('AdBlue')),
     ('other', _l('Other'))
 ]
 

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -285,7 +285,8 @@ def vehicle_stats(vehicle_id):
             consumption_data.append({
                 'date': log.date.isoformat(),
                 'consumption': round(consumption, 2),
-                'odometer': log.odometer
+                'odometer': log.odometer,
+                'fuel_type': log.fuel_type or vehicle.fuel_type
             })
 
     expenses = vehicle.expenses.all()

--- a/app/templates/fuel/index.html
+++ b/app/templates/fuel/index.html
@@ -26,6 +26,7 @@
                 <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Date') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Vehicle') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Fuel Type') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Odometer') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Volume') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Price/Unit') }}</th>
@@ -42,6 +43,12 @@
                         <a href="{{ url_for('vehicles.view', vehicle_id=log.vehicle_id) }}" class="text-primary-600 hover:text-primary-500">
                             {{ log.vehicle.name }}
                         </a>
+                    </td>
+                    {% set effective_fuel_type = log.fuel_type or log.vehicle.fuel_type %}
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                        <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full {% if effective_fuel_type == 'adblue' %}bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200{% else %}bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200{% endif %}">
+                            {{ effective_fuel_type|fuel_type_label }}
+                        </span>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ "%.0f"|format(log.odometer) }} {{ log.vehicle.get_effective_odometer_unit() }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -1143,25 +1143,35 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!consumptionEl) return;
             if (data.consumption && data.consumption.length > 0) {
                 const ctx = consumptionEl.getContext('2d');
+                const fuelTypes = [...new Set(data.consumption.map(d => d.fuel_type || 'other'))];
+                const palette = [
+                    ['rgb(14, 165, 233)', 'rgba(14, 165, 233, 0.1)'],
+                    ['rgb(37, 99, 235)', 'rgba(37, 99, 235, 0.1)'],
+                    ['rgb(245, 158, 11)', 'rgba(245, 158, 11, 0.1)'],
+                    ['rgb(16, 185, 129)', 'rgba(16, 185, 129, 0.1)']
+                ];
+                const fuelLabel = type => type === 'adblue' ? 'AdBlue' : type.charAt(0).toUpperCase() + type.slice(1).replaceAll('_', ' ');
+                const consumptionDatasets = fuelTypes.map((type, index) => ({
+                    label: fuelLabel(type) + ' ({{ current_user.consumption_unit }})',
+                    data: data.consumption.map(d => (d.fuel_type || 'other') === type ? d.consumption : null),
+                    borderColor: palette[index % palette.length][0],
+                    backgroundColor: palette[index % palette.length][1],
+                    tension: 0.3,
+                    fill: false,
+                    spanGaps: true
+                }));
                 chartInstances['consumption'] = new Chart(ctx, {
                     type: 'line',
                     data: {
                         labels: data.consumption.map(d => d.date),
-                        datasets: [{
-                            label: {{ (_('Consumption') + ' (' + current_user.consumption_unit + ')')|tojson }},
-                            data: data.consumption.map(d => d.consumption),
-                            borderColor: 'rgb(14, 165, 233)',
-                            backgroundColor: 'rgba(14, 165, 233, 0.1)',
-                            tension: 0.3,
-                            fill: true
-                        }]
+                        datasets: consumptionDatasets
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
                         plugins: {
                             legend: {
-                                display: false
+                                display: fuelTypes.length > 1
                             }
                         },
                         scales: {

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -376,6 +376,68 @@ class TestPartialFillConsumption:
         assert abs(avg - 6.286) < 0.01
 
 
+    def test_secondary_fluid_does_not_affect_primary_consumption(
+            self, app, test_user, sample_vehicle):
+        sample_vehicle.fuel_type = 'diesel'
+        sample_vehicle.secondary_fuel_type = 'adblue'
+        logs = [
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 1), odometer=10000, volume=40,
+                    fuel_type='diesel', is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 8), odometer=10200, volume=10,
+                    fuel_type='adblue', is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 15), odometer=10500, volume=35,
+                    fuel_type='diesel', is_full_tank=True),
+        ]
+        db.session.add_all(logs)
+        db.session.commit()
+
+        # Diesel is 35 L / 500 km, not (10 + 35) L / 300 km from AdBlue.
+        assert abs(logs[-1].get_consumption() - 7.0) < 0.01
+
+    def test_average_consumption_is_separate_for_each_fluid(
+            self, app, test_user, sample_vehicle):
+        sample_vehicle.fuel_type = 'diesel'
+        sample_vehicle.secondary_fuel_type = 'adblue'
+        logs = [
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 1), odometer=10000, volume=40,
+                    fuel_type='diesel', is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 2), odometer=10100, volume=8,
+                    fuel_type='adblue', is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 15), odometer=10500, volume=35,
+                    fuel_type='diesel', is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 2, 1), odometer=12100, volume=6,
+                    fuel_type='adblue', is_full_tank=True),
+        ]
+        db.session.add_all(logs)
+        db.session.commit()
+
+        assert abs(sample_vehicle.get_average_consumption() - 7.0) < 0.01
+        assert abs(sample_vehicle.get_average_consumption(fuel_type='adblue') - 0.3) < 0.01
+
+    def test_legacy_null_fuel_type_is_primary_fuel(
+            self, app, test_user, sample_vehicle):
+        sample_vehicle.fuel_type = 'diesel'
+        logs = [
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 1), odometer=10000, volume=40,
+                    fuel_type=None, is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2026, 1, 15), odometer=10500, volume=35,
+                    fuel_type='diesel', is_full_tank=True),
+        ]
+        db.session.add_all(logs)
+        db.session.commit()
+
+        assert abs(logs[-1].get_consumption() - 7.0) < 0.01
+
+
 @pytest.fixture
 def sample_station(app, test_user):
     station = FuelStation(


### PR DESCRIPTION
## Summary

- separate full-to-full consumption calculations by effective fuel type
- keep primary-fuel averages independent from secondary fuels and auxiliary fluids such as AdBlue
- treat legacy NULL fuel-type rows as the vehicle primary fuel
- add AdBlue to the available fuel types
- show the effective fuel type in the Fuel Logs table
- render separate labelled consumption-trend series for Diesel, AdBlue, and other fuel types

## Why

A secondary AdBlue refill could become the previous full-tank anchor, be included in diesel volume, and appear in the same Fuel Consumption Trend series. This produced incorrect diesel L/100 km values.

Fixes #319.
Related to #221.

## Testing

- Added regression coverage ensuring a full AdBlue entry does not affect diesel full-to-full consumption.
- Added coverage for independent primary and secondary-fluid averages.
- Added coverage for legacy NULL fuel-type rows inheriting the primary vehicle fuel.
- `python -m pytest tests/test_fuel.py tests/test_api.py -q` — 90 tests passed in the project Docker environment.