### PR TITLE
Release v0.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Fixed
+
+- An empty `.secret_key` file in May's data folder no longer leaves every
+  worker process signing sessions with a key of its own, which showed up as
+  forms — creating a user, say — being refused with "The CSRF session token is
+  missing" or doing nothing at all. May now fills in a key file that exists but
+  holds nothing, instead of leaving it as it found it.
+  ([#315](https://github.com/dannymcc/may/issues/315))
+
 ## [0.35.2] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.35.3] - 2026-08-24
+
 ### Fixed
 
 - An empty `.secret_key` file in May's data folder no longer leaves every

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.35.2'
+APP_VERSION = '0.35.3'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/config.py
+++ b/config.py
@@ -36,6 +36,57 @@ else:
 SECRET_KEY_FILE = basedir / 'data' / '.secret_key'
 
 
+def _read_secret_key(path):
+    """The key held in ``path``: the empty string if the file holds no key,
+    None if there is no reading it at all (it is missing, it belongs to
+    another user, it is a directory)."""
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def _warn_secret_key_not_saved(path):
+    import warnings
+    warnings.warn(
+        "SECRET_KEY environment variable not set and the generated key "
+        f"could not be saved to {path}. Sessions will not persist across "
+        "restarts, and will break between worker processes. "
+        "Set SECRET_KEY for production.",
+        RuntimeWarning
+    )
+
+
+def _claim_empty_secret_key(path, key):
+    """Write ``key`` into an existing but empty key file.
+
+    The write goes to a temporary file that is then renamed over the empty
+    one, so a worker reading the file while this happens sees either nothing
+    or a whole key, never half of one. What is returned is the key on disk
+    afterwards rather than the one just written, so a worker repairing the
+    file a moment behind another falls in behind it. Two workers repairing it
+    in the very same instant can still end up with a key each until the next
+    restart, when both read the one that survived — a good deal better than
+    the empty file everyone falls back from for good.
+    """
+    tmp_path = path.with_name(f'{path.name}.{os.getpid()}')
+    try:
+        fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        try:
+            os.write(fd, key.encode())
+        finally:
+            os.close(fd)
+        os.replace(tmp_path, path)
+    except OSError:
+        _warn_secret_key_not_saved(path)
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return key
+    return _read_secret_key(path) or key
+
+
 def _load_or_create_secret_key(path=SECRET_KEY_FILE):
     """Return a session-signing key, generating and persisting one if needed.
 
@@ -43,21 +94,19 @@ def _load_or_create_secret_key(path=SECRET_KEY_FILE):
     gunicorn runs several workers, each importing this module separately, so a
     key held only in memory differs per worker. A session cookie signed by one
     worker then fails validation on another and the user is bounced back to
-    the login page on the next request (#317). Keeping the key in a file under
-    the data directory gives every worker the same key, and sessions survive a
-    restart too.
+    the login page on the next request (#317), or a form they have just filled
+    in is refused with "The CSRF session token is missing" (#315). Keeping the
+    key in a file under the data directory gives every worker the same key,
+    and sessions survive a restart too.
 
     If the file cannot be written (a read-only filesystem, say) this falls
     back to the previous behaviour: an in-memory key, with a warning.
     """
     import secrets
 
-    try:
-        key = path.read_text().strip()
-        if key:
-            return key
-    except OSError:
-        pass
+    key = _read_secret_key(path)
+    if key:
+        return key
 
     key = secrets.token_hex(32)
     try:
@@ -67,23 +116,28 @@ def _load_or_create_secret_key(path=SECRET_KEY_FILE):
             # each other's key; the loser reads the winner's instead.
             fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         except FileExistsError:
-            existing = path.read_text().strip()
+            existing = _read_secret_key(path)
             if existing:
                 return existing
-            raise
+            if existing is None:
+                # Something is at that path that we cannot read — a file
+                # belonging to another user, or a directory. It may well hold
+                # the key the other workers are using, so leave it be and warn
+                # rather than write over it.
+                raise
+            # The file is there but holds no key — a container killed between
+            # creating it and writing to it, a full disk, or someone who made
+            # the file by hand meaning to fill it in later. Nothing repairs it
+            # on a later boot, so left alone every worker would keep falling
+            # back to a key of its own and sessions would keep breaking
+            # between them (#315). Claim the empty file instead.
+            return _claim_empty_secret_key(path, key)
         try:
             os.write(fd, key.encode())
         finally:
             os.close(fd)
     except OSError:
-        import warnings
-        warnings.warn(
-            "SECRET_KEY environment variable not set and the generated key "
-            f"could not be saved to {path}. Sessions will not persist across "
-            "restarts, and will break between worker processes. "
-            "Set SECRET_KEY for production.",
-            RuntimeWarning
-        )
+        _warn_secret_key_not_saved(path)
     return key
 
 

--- a/tests/test_migration_heads.py
+++ b/tests/test_migration_heads.py
@@ -1,0 +1,64 @@
+"""Regression test: the alembic migration graph must have exactly one head.
+
+Two migrations can end up with the same ``down_revision`` when they are
+authored in parallel (e.g. two features branching off the same prior
+migration) and neither is rebased onto the other with a merge revision. When
+that happens ``flask db upgrade`` refuses to run ("Multiple head revisions
+are present for given argument 'head'"), and docker-entrypoint.sh only logs
+that failure rather than treating it as fatal, so a deploy can silently stop
+tracking new migrations until someone notices and merges the heads by hand.
+
+This walks the migration files directly via ``ast`` rather than importing
+alembic/Flask, so it can run without the application's runtime dependencies
+installed.
+"""
+import ast
+from pathlib import Path
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / 'migrations' / 'versions'
+
+
+def _parse_revision(path):
+    """Pull ``revision`` and ``down_revision`` out of a migration file's source."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    revision = None
+    down_revision = None
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if 'revision' in targets:
+            revision = ast.literal_eval(node.value)
+        if 'down_revision' in targets:
+            down_revision = ast.literal_eval(node.value)
+    return revision, down_revision
+
+
+def _migration_files():
+    return sorted(p for p in MIGRATIONS_DIR.glob('*.py') if p.name != '__init__.py')
+
+
+def test_migration_graph_has_a_single_head():
+    files = _migration_files()
+    assert files, 'expected migration files to be found under migrations/versions/'
+
+    revisions = {}
+    down_revisions = set()
+    for path in files:
+        revision, down_revision = _parse_revision(path)
+        assert revision is not None, f'{path.name} has no revision id'
+        revisions[revision] = path.name
+        if down_revision is None:
+            continue
+        if isinstance(down_revision, (tuple, list)):
+            down_revisions.update(down_revision)
+        else:
+            down_revisions.add(down_revision)
+
+    heads = [rev for rev in revisions if rev not in down_revisions]
+
+    assert len(heads) == 1, (
+        'expected exactly one migration head, found branching heads: '
+        + ', '.join(f'{rev} ({revisions[rev]})' for rev in heads)
+        + '. Add a merge migration (down_revision = (<head1>, <head2>)) to join them.'
+    )

--- a/tests/test_secret_key_persistence.py
+++ b/tests/test_secret_key_persistence.py
@@ -94,6 +94,62 @@ class TestSecretKeyPersistsAcrossProcesses:
         assert settings['SECRET_KEY'] == 'from-real-env'
         assert not (tmp_path / 'data' / '.secret_key').exists()
 
+    def test_empty_key_file_is_claimed_rather_than_left_alone(self, tmp_path):
+        """A key file that exists but holds nothing is filled in.
+
+        A container killed between creating the file and writing to it, a full
+        disk, or someone making the file by hand meaning to fill it in later
+        all leave an empty data/.secret_key. Nothing repairs it on a later
+        boot, so every worker would keep falling back to a key of its own and
+        forms would keep being refused with "The CSRF session token is
+        missing" (#315).
+        """
+        key_file = tmp_path / 'data' / '.secret_key'
+        key_file.parent.mkdir()
+        key_file.write_text('')
+
+        first_worker = run_config(tmp_path)['SECRET_KEY']
+        second_worker = run_config(tmp_path)['SECRET_KEY']
+
+        assert first_worker == second_worker, (
+            "SECRET_KEY differs between two process boots against an empty "
+            "key file -- sessions and CSRF tokens break whenever a request "
+            "lands on the other gunicorn worker."
+        )
+        assert key_file.read_text().strip() == first_worker
+
+    def test_whitespace_only_key_file_is_claimed(self, tmp_path):
+        """A file holding only whitespace is no more a key than an empty one."""
+        key_file = tmp_path / 'data' / '.secret_key'
+        key_file.parent.mkdir()
+        key_file.write_text('   \n')
+
+        first_worker = run_config(tmp_path)['SECRET_KEY']
+
+        assert key_file.read_text().strip() == first_worker
+        assert run_config(tmp_path)['SECRET_KEY'] == first_worker
+
+    def test_unreadable_key_file_is_left_alone(self, tmp_path):
+        """Only a file that positively reads as empty is claimed.
+
+        A key file there is no reading — one belonging to another user, or a
+        directory, as Docker leaves behind when a bind mount names a path that
+        does not exist — may hold the very key the other workers are signing
+        with, so May warns and starts on an in-memory key rather than writing
+        over it.
+        """
+        key_dir = tmp_path / 'data' / '.secret_key'
+        key_dir.mkdir(parents=True)
+
+        result = run_config_raw(tmp_path)
+
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)['SECRET_KEY']
+        assert 'RuntimeWarning' in result.stderr
+        assert 'Set SECRET_KEY for production' in result.stderr
+        assert key_dir.is_dir() and not list(key_dir.iterdir())
+        assert sorted(p.name for p in (tmp_path / 'data').iterdir()) == ['.secret_key']
+
     def test_unwritable_data_directory_falls_back_with_a_warning(self, tmp_path):
         """If the key cannot be saved (read-only filesystem, say) May still
         starts with an in-memory key and says so."""


### PR DESCRIPTION
## May 0.35.3

A single fix, following on from 0.35.2.

### Fixed

- An empty `.secret_key` file in May's data folder no longer leaves every worker process signing sessions with a key of its own. The symptom was forms — creating a user, say — being refused with "The CSRF session token is missing", or simply doing nothing. May now fills in a key file that exists but holds nothing, rather than leaving it as it found it. A key file it cannot read at all is still left alone, since it may hold the key the other workers are using. ([#315](https://github.com/dannymcc/may/issues/315))

### Notes

This is worth taking if you are on 0.35.2. That release started saving a generated key to `data/.secret_key`; if the very first write was interrupted, the empty file it left behind put May into exactly the state above, and nothing repaired it. Setting `SECRET_KEY` yourself avoids the whole business, and users of the supplied `docker-compose.yml` are unaffected — it passes a placeholder key of its own.

Thanks to the reporter of #315 for the clear account of what failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty or whitespace-only secret-key files so they are populated and shared reliably across worker processes.
  * Prevented form submission failures caused by missing shared signing keys.
  * Improved handling of unreadable key files by preserving them and using a safe fallback.

* **Tests**
  * Added regression coverage for secret-key persistence and migration consistency.

* **Chores**
  * Updated the application version to 0.35.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->