### PR TITLE
Release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Fixed
+
+- Fuel consumption is now worked out per fuel type, so an AdBlue refill logged
+  against a diesel no longer inflates that diesel's L/100km. The previous
+  full-tank lookup, the litres counted in between and the consumption average
+  all consider one fuel at a time, and the Fuel Consumption Trend draws a
+  separate labelled line for each. Logs recorded before the fuel type selector
+  existed count as the vehicle's own fuel type.
+  ([#319](https://github.com/dannymcc/may/issues/319))
+
+### Added
+
+- "AdBlue/DEF" is offered as a secondary fuel type, so the fluid a diesel
+  tracks alongside its fuel can be named rather than logged as "Other". It
+  counts as no tailpipe CO2, being an exhaust additive rather than a fuel.
+  ([#319](https://github.com/dannymcc/may/issues/319))
+
+- The Fuel Logs table shows the fuel type of each entry.
+  ([#319](https://github.com/dannymcc/may/issues/319))
+
 ## [0.35.3] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,7 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
-### Fixed
-
-- Fuel consumption is now worked out per fuel type, so an AdBlue refill logged
-  against a diesel no longer inflates that diesel's L/100km. The previous
-  full-tank lookup, the litres counted in between and the consumption average
-  all consider one fuel at a time, and the Fuel Consumption Trend draws a
-  separate labelled line for each. Logs recorded before the fuel type selector
-  existed count as the vehicle's own fuel type.
-  ([#319](https://github.com/dannymcc/may/issues/319))
+## [0.36.0] - 2026-08-24
 
 ### Added
 
@@ -28,6 +20,22 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   ([#319](https://github.com/dannymcc/may/issues/319))
 
 - The Fuel Logs table shows the fuel type of each entry.
+  ([#319](https://github.com/dannymcc/may/issues/319))
+
+- Fuel logs returned by the REST API now carry a `fuel_type` field, and each
+  point of the vehicle stats consumption series is labelled with the fuel it
+  belongs to. Fuel type remains read-only over the API: a log created there
+  takes the vehicle's own fuel type.
+  ([#319](https://github.com/dannymcc/may/issues/319))
+
+### Fixed
+
+- Fuel consumption is now worked out per fuel type, so an AdBlue refill logged
+  against a diesel no longer inflates that diesel's L/100km. The previous
+  full-tank lookup, the litres counted in between and the consumption average
+  all consider one fuel at a time, and the Fuel Consumption Trend draws a
+  separate labelled line for each. Logs recorded before the fuel type selector
+  existed count as the vehicle's own fuel type.
   ([#319](https://github.com/dannymcc/may/issues/319))
 
 ## [0.35.3] - 2026-08-24

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Track every fill-up with:
 - Automatic MPG/L per 100km calculations
 - Fuel type selection for vehicles that take more than one fuel, including hybrids (petrol or diesel), so station price charts stay grouped by the fuel actually bought
 - Each fuel is measured on its own: consumption figures, averages and the consumption trend chart count only the logs of that fuel type, so an AdBlue refill on a diesel never lands in the diesel L/100km. Logs recorded before the fuel type selector existed count as the vehicle's own fuel type.
+- "AdBlue/DEF" is available as a vehicle's secondary fuel type, for the fluid a diesel tracks alongside its fuel. It is an exhaust additive rather than a fuel, so it is not offered as a vehicle's own fuel type and counts as no tailpipe CO2.
+- The fuel log list shows the fuel type of each entry
 
 Saving a fuel log returns you to the fuel log list, unless you started from a vehicle page, in which case you go back to that vehicle. Deleting one does the same: from the fuel log list you stay on the list, from a vehicle page you return to that vehicle. Notes behave the same way.
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Track every fill-up with:
 - Full tank indicator for accurate consumption calculations
 - Automatic MPG/L per 100km calculations
 - Fuel type selection for vehicles that take more than one fuel, including hybrids (petrol or diesel), so station price charts stay grouped by the fuel actually bought
+- Each fuel is measured on its own: consumption figures, averages and the consumption trend chart count only the logs of that fuel type, so an AdBlue refill on a diesel never lands in the diesel L/100km. Logs recorded before the fuel type selector existed count as the vehicle's own fuel type.
 
 Saving a fuel log returns you to the fuel log list, unless you started from a vehicle page, in which case you go back to that vehicle. Deleting one does the same: from the fuel log list you stay on the list, from a vehicle page you return to that vehicle. Notes behave the same way.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -362,8 +362,8 @@ def create_app(config_class=Config):
 
     @app.template_filter('fuel_type_label')
     def fuel_type_label_filter(value):
-        from app.models import FUEL_TYPES
-        return dict(FUEL_TYPES).get(value) or (value or '').replace('_', ' ').title()
+        from app.models import fuel_type_label
+        return fuel_type_label(value)
 
     @app.template_filter('spec_label')
     def spec_label_filter(spec):

--- a/app/models.py
+++ b/app/models.py
@@ -404,7 +404,7 @@ class Vehicle(db.Model):
             return _distance_in(raw_distance, self.get_effective_odometer_unit(), distance_unit)
         return raw_distance
 
-    def _valid_consumption_segments(self):
+    def _valid_consumption_segments(self, fuel_type=None):
         """Collect (distance, fuel) spans usable for the consumption average.
 
         Each span runs between consecutive full-tank fill-ups, counting every
@@ -414,16 +414,26 @@ class Vehicle(db.Model):
         usable, so one missed fill-up doesn't invalidate the whole history
         (issue #251).
 
+        Only logs of one fuel type are considered, defaulting to the
+        vehicle's own. A diesel that also tracks AdBlue keeps the two
+        apart: AdBlue is an auxiliary fluid, not propulsion, so pouring it
+        in must never move the diesel figure (issue #319).
+
         Returns ``None`` when there are fewer than two full-tank anchors,
         otherwise a (possibly empty) list of ``(distance, fuel)`` tuples.
         """
-        full_logs = self.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.odometer).all()
+        same_fuel = FuelLog.effective_fuel_type_filter(
+            fuel_type or resolve_price_fuel_type(None, self.fuel_type), self.fuel_type)
+        full_logs = self.fuel_logs.filter(
+            FuelLog.is_full_tank == True, same_fuel
+        ).order_by(FuelLog.odometer).all()
         if len(full_logs) < 2:
             return None
 
         range_logs = self.fuel_logs.filter(
             FuelLog.odometer > full_logs[0].odometer,
             FuelLog.odometer <= full_logs[-1].odometer,
+            same_fuel,
         ).order_by(FuelLog.odometer).all()
 
         segments = []
@@ -438,15 +448,16 @@ class Vehicle(db.Model):
                 segments.append((distance, fuel))
         return segments
 
-    def get_average_consumption(self, consumption_unit=None, volume_unit='L'):
+    def get_average_consumption(self, consumption_unit=None, volume_unit='L', fuel_type=None):
         """Calculate average fuel consumption across full-tank fill-up spans.
 
         Spans contaminated by a missed fill-up are excluded rather than
         poisoning the whole figure (issue #251); the average covers every
-        remaining span, partial fills included (issue #169). Returns None
-        when no honest span exists.
+        remaining span, partial fills included (issue #169). Each fuel type
+        is averaged on its own, the vehicle's primary fuel by default
+        (issue #319). Returns None when no honest span exists.
         """
-        segments = self._valid_consumption_segments()
+        segments = self._valid_consumption_segments(fuel_type)
         if not segments:
             return None
 
@@ -470,7 +481,7 @@ class Vehicle(db.Model):
             return (litres / km) * 100  # L/100km
         return None
 
-    def get_consumption_unavailable_reason(self):
+    def get_consumption_unavailable_reason(self, fuel_type=None):
         """Explain why :meth:`get_average_consumption` returns ``None``.
 
         Returns a stable reason code (translated for display in the template)
@@ -482,16 +493,21 @@ class Vehicle(db.Model):
         - ``'missed_fill_up'`` — every span is invalidated by a missed fill-up
         - ``'insufficient_data'`` — not enough distance/volume to calculate
         """
-        segments = self._valid_consumption_segments()
+        segments = self._valid_consumption_segments(fuel_type)
         if segments is None:
             return 'insufficient_full_tanks'
         if segments:
             return None
 
-        full_logs = self.fuel_logs.filter_by(is_full_tank=True).order_by(FuelLog.odometer).all()
+        same_fuel = FuelLog.effective_fuel_type_filter(
+            fuel_type or resolve_price_fuel_type(None, self.fuel_type), self.fuel_type)
+        full_logs = self.fuel_logs.filter(
+            FuelLog.is_full_tank == True, same_fuel
+        ).order_by(FuelLog.odometer).all()
         range_logs = self.fuel_logs.filter(
             FuelLog.odometer > full_logs[0].odometer,
             FuelLog.odometer <= full_logs[-1].odometer,
+            same_fuel,
         ).all()
         if any(log.is_missed for log in range_logs):
             return 'missed_fill_up'
@@ -732,6 +748,7 @@ FUEL_CO2_KG_PER_LITRE = {
     'plugin_hybrid': 2.31,
     'electric': 0.0,
     'hydrogen': 0.0,
+    'adblue': 0.0,  # a diesel exhaust additive, not a fuel being burned (#319)
 }
 
 
@@ -796,6 +813,33 @@ class FuelLog(db.Model):
     attachments = db.relationship('Attachment', backref='fuel_log', lazy='dynamic',
                                   cascade='all, delete-orphan')
 
+    @property
+    def effective_fuel_type(self):
+        """The fuel this fill-up actually put in the vehicle (issue #319).
+
+        Logs written before the per-log selector existed carry no fuel type
+        of their own, so they inherit the vehicle's. Propulsion types are
+        mapped to the fuel they burn, which keeps a hybrid's untyped rows in
+        the same series as ones explicitly logged as petrol (issue #268).
+        """
+        return resolve_price_fuel_type(
+            self.fuel_type, self.vehicle.fuel_type if self.vehicle else None)
+
+    @classmethod
+    def effective_fuel_type_filter(cls, fuel_type, vehicle_fuel_type):
+        """Filter criterion matching logs whose effective fuel type is ``fuel_type``.
+
+        Mirrors :attr:`effective_fuel_type` in SQL: a stored propulsion type
+        counts as the fuel it burns, and a NULL fuel type counts as the
+        vehicle's own.
+        """
+        stored = {fuel_type} | {propulsion for propulsion, fuel in PROPULSION_TO_FUEL.items()
+                                if fuel == fuel_type}
+        criterion = cls.fuel_type.in_(stored)
+        if resolve_price_fuel_type(None, vehicle_fuel_type) == fuel_type:
+            criterion = db.or_(criterion, cls.fuel_type.is_(None))
+        return criterion
+
     def get_consumption(self, consumption_unit=None, volume_unit='L'):
         """Calculate consumption for this fill-up.
 
@@ -806,6 +850,9 @@ class FuelLog(db.Model):
         (issue #169). If any of the intervening logs is flagged ``is_missed``,
         the figure is unknowable and we return None.
 
+        Only logs of the same effective fuel type count, so an AdBlue refill
+        never lands in a diesel figure and vice versa (issue #319).
+
         Partial fills return None: the litres added in a top-up tell you
         nothing about consumption over the preceding distance, and surfacing
         a number there is misleading (issue #194).
@@ -813,10 +860,15 @@ class FuelLog(db.Model):
         if not self.volume or not self.is_full_tank:
             return None
 
+        same_fuel = FuelLog.effective_fuel_type_filter(
+            self.effective_fuel_type,
+            self.vehicle.fuel_type if self.vehicle else None)
+
         prev_full = FuelLog.query.filter(
             FuelLog.vehicle_id == self.vehicle_id,
             FuelLog.odometer < self.odometer,
             FuelLog.is_full_tank == True,
+            same_fuel,
         ).order_by(FuelLog.odometer.desc()).first()
         if not prev_full:
             return None
@@ -825,6 +877,7 @@ class FuelLog(db.Model):
             FuelLog.vehicle_id == self.vehicle_id,
             FuelLog.odometer > prev_full.odometer,
             FuelLog.odometer <= self.odometer,
+            same_fuel,
         ).all()
         if any(log.is_missed for log in between):
             return None
@@ -859,6 +912,7 @@ class FuelLog(db.Model):
             'price_per_unit': self.price_per_unit,
             'discount_per_unit': self.discount_per_unit,
             'total_cost': self.total_cost,
+            'fuel_type': self.effective_fuel_type,
             'is_full_tank': self.is_full_tank,
             'is_missed': self.is_missed,
             'station': self.station,
@@ -1128,6 +1182,9 @@ FUEL_TYPES = [
     ('cng', _l('CNG')),
     ('hydrogen', _l('Hydrogen')),
     ('e85', _l('E85/Flex Fuel')),
+    # AdBlue propels nothing — it is an auxiliary fluid a diesel tracks
+    # alongside its fuel, so it belongs here only as a secondary type (#319).
+    ('adblue', _l('AdBlue/DEF')),
     ('other', _l('Other'))
 ]
 
@@ -1151,6 +1208,11 @@ def resolve_price_fuel_type(log_fuel_type, vehicle_fuel_type):
     """
     fuel_type = log_fuel_type or vehicle_fuel_type
     return PROPULSION_TO_FUEL.get(fuel_type, fuel_type) or 'petrol'
+
+
+def fuel_type_label(fuel_type):
+    """Display label for a stored fuel type slug, translated where known."""
+    return dict(FUEL_TYPES).get(fuel_type) or (fuel_type or '').replace('_', ' ').title()
 
 
 # Reminder types

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -18,7 +18,7 @@ from app.models import (
     User, Vehicle, VehicleSpec, FuelLog, Expense, EXPENSE_CATEGORIES,
     Reminder, MaintenanceSchedule, RecurringExpense, FuelStation,
     Document, Trip, ChargingSession, VehiclePart, FuelPriceHistory, Attachment,
-    TRIP_PURPOSES, CHARGER_TYPES
+    TRIP_PURPOSES, CHARGER_TYPES, fuel_type_label
 )
 from app.services.tessie import TessieService
 from app.services.backup_restore import (
@@ -285,7 +285,12 @@ def vehicle_stats(vehicle_id):
             consumption_data.append({
                 'date': log.date.isoformat(),
                 'consumption': round(consumption, 2),
-                'odometer': log.odometer
+                'odometer': log.odometer,
+                # Each fuel gets its own series in the trend chart; mixing a
+                # diesel's AdBlue refills into its diesel line would be
+                # nonsense (#319).
+                'fuel_type': log.effective_fuel_type,
+                'fuel_type_label': str(fuel_type_label(log.effective_fuel_type)),
             })
 
     expenses = vehicle.expenses.all()

--- a/app/templates/api/docs.html
+++ b/app/templates/api/docs.html
@@ -153,7 +153,7 @@
                                 <tr class="border-b"><td class="py-2 pr-4"><code>year</code></td><td class="py-2 pr-4">integer</td><td class="py-2 pr-4">No</td><td class="py-2">Model year</td></tr>
                                 <tr class="border-b"><td class="py-2 pr-4"><code>registration</code></td><td class="py-2 pr-4">string</td><td class="py-2 pr-4">No</td><td class="py-2">License plate number</td></tr>
                                 <tr class="border-b"><td class="py-2 pr-4"><code>vin</code></td><td class="py-2 pr-4">string</td><td class="py-2 pr-4">No</td><td class="py-2">Vehicle Identification Number</td></tr>
-                                <tr class="border-b"><td class="py-2 pr-4"><code>fuel_type</code></td><td class="py-2 pr-4">string</td><td class="py-2 pr-4">No</td><td class="py-2">petrol, diesel, electric, hybrid, lpg, cng</td></tr>
+                                <tr class="border-b"><td class="py-2 pr-4"><code>fuel_type</code></td><td class="py-2 pr-4">string</td><td class="py-2 pr-4">No</td><td class="py-2">petrol, diesel, electric, hybrid, plugin_hybrid, lpg, cng, hydrogen, e85, other</td></tr>
                                 <tr><td class="py-2 pr-4"><code>tank_capacity</code></td><td class="py-2 pr-4">number</td><td class="py-2 pr-4">No</td><td class="py-2">Fuel tank capacity in liters</td></tr>
                             </tbody>
                         </table>
@@ -247,6 +247,7 @@
       "volume": 45.5,
       "price_per_unit": 1.45,
       "total_cost": 65.98,
+      "fuel_type": "petrol",
       "is_full_tank": true,
       "is_missed": false,
       "station": "Shell",
@@ -261,6 +262,7 @@
   "offset": 0
 }</code></pre>
                     </div>
+                    <p class="text-gray-600 dark:text-gray-400 mt-4"><code>fuel_type</code> is the fuel the fill-up actually put in; logs recorded without one report the vehicle's own fuel type. It is read-only over the API — set it in the web interface if a vehicle takes more than one fuel.</p>
                 </div>
             </div>
 

--- a/app/templates/fuel/index.html
+++ b/app/templates/fuel/index.html
@@ -27,6 +27,7 @@
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Date') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Vehicle') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Odometer') }}</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Fuel Type') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Volume') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Price/Unit') }}</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{{ _('Cost') }}</th>
@@ -44,6 +45,7 @@
                         </a>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ "%.0f"|format(log.odometer) }} {{ log.vehicle.get_effective_odometer_unit() }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{{ log.effective_fuel_type|fuel_type_label }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {{ "%.1f"|format(log.volume or 0) }} {{ current_user.volume_unit }}
                         {% if log.is_full_tank %}

--- a/app/templates/vehicles/form.html
+++ b/app/templates/vehicles/form.html
@@ -59,7 +59,8 @@
                     <label for="fuel_type" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Fuel Type') }}</label>
                     <select name="fuel_type" id="fuel_type"
                             class="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500">
-                        {% for value, label in fuel_types %}
+                        {# AdBlue never propels a vehicle, so it is offered as a secondary type only (#319). #}
+                        {% for value, label in fuel_types if value != 'adblue' or (vehicle and vehicle.fuel_type == value) %}
                         <option value="{{ value }}" {% if vehicle and vehicle.fuel_type == value %}selected{% endif %}>{{ label }}</option>
                         {% endfor %}
                     </select>

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -1143,25 +1143,63 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!consumptionEl) return;
             if (data.consumption && data.consumption.length > 0) {
                 const ctx = consumptionEl.getContext('2d');
+
+                // A diesel that also tracks AdBlue logs two quite different
+                // fluids, so plot one line per fuel type rather than mixing
+                // them into a single misleading series (#319). Each point
+                // keeps its own slot on the x-axis, so two fills on one date
+                // are still two points.
+                const dates = data.consumption.map(d => d.date);
+                const typeLabels = {};
+                data.consumption.forEach(d => {
+                    typeLabels[d.fuel_type || 'unknown'] = d.fuel_type_label || d.fuel_type || 'unknown';
+                });
+
+                const typeColours = {
+                    petrol: 'rgb(14, 165, 233)',
+                    diesel: 'rgb(234, 88, 12)',
+                    electric: 'rgb(16, 185, 129)',
+                    hybrid: 'rgb(250, 204, 21)',
+                    plugin_hybrid: 'rgb(132, 204, 22)',
+                    lpg: 'rgb(168, 85, 247)',
+                    cng: 'rgb(236, 72, 153)',
+                    hydrogen: 'rgb(6, 182, 212)',
+                    e85: 'rgb(217, 70, 239)',
+                    other: 'rgb(100, 116, 139)'
+                };
+                const fallbackColours = ['rgb(59, 130, 246)', 'rgb(239, 68, 68)', 'rgb(34, 197, 94)', 'rgb(245, 158, 11)', 'rgb(139, 92, 246)'];
+                const fuelTypes = Object.keys(typeLabels);
+                const unit = {{ current_user.consumption_unit|tojson }};
+                const datasets = fuelTypes.map((ft, i) => {
+                    const colour = typeColours[ft] || fallbackColours[i % fallbackColours.length];
+                    // A single series keeps the filled look it has always had;
+                    // several would obscure each other, so they stay as lines.
+                    const single = fuelTypes.length === 1;
+                    return {
+                        label: typeLabels[ft] + ' (' + unit + ')',
+                        data: data.consumption.map(d => (d.fuel_type || 'unknown') === ft ? d.consumption : null),
+                        borderColor: colour,
+                        backgroundColor: single ? colour.replace('rgb(', 'rgba(').replace(')', ', 0.1)') : colour,
+                        tension: 0.3,
+                        fill: single,
+                        spanGaps: true
+                    };
+                });
+
                 chartInstances['consumption'] = new Chart(ctx, {
                     type: 'line',
                     data: {
-                        labels: data.consumption.map(d => d.date),
-                        datasets: [{
-                            label: {{ (_('Consumption') + ' (' + current_user.consumption_unit + ')')|tojson }},
-                            data: data.consumption.map(d => d.consumption),
-                            borderColor: 'rgb(14, 165, 233)',
-                            backgroundColor: 'rgba(14, 165, 233, 0.1)',
-                            tension: 0.3,
-                            fill: true
-                        }]
+                        labels: dates,
+                        datasets: datasets
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
                         plugins: {
                             legend: {
-                                display: false
+                                // Only worth showing the key once more than
+                                // one fuel type is being charted.
+                                display: datasets.length > 1
                             }
                         },
                         scales: {

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -229,6 +229,10 @@ msgstr ""
 msgid "E85/Flex Fuel"
 msgstr ""
 
+#: app/models.py:1037
+msgid "AdBlue/DEF"
+msgstr ""
+
 #: app/models.py:1042
 msgid "MOT/Inspection"
 msgstr ""

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.35.3'
+APP_VERSION = '0.36.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,6 +75,39 @@ class TestVehicleStats:
         assert 'total_fuel_cost' in data
         assert 'total_expense_cost' in data
 
+    def test_vehicle_stats_labels_each_consumption_point(
+            self, auth_client, test_user, app):
+        """#319 — the trend chart needs the fuel type of every point so it can
+        plot diesel and AdBlue as separate, labelled series."""
+        from datetime import date
+        from app.models import FuelLog
+
+        vehicle = Vehicle(
+            owner_id=test_user.id, name='Diesel Van', vehicle_type='car',
+            fuel_type='diesel', secondary_fuel_type='adblue', odometer_unit='km',
+        )
+        _db_ext.session.add(vehicle)
+        _db_ext.session.commit()
+        for odometer, volume, fuel_type in ((10000, 50, 'diesel'),
+                                            (10100, 10, 'adblue'),
+                                            (10500, 45, 'diesel'),
+                                            (10600, 5, 'adblue')):
+            _db_ext.session.add(FuelLog(
+                vehicle_id=vehicle.id, user_id=test_user.id, date=date(2024, 1, 1),
+                odometer=odometer, volume=volume, fuel_type=fuel_type,
+                is_full_tank=True,
+            ))
+        _db_ext.session.commit()
+
+        resp = auth_client.get(f'/api/vehicles/{vehicle.id}/stats')
+        assert resp.status_code == 200
+        points = resp.get_json()['consumption']
+        by_type = {p['fuel_type']: p for p in points}
+        assert set(by_type) == {'diesel', 'adblue'}
+        assert by_type['diesel']['consumption'] == 9.0
+        assert by_type['adblue']['consumption'] == 1.0
+        assert by_type['adblue']['fuel_type_label'] == 'AdBlue/DEF'
+
     def test_get_vehicle_stats_unauthenticated(self, client, sample_vehicle):
         resp = client.get(f'/api/vehicles/{sample_vehicle.id}/stats')
         assert resp.status_code in (302, 401)

--- a/tests/test_fuel.py
+++ b/tests/test_fuel.py
@@ -996,3 +996,143 @@ class TestFuelRedirects:
         resp = auth_client.get('/fuel/new')
         assert resp.status_code == 200
         assert b'name="return_to"' not in resp.data
+
+
+@pytest.fixture
+def adblue_vehicle(app, test_user):
+    """A diesel that tracks AdBlue as its secondary fluid (#319)."""
+    vehicle = Vehicle(
+        owner_id=test_user.id,
+        name='Diesel Van',
+        vehicle_type='car',
+        fuel_type='diesel',
+        secondary_fuel_type='adblue',
+        odometer_unit='km',
+    )
+    db.session.add(vehicle)
+    db.session.commit()
+    return vehicle
+
+
+class TestSecondaryFuelConsumption:
+    """Issue #319: AdBlue is an auxiliary fluid, not propulsion, so its
+    refills must never move a diesel's consumption figures."""
+
+    @staticmethod
+    def _log(vehicle, test_user, odometer, volume, fuel_type,
+             is_full_tank=True, is_missed=False):
+        log = FuelLog(
+            vehicle_id=vehicle.id, user_id=test_user.id,
+            date=date(2024, 1, 1), odometer=odometer, volume=volume,
+            fuel_type=fuel_type, is_full_tank=is_full_tank, is_missed=is_missed,
+        )
+        db.session.add(log)
+        return log
+
+    def test_effective_fuel_type_falls_back_to_vehicle(
+            self, app, test_user, adblue_vehicle):
+        legacy = self._log(adblue_vehicle, test_user, 10000, 50, None)
+        adblue = self._log(adblue_vehicle, test_user, 10100, 10, 'adblue')
+        db.session.commit()
+        assert legacy.effective_fuel_type == 'diesel'
+        assert adblue.effective_fuel_type == 'adblue'
+
+    def test_effective_fuel_type_maps_propulsion_to_fuel(
+            self, app, test_user, hybrid_vehicle):
+        log = self._log(hybrid_vehicle, test_user, 20000, 35, None)
+        db.session.commit()
+        assert log.effective_fuel_type == 'petrol'
+
+    def test_adblue_refill_excluded_from_diesel_consumption(
+            self, app, test_user, adblue_vehicle):
+        self._log(adblue_vehicle, test_user, 10000, 50, 'diesel')
+        self._log(adblue_vehicle, test_user, 10300, 10, 'adblue', is_full_tank=False)
+        second_diesel = self._log(adblue_vehicle, test_user, 10500, 45, 'diesel')
+        db.session.commit()
+        # 45 L over 500 km — the 10 L of AdBlue is no part of it.
+        assert abs(second_diesel.get_consumption() - 9.0) < 0.01
+
+    def test_adblue_full_tank_does_not_anchor_diesel(
+            self, app, test_user, adblue_vehicle):
+        """An AdBlue tank filled to the brim is not a diesel fill-up, so it
+        must not become the previous full tank a diesel figure spans from."""
+        self._log(adblue_vehicle, test_user, 10000, 50, 'diesel')
+        self._log(adblue_vehicle, test_user, 10300, 10, 'adblue')
+        second_diesel = self._log(adblue_vehicle, test_user, 10500, 45, 'diesel')
+        db.session.commit()
+        assert abs(second_diesel.get_consumption() - 9.0) < 0.01
+
+    def test_legacy_untyped_diesel_logs_still_pair_up(
+            self, app, test_user, adblue_vehicle):
+        """Rows logged before the fuel type selector existed carry no type of
+        their own and are read as the vehicle's primary fuel."""
+        self._log(adblue_vehicle, test_user, 10000, 50, None)
+        self._log(adblue_vehicle, test_user, 10300, 10, 'adblue', is_full_tank=False)
+        second_diesel = self._log(adblue_vehicle, test_user, 10500, 45, None)
+        db.session.commit()
+        assert abs(second_diesel.get_consumption() - 9.0) < 0.01
+
+    def test_missed_adblue_refill_does_not_void_diesel_figure(
+            self, app, test_user, adblue_vehicle):
+        self._log(adblue_vehicle, test_user, 10000, 50, 'diesel')
+        self._log(adblue_vehicle, test_user, 10300, 10, 'adblue',
+                  is_full_tank=False, is_missed=True)
+        second_diesel = self._log(adblue_vehicle, test_user, 10500, 45, 'diesel')
+        db.session.commit()
+        assert abs(second_diesel.get_consumption() - 9.0) < 0.01
+
+    def test_adblue_consumption_is_its_own_series(
+            self, app, test_user, adblue_vehicle):
+        self._log(adblue_vehicle, test_user, 10000, 50, 'diesel')
+        self._log(adblue_vehicle, test_user, 10100, 10, 'adblue')
+        self._log(adblue_vehicle, test_user, 10500, 45, 'diesel')
+        second_adblue = self._log(adblue_vehicle, test_user, 10600, 5, 'adblue')
+        db.session.commit()
+        # 5 L of AdBlue over the 500 km since the last AdBlue fill.
+        assert abs(second_adblue.get_consumption() - 1.0) < 0.01
+
+    def test_average_consumption_is_per_fuel_type(
+            self, app, test_user, adblue_vehicle):
+        self._log(adblue_vehicle, test_user, 10000, 50, 'diesel')
+        self._log(adblue_vehicle, test_user, 10100, 10, 'adblue')
+        self._log(adblue_vehicle, test_user, 10500, 45, 'diesel')
+        self._log(adblue_vehicle, test_user, 10600, 5, 'adblue')
+        db.session.commit()
+        assert abs(adblue_vehicle.get_average_consumption() - 9.0) < 0.01
+        assert abs(adblue_vehicle.get_average_consumption(fuel_type='adblue') - 1.0) < 0.01
+
+    def test_unavailable_reason_is_per_fuel_type(
+            self, app, test_user, adblue_vehicle):
+        self._log(adblue_vehicle, test_user, 10000, 50, 'diesel')
+        self._log(adblue_vehicle, test_user, 10100, 10, 'adblue')
+        self._log(adblue_vehicle, test_user, 10500, 45, 'diesel')
+        db.session.commit()
+        assert adblue_vehicle.get_consumption_unavailable_reason() is None
+        assert adblue_vehicle.get_consumption_unavailable_reason(
+            fuel_type='adblue') == 'insufficient_full_tanks'
+
+    def test_fuel_log_to_dict_reports_effective_fuel_type(
+            self, app, test_user, adblue_vehicle):
+        legacy = self._log(adblue_vehicle, test_user, 10000, 50, None)
+        db.session.commit()
+        assert legacy.to_dict()['fuel_type'] == 'diesel'
+
+    def test_fuel_index_shows_fuel_type(
+            self, auth_client, test_user, adblue_vehicle):
+        self._log(adblue_vehicle, test_user, 10000, 50, 'diesel')
+        self._log(adblue_vehicle, test_user, 10100, 10, 'adblue')
+        db.session.commit()
+        resp = auth_client.get('/fuel/')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'Diesel' in html
+        assert 'AdBlue/DEF' in html
+
+    def test_vehicle_page_charts_each_fuel_type_separately(
+            self, auth_client, test_user, adblue_vehicle):
+        resp = auth_client.get(f'/vehicles/{adblue_vehicle.id}')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # The trend chart builds one dataset per fuel type rather than one
+        # flat consumption series.
+        assert 'typeLabels' in html


### PR DESCRIPTION
## 0.36.0

Fuel consumption is now worked out one fuel at a time, so an AdBlue refill
logged against a diesel no longer distorts that diesel's figures.

### Added

- **AdBlue/DEF as a secondary fuel type.** The fluid a diesel tracks alongside
  its fuel can now be named rather than logged as "Other". It is an exhaust
  additive rather than a fuel, so it is offered only as a vehicle's *secondary*
  fuel type and counts as no tailpipe CO2. (#319)
- The fuel log list shows the fuel type of each entry. (#319)
- Fuel logs returned by the REST API carry a `fuel_type` field, and every point
  of the vehicle stats consumption series is labelled with the fuel it belongs
  to. Fuel type stays read-only over the API: a log created there takes the
  vehicle's own fuel type. (#319)

### Fixed

- **Consumption is calculated per fuel type.** The full-tank lookup, the litres
  counted in between and the consumption average all consider a single fuel,
  and the Fuel Consumption Trend draws a separate labelled line for each. An
  AdBlue refill on a diesel therefore never lands in that diesel's L/100km.
  Logs recorded before the fuel type selector existed count as the vehicle's
  own fuel type, so existing histories read as before. (#319)

### Other

- The built-in API documentation now shows the `fuel_type` field on fuel log
  responses, and its list of selectable vehicle fuel types is complete again —
  it had been missing plug-in hybrid, hydrogen, E85 and other.

Thanks to the reporter of [#319](https://github.com/dannymcc/may/issues/319)
for the clear description of the problem.

Upgrading is a straight version bump: no migration and no configuration change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking AdBlue/DEF as a secondary fuel.
  - Fuel logs now display fuel type labels, including in API and statistics responses.
  - Consumption calculations and trend charts are separated by fuel type.
  - Added fuel-type-specific averages and unavailable-consumption messaging.
- **Bug Fixes**
  - AdBlue refills no longer affect diesel consumption figures.
  - Legacy logs remain compatible by using the vehicle’s primary fuel type.
- **Documentation**
  - Updated fuel log and API documentation with supported fuel types and read-only handling.
- **Chores**
  - Updated the application version to 0.36.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->