### PR TITLE
Release v0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Fixed
+
+- A vehicle set to track engine hours has its readings treated as hours rather
+  than as a distance. Its consumption is worked out in litres per hour, its
+  running cost per hour, and a charged machine's energy use per 100 hours;
+  none of those figures change any more when the vehicle's (distance-only)
+  odometer unit is switched between km and miles, which used to scale 50
+  engine hours into 80.5 as though they were miles. Vehicles tracked by
+  mileage are unaffected. The labels shown alongside these figures still read
+  in distance terms and are being corrected separately.
+  ([#323](https://github.com/dannymcc/may/issues/323))
+
+### Changed
+
+- A vehicle's tracking unit can no longer be changed once anything has been
+  logged against its odometer. Switching it would have reinterpreted every
+  existing reading — 50 miles becoming 50 engine hours — so the rest of the
+  edit saves and that one field is refused with a message.
+  ([#323](https://github.com/dannymcc/may/issues/323))
+
 ## [0.36.0] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.36.1] - 2026-08-24
+
 ### Fixed
 
 - A vehicle set to track engine hours has its readings treated as hours rather
@@ -29,6 +31,16 @@ This file starts at 0.28.0. Notes for earlier releases are on the
   existing reading — 50 miles becoming 50 engine hours — so the rest of the
   edit saves and that one field is refused with a message.
   ([#323](https://github.com/dannymcc/may/issues/323))
+
+- The README documents the tracking unit, including the note that the figures
+  for an hours-tracked vehicle are correct while the labels beside them still
+  read in distance terms. The API documentation says the same about
+  `total_distance` and `average_consumption`, and that the tracking unit is
+  neither exposed nor settable over the API.
+  ([#323](https://github.com/dannymcc/may/issues/323))
+
+- The vehicle response example in the API documentation includes
+  `secondary_fuel_type`, which the API has returned since 0.36.0.
 
 ## [0.36.0] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Add and manage your vehicles with detailed information:
 - Make, model, year, and registration
 - Fuel type and tank capacity
 - Custom specifications and notes
+- **Tracking Unit**: Choose whether a vehicle's odometer counts distance or engine hours — plant and machinery are metered in hours, and their consumption and running costs are worked out per hour rather than per mile. The unit is fixed once anything has been logged against the odometer, since changing it would reinterpret every existing reading
 - **Photo Gallery**: Upload as many photos per vehicle as you like from the "Photos" section on the vehicle page. Any of them can be set as the main photo — the one shown on the dashboard and vehicle list — and the vehicle page steps through the rest with left/right arrows
 - **Vehicle Sharing**: Mark a vehicle as "Shared" to make it visible and loggable by all users on the instance
 - **Upcoming Maintenance**: Vehicle detail pages show a live panel of scheduled maintenance tasks, with overdue and due-soon alerts

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Add and manage your vehicles with detailed information:
 - Make, model, year, and registration
 - Fuel type and tank capacity
 - Custom specifications and notes
-- **Tracking Unit**: Choose whether a vehicle's odometer counts distance or engine hours — plant and machinery are metered in hours, and their consumption and running costs are worked out per hour rather than per mile. The unit is fixed once anything has been logged against the odometer, since changing it would reinterpret every existing reading
+- **Tracking Unit**: Choose whether a vehicle's odometer counts distance or engine hours — plant and machinery are metered in hours, and their consumption and running costs are worked out per hour rather than per mile. The unit is fixed once anything has been logged against the odometer, since changing it would reinterpret every existing reading. The figures themselves are correct for an hours-tracked vehicle, but the labels beside them still read in distance terms ("L/100km", "Cost per mi"); that is being corrected separately
 - **Photo Gallery**: Upload as many photos per vehicle as you like from the "Photos" section on the vehicle page. Any of them can be set as the main photo — the one shown on the dashboard and vehicle list — and the vehicle page steps through the rest with left/right arrows
 - **Vehicle Sharing**: Mark a vehicle as "Shared" to make it visible and loggable by all users on the instance
 - **Upcoming Maintenance**: Vehicle detail pages show a live panel of scheduled maintenance tasks, with overdue and due-soon alerts

--- a/app/models.py
+++ b/app/models.py
@@ -319,11 +319,36 @@ class Vehicle(db.Model):
     charging_sessions = db.relationship('ChargingSession', backref='vehicle', lazy='dynamic',
                                         cascade='all, delete-orphan')
 
+    def tracks_hours(self):
+        """True when this vehicle's readings are engine hours, not distance (#323).
+
+        ``tracking_unit`` is the authority for how every ``odometer`` value
+        belonging to this vehicle is interpreted: a tractor logged at 50 is
+        at 50 engine hours, not 50 miles. Hours never convert by a distance
+        factor, so ``odometer_unit`` is meaningless for such a vehicle.
+        """
+        return self.tracking_unit == 'hours'
+
+    def has_odometer_readings(self):
+        """True when anything has already been logged against this odometer (#323).
+
+        Used to refuse a ``tracking_unit`` change that would silently
+        reinterpret existing readings — 50 miles becoming 50 hours.
+        """
+        if self.fuel_logs.first() is not None:
+            return True
+        if self.trips.filter(Trip.end_odometer.isnot(None)).first() is not None:
+            return True
+        if self.charging_sessions.filter(ChargingSession.odometer.isnot(None)).first() is not None:
+            return True
+        return self.expenses.filter(Expense.odometer.isnot(None)).first() is not None
+
     def get_effective_odometer_unit(self):
         """Return the odometer unit for this vehicle.
 
         Uses the vehicle's own odometer_unit if set, otherwise falls back to
-        the owner's distance_unit preference.
+        the owner's distance_unit preference. Only meaningful for a vehicle
+        tracked by distance; see :meth:`tracks_hours`.
         """
         if self.odometer_unit:
             return self.odometer_unit
@@ -387,7 +412,17 @@ class Vehicle(db.Model):
             distance_unit: If provided ('km' or 'mi'), converts the result
                 to this unit. Otherwise returns the raw value in the
                 vehicle's effective odometer unit.
+
+        For an hours-tracked vehicle the readings are engine hours, so the
+        span is returned as logged and ``distance_unit`` is ignored — there
+        is no km/mi conversion to apply to an hour (#323).
         """
+        if self.tracks_hours():
+            logs = self.fuel_logs.order_by(FuelLog.odometer).all()
+            if len(logs) < 2:
+                return 0
+            return logs[-1].odometer - logs[0].odometer
+
         # If Tessie is enabled, use the odometer reading directly (always stored in km)
         if self.uses_tessie_odometer() and self.tessie_last_odometer:
             odometer = self.tessie_last_odometer
@@ -421,6 +456,9 @@ class Vehicle(db.Model):
 
         Returns ``None`` when there are fewer than two full-tank anchors,
         otherwise a (possibly empty) list of ``(distance, fuel)`` tuples.
+        The span is expressed in the vehicle's own ``tracking_unit`` — km or
+        miles for a distance-tracked vehicle, engine hours for one tracked by
+        hours (#323) — and is never converted here.
         """
         same_fuel = FuelLog.effective_fuel_type_filter(
             fuel_type or resolve_price_fuel_type(None, self.fuel_type), self.fuel_type)
@@ -456,6 +494,10 @@ class Vehicle(db.Model):
         remaining span, partial fills included (issue #169). Each fuel type
         is averaged on its own, the vehicle's primary fuel by default
         (issue #319). Returns None when no honest span exists.
+
+        An hours-tracked vehicle is averaged in litres per engine hour and
+        ``consumption_unit`` is ignored: mpg, km/L and L/100km are all named
+        for a distance this vehicle never records (issue #323).
         """
         segments = self._valid_consumption_segments(fuel_type)
         if not segments:
@@ -465,6 +507,8 @@ class Vehicle(db.Model):
         total_fuel = sum(fuel for _, fuel in segments)
 
         if total_distance > 0 and total_fuel > 0:
+            if self.tracks_hours():
+                return _to_litres(total_fuel, volume_unit) / total_distance
             odometer_unit = self.get_effective_odometer_unit()
             if consumption_unit == 'mpg':
                 miles = _distance_in(total_distance, odometer_unit, 'mi')
@@ -580,6 +624,11 @@ class Vehicle(db.Model):
         the vehicle's odometer unit). Mirrors the fill-to-fill approach used
         for fuel: needs at least two anchor sessions with odometers, and sums
         every charge in between.
+
+        Charging is rare on hours-tracked machinery but not impossible —
+        electric plant exists — so the same rule applies as for fuel: an
+        hours-tracked vehicle gets kWh per 100 engine hours and
+        ``distance_unit`` is ignored (issue #323).
         """
         sessions = (self.charging_sessions
                     .filter(ChargingSession.odometer.isnot(None))
@@ -594,6 +643,8 @@ class Vehicle(db.Model):
         total_kwh = sum(s.kwh_added for s in sessions if s.kwh_added) or 0
         if total_kwh <= 0:
             return None
+        if self.tracks_hours():
+            return (total_kwh / raw_distance) * 100
         target = distance_unit or self.get_effective_odometer_unit()
         distance = _distance_in(raw_distance, self.get_effective_odometer_unit(), target)
         return (total_kwh / distance) * 100 if distance > 0 else None
@@ -610,7 +661,14 @@ class Vehicle(db.Model):
         return sum(trip.distance for trip in self.trips.all()) or 0
 
     def get_cost_per_distance(self):
-        """Calculate total cost of ownership per distance unit"""
+        """Calculate total cost of ownership per unit on the vehicle's odometer.
+
+        That unit is whatever ``tracking_unit`` says it is: cost per km or
+        per mile for a distance-tracked vehicle, cost per engine hour for an
+        hours-tracked one (issue #323). The arithmetic is the same either
+        way because :meth:`get_total_distance` returns the span as logged,
+        without a km/mi conversion, for an hours-tracked vehicle.
+        """
         total_cost = self.get_total_fuel_cost() + self.get_total_expense_cost() + self.get_total_charging_cost()
         total_distance = self.get_total_distance()
         if total_distance > 0:
@@ -856,6 +914,11 @@ class FuelLog(db.Model):
         Partial fills return None: the litres added in a top-up tell you
         nothing about consumption over the preceding distance, and surfacing
         a number there is misleading (issue #194).
+
+        The owning vehicle's ``tracking_unit`` decides what the span between
+        two readings means. For an hours-tracked vehicle it is engine hours,
+        so the figure is litres per hour and ``consumption_unit`` is ignored
+        (issue #323).
         """
         if not self.volume or not self.is_full_tank:
             return None
@@ -884,6 +947,8 @@ class FuelLog(db.Model):
         volume_native = sum(log.volume for log in between if log.volume)
 
         if distance > 0 and volume_native > 0:
+            if self.vehicle and self.vehicle.tracks_hours():
+                return _to_litres(volume_native, volume_unit) / distance
             odometer_unit = self.vehicle.get_effective_odometer_unit()
             if consumption_unit == 'mpg':
                 miles = _distance_in(distance, odometer_unit, 'mi')

--- a/app/routes/vehicles.py
+++ b/app/routes/vehicles.py
@@ -259,7 +259,16 @@ def edit(vehicle_id):
     if request.method == 'POST':
         vehicle.name = request.form.get('name')
         vehicle.vehicle_type = request.form.get('vehicle_type')
-        vehicle.tracking_unit = request.form.get('tracking_unit', 'mileage')
+        # Changing the tracking unit would reinterpret every reading already
+        # logged — 50 miles silently becoming 50 engine hours — so once a
+        # vehicle has readings the unit is fixed (#323). The rest of the edit
+        # still saves; only this field is refused.
+        submitted_tracking_unit = request.form.get('tracking_unit', 'mileage')
+        if submitted_tracking_unit != vehicle.tracking_unit and vehicle.has_odometer_readings():
+            flash(_('Tracking unit cannot be changed once readings have been logged '
+                    'for this vehicle. Existing readings were kept as they are.'), 'error')
+        else:
+            vehicle.tracking_unit = submitted_tracking_unit
         vehicle.odometer_unit = request.form.get('odometer_unit') or None
         vehicle.make = request.form.get('make')
         vehicle.model = request.form.get('model')

--- a/app/templates/api/docs.html
+++ b/app/templates/api/docs.html
@@ -96,6 +96,7 @@
       "registration": "ABC 123",
       "vin": "...",
       "fuel_type": "petrol",
+      "secondary_fuel_type": null,
       "tank_capacity": 50.0,
       "is_active": true,
       "created_at": "2024-01-15T10:30:00",
@@ -111,6 +112,13 @@
   "count": 1
 }</code></pre>
                     </div>
+                    <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+                        A vehicle whose odometer is metered in engine hours rather than distance
+                        reports <code>total_distance</code> in hours and
+                        <code>average_consumption</code> in litres per hour. The tracking unit is
+                        set on the vehicle page and is not currently exposed or settable over the
+                        API; vehicles created here are tracked by distance.
+                    </p>
                 </div>
             </div>
 

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -941,6 +941,12 @@ msgstr ""
 msgid "Vehicle \"%(name)s\" added successfully"
 msgstr ""
 
+#: app/routes/vehicles.py:268
+msgid ""
+"Tracking unit cannot be changed once readings have been logged for this "
+"vehicle. Existing readings were kept as they are."
+msgstr ""
+
 #: app/routes/vehicles.py:259
 msgid "Vehicle updated successfully"
 msgstr ""

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.36.0'
+APP_VERSION = '0.36.1'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_tracking_unit_hours.py
+++ b/tests/test_tracking_unit_hours.py
@@ -1,0 +1,283 @@
+"""Repro for issue #323: Vehicle.tracking_unit is not authoritative.
+
+Vehicle.tracking_unit ('mileage' | 'hours') is stored on the model and set
+from the vehicle form, but nothing in the consumption maths in
+app/models.py checks it. Vehicle._valid_consumption_segments,
+get_average_consumption and FuelLog.get_consumption all treat the
+`odometer` column as a distance unconditionally, running it through
+_distance_in(distance, odometer_unit, 'km'/'mi') regardless of
+tracking_unit. For an 'hours' vehicle this means its hour readings get
+silently scaled by the km<->mi conversion factor, as if 50 engine hours
+were 50 miles.
+
+These tests assert an invariant that must hold no matter which exact
+hours-based formula the eventual fix adopts: an hours-tracked vehicle's
+computed consumption must not change just because its (purely cosmetic,
+distance-only) odometer_unit preference is 'km' vs 'mi' — hours never
+convert by a distance factor. Today it does change, because the code
+runs hours through the distance-conversion path.
+"""
+from datetime import date
+
+from app import db
+from app.models import Vehicle, FuelLog
+
+
+class TestHoursTrackingUnitConsumption:
+    def _hours_vehicle(self, test_user, odometer_unit):
+        v = Vehicle(
+            owner_id=test_user.id, name='Tractor', vehicle_type='car',
+            fuel_type='diesel', tracking_unit='hours', odometer_unit=odometer_unit,
+        )
+        db.session.add(v)
+        db.session.commit()
+        db.session.add_all([
+            FuelLog(vehicle_id=v.id, user_id=test_user.id, date=date(2026, 1, 1),
+                    odometer=0, volume=20.0, is_full_tank=True),
+            FuelLog(vehicle_id=v.id, user_id=test_user.id, date=date(2026, 1, 15),
+                    odometer=50, volume=20.0, is_full_tank=True),
+        ])
+        db.session.commit()
+        return v
+
+    def test_average_consumption_independent_of_odometer_unit(self, app, test_user):
+        """50 engine hours must not behave as 50 miles (issue #323 / #282).
+
+        Two vehicles with identical hour readings and fuel but different
+        (irrelevant, distance-only) odometer_unit settings must produce the
+        same consumption figure. Today they don't: the km vehicle reads 50
+        as 50 km, the mi vehicle reads 50 as 50 miles and converts it to
+        ~80.5 km before dividing, because the code has no idea the vehicle
+        is tracking hours.
+        """
+        km_vehicle = self._hours_vehicle(test_user, 'km')
+        mi_vehicle = self._hours_vehicle(test_user, 'mi')
+
+        km_result = km_vehicle.get_average_consumption()
+        mi_result = mi_vehicle.get_average_consumption()
+
+        assert km_result is not None
+        assert mi_result is not None
+        assert abs(km_result - mi_result) < 0.01, (
+            f"hours-tracked consumption changed with odometer_unit alone "
+            f"(km={km_result!r}, mi={mi_result!r}) — 50 hours is being "
+            f"treated as a distance and converted like miles"
+        )
+
+    def test_fuel_log_get_consumption_independent_of_odometer_unit(self, app, test_user):
+        """Same invariant, exercised through FuelLog.get_consumption directly."""
+        km_vehicle = self._hours_vehicle(test_user, 'km')
+        mi_vehicle = self._hours_vehicle(test_user, 'mi')
+
+        km_log = km_vehicle.fuel_logs.order_by(FuelLog.odometer.desc()).first()
+        mi_log = mi_vehicle.fuel_logs.order_by(FuelLog.odometer.desc()).first()
+
+        km_result = km_log.get_consumption()
+        mi_result = mi_log.get_consumption()
+
+        assert km_result is not None
+        assert mi_result is not None
+        assert abs(km_result - mi_result) < 0.01, (
+            f"FuelLog.get_consumption for an hours-tracked vehicle changed "
+            f"with odometer_unit alone (km={km_result!r}, mi={mi_result!r})"
+        )
+
+    def test_mileage_vehicle_unaffected(self, app, test_user, sample_vehicle):
+        """Regression guard: a 'mileage' vehicle (the default) must keep
+        behaving exactly as it does today — this is the acceptance
+        criterion that today's fix must not break."""
+        assert sample_vehicle.tracking_unit == 'mileage'
+        db.session.add_all([
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2024, 1, 1), odometer=10000.0, volume=40.0, is_full_tank=True),
+            FuelLog(vehicle_id=sample_vehicle.id, user_id=test_user.id,
+                    date=date(2024, 1, 15), odometer=10500.0, volume=35.0, is_full_tank=True),
+        ])
+        db.session.commit()
+        # Same figure documented in TestFuelLogConsumption.test_get_consumption_with_previous_log
+        assert abs(sample_vehicle.get_average_consumption() - 7.0) < 0.01
+
+
+class TestHoursTractorFigures:
+    """The tractor case from #282, with the numbers spelled out.
+
+    The unit is derived from the owning vehicle at read time, so an
+    hours-tracked vehicle's span is engine hours and never touches the
+    km/mi conversion.
+    """
+
+    def _tractor(self, test_user):
+        v = Vehicle(
+            owner_id=test_user.id, name='Tractor', vehicle_type='car',
+            fuel_type='diesel', tracking_unit='hours', odometer_unit='mi',
+        )
+        db.session.add(v)
+        db.session.commit()
+        db.session.add_all([
+            FuelLog(vehicle_id=v.id, user_id=test_user.id, date=date(2026, 1, 1),
+                    odometer=0, volume=20.0, total_cost=30.0, is_full_tank=True),
+            FuelLog(vehicle_id=v.id, user_id=test_user.id, date=date(2026, 1, 15),
+                    odometer=50, volume=20.0, total_cost=30.0, is_full_tank=True),
+        ])
+        db.session.commit()
+        return v
+
+    def test_average_consumption_is_litres_per_hour(self, app, test_user):
+        # 20 L over 50 engine hours = 0.4 L/hour. Treated as 50 miles it
+        # would have come out as (20 / 80.4672) * 100 = 24.9 "L/100km".
+        tractor = self._tractor(test_user)
+        assert abs(tractor.get_average_consumption() - 0.4) < 0.0001
+
+    def test_consumption_unit_preference_is_ignored_for_hours(self, app, test_user):
+        """mpg, km/L and L/100km are all named for a distance a tractor
+        never records, so the hours figure is the same whichever is asked
+        for."""
+        tractor = self._tractor(test_user)
+        for unit in ('L/100km', 'mpg', 'mpg_us', 'km/L', None):
+            assert abs(tractor.get_average_consumption(unit) - 0.4) < 0.0001
+
+    def test_fuel_log_consumption_is_litres_per_hour(self, app, test_user):
+        tractor = self._tractor(test_user)
+        log = tractor.fuel_logs.order_by(FuelLog.odometer.desc()).first()
+        assert abs(log.get_consumption() - 0.4) < 0.0001
+
+    def test_total_distance_ignores_distance_unit(self, app, test_user):
+        """50 engine hours are 50 engine hours whichever distance unit is
+        asked for — there is no conversion to apply to an hour."""
+        tractor = self._tractor(test_user)
+        assert tractor.get_total_distance() == 50
+        assert tractor.get_total_distance('km') == 50
+        assert tractor.get_total_distance('mi') == 50
+
+    def test_cost_per_unit_is_per_hour(self, app, test_user):
+        # £60 of fuel over 50 engine hours = £1.20 per hour.
+        tractor = self._tractor(test_user)
+        assert abs(tractor.get_cost_per_distance() - 1.2) < 0.0001
+
+    def test_charging_consumption_is_per_hundred_hours(self, app, test_user):
+        """Electric plant is tracked in hours too, so kWh per 100 hours."""
+        from app.models import ChargingSession
+
+        v = Vehicle(
+            owner_id=test_user.id, name='Electric loader', vehicle_type='car',
+            fuel_type='electric', tracking_unit='hours', odometer_unit='mi',
+        )
+        db.session.add(v)
+        db.session.commit()
+        db.session.add_all([
+            ChargingSession(vehicle_id=v.id, user_id=test_user.id,
+                            date=date(2026, 1, 1), odometer=0, kwh_added=10.0),
+            ChargingSession(vehicle_id=v.id, user_id=test_user.id,
+                            date=date(2026, 1, 15), odometer=50, kwh_added=10.0),
+        ])
+        db.session.commit()
+        # 20 kWh over 50 hours = 40 kWh per 100 hours; as miles it would
+        # have been converted to 80.47 km and read 24.9.
+        assert abs(v.get_average_charging_consumption() - 40.0) < 0.0001
+
+
+class TestMileageRegression:
+    """A 'mileage' vehicle must produce byte-identical figures to before."""
+
+    def _car(self, test_user, odometer_unit):
+        v = Vehicle(
+            owner_id=test_user.id, name='Car', vehicle_type='car',
+            fuel_type='petrol', tracking_unit='mileage', odometer_unit=odometer_unit,
+        )
+        db.session.add(v)
+        db.session.commit()
+        db.session.add_all([
+            FuelLog(vehicle_id=v.id, user_id=test_user.id, date=date(2024, 1, 1),
+                    odometer=10000.0, volume=40.0, total_cost=60.0, is_full_tank=True),
+            FuelLog(vehicle_id=v.id, user_id=test_user.id, date=date(2024, 1, 15),
+                    odometer=10500.0, volume=35.0, total_cost=52.5, is_full_tank=True),
+        ])
+        db.session.commit()
+        return v
+
+    def test_km_vehicle_figures_unchanged(self, app, test_user):
+        car = self._car(test_user, 'km')
+        log = car.fuel_logs.order_by(FuelLog.odometer.desc()).first()
+        assert car.get_average_consumption() == (35.0 / 500.0) * 100
+        assert log.get_consumption() == (35.0 / 500.0) * 100
+        assert car.get_average_consumption('km/L') == 500.0 / 35.0
+        assert car.get_total_distance('km') == 500.0
+        assert car.get_cost_per_distance() == 112.5 / 500.0
+
+    def test_mi_vehicle_still_converts(self, app, test_user):
+        """A distance-tracked vehicle keeps converting exactly as before —
+        the km/mi factor is only skipped for hours."""
+        car = self._car(test_user, 'mi')
+        km = 500.0 * 1.609344
+        assert car.get_average_consumption() == (35.0 / km) * 100
+        assert car.get_average_consumption('mpg') == 500.0 / (35.0 / 4.54609)
+        assert car.get_total_distance('km') == km
+        assert car.get_total_distance() == 500.0
+
+    def test_mileage_charging_consumption_unchanged(self, app, test_user):
+        from app.models import ChargingSession
+
+        car = self._car(test_user, 'mi')
+        db.session.add_all([
+            ChargingSession(vehicle_id=car.id, user_id=test_user.id,
+                            date=date(2024, 1, 1), odometer=10000.0, kwh_added=10.0),
+            ChargingSession(vehicle_id=car.id, user_id=test_user.id,
+                            date=date(2024, 1, 15), odometer=10500.0, kwh_added=10.0),
+        ])
+        db.session.commit()
+        assert car.get_average_charging_consumption() == (20.0 / 500.0) * 100
+        assert car.get_average_charging_consumption('km') == (20.0 / (500.0 * 1.609344)) * 100
+
+
+class TestTrackingUnitChangeGuard:
+    """Changing tracking_unit once readings exist would reinterpret them,
+    so the edit route refuses that field (#323)."""
+
+    def test_change_refused_once_fuel_logs_exist(self, app, auth_client, test_user, sample_vehicle):
+        db.session.add(FuelLog(
+            vehicle_id=sample_vehicle.id, user_id=test_user.id,
+            date=date(2024, 1, 1), odometer=10000.0, volume=40.0, is_full_tank=True))
+        db.session.commit()
+
+        resp = auth_client.post(f'/vehicles/{sample_vehicle.id}/edit', data={
+            'name': 'Renamed', 'vehicle_type': 'car', 'fuel_type': 'petrol',
+            'tracking_unit': 'hours',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.tracking_unit == 'mileage'
+        # The rest of the edit still saves.
+        assert sample_vehicle.name == 'Renamed'
+
+    def test_change_allowed_before_any_reading(self, app, auth_client, sample_vehicle):
+        resp = auth_client.post(f'/vehicles/{sample_vehicle.id}/edit', data={
+            'name': sample_vehicle.name, 'vehicle_type': 'car', 'fuel_type': 'petrol',
+            'tracking_unit': 'hours',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.tracking_unit == 'hours'
+
+    def test_unchanged_unit_saves_normally_with_readings(self, app, auth_client, test_user, sample_vehicle):
+        db.session.add(FuelLog(
+            vehicle_id=sample_vehicle.id, user_id=test_user.id,
+            date=date(2024, 1, 1), odometer=10000.0, volume=40.0, is_full_tank=True))
+        db.session.commit()
+
+        resp = auth_client.post(f'/vehicles/{sample_vehicle.id}/edit', data={
+            'name': 'Still Fine', 'vehicle_type': 'car', 'fuel_type': 'petrol',
+            'tracking_unit': 'mileage',
+        }, follow_redirects=True)
+
+        assert resp.status_code == 200
+        db.session.refresh(sample_vehicle)
+        assert sample_vehicle.name == 'Still Fine'
+        assert sample_vehicle.tracking_unit == 'mileage'
+
+    def test_has_odometer_readings_sees_other_record_types(self, app, test_user, sample_vehicle, sample_trip):
+        """A vehicle with no fuel logs but trips against its odometer still
+        has readings that a unit change would reinterpret."""
+        assert sample_vehicle.fuel_logs.first() is None
+        assert sample_vehicle.has_odometer_readings() is True


### PR DESCRIPTION
## 0.36.1

A single fix, for vehicles metered in engine hours rather than distance.

### Fixed

- A vehicle set to track engine hours has its readings treated as hours rather
  than as a distance. Its consumption is worked out in litres per hour, its
  running cost per hour, and a charged machine's energy use per 100 hours.
  None of those figures change any more when the vehicle's (distance-only)
  odometer unit is switched between km and miles, which used to scale 50
  engine hours into 80.5 as though they were miles. Vehicles tracked by
  mileage are unaffected. ([#323](https://github.com/dannymcc/may/issues/323))

### Changed

- A vehicle's tracking unit can no longer be changed once anything has been
  logged against its odometer. Switching it would have reinterpreted every
  existing reading — 50 miles becoming 50 engine hours — so the rest of the
  edit saves and that one field is refused with a message.
  ([#323](https://github.com/dannymcc/may/issues/323))

### Documentation

- The README describes the tracking unit and is candid about the remaining
  gap: the figures for an hours-tracked vehicle are correct, but the labels
  beside them still read in distance terms ("L/100km", "Cost per mi"). That
  is being corrected separately.
- The API documentation says the same about `total_distance` and
  `average_consumption`, and records that the tracking unit is neither
  exposed nor settable over the API. The vehicle response example also now
  includes `secondary_fuel_type`, which the API has returned since 0.36.0.

Thanks to whoever reported [#323](https://github.com/dannymcc/may/issues/323)
— it was a quiet fault that only showed up on plant and machinery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Vehicles can now track usage by engine hours as well as distance.
  - Consumption, energy use and running costs are calculated correctly for hours-tracked vehicles.
  - Added API documentation for tracking units and `secondary_fuel_type`.

- **Bug Fixes**
  - Tracking units can no longer be changed after odometer activity has been recorded.
  - Existing distance-based vehicle calculations remain unchanged.

- **Documentation**
  - Updated the README, API documentation and changelog with tracking-unit details.
  - Updated the application version to 0.36.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->