### PR TITLE
Release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Changed
+
+- Trips logged on the same date are now listed in odometer order, the highest
+  reading first, rather than in whatever order the database returned them. A
+  trip's date carries no time of day, so several journeys on one day could
+  appear out of sequence and the reading on the top row would not be the
+  vehicle's latest — easily missed on a phone. The list is still ordered by
+  date, most recent first.
+  ([#325](https://github.com/dannymcc/may/issues/325))
+
 ## [0.36.1] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-08-24
+
 ### Changed
 
 - Trips logged on the same date are now listed in odometer order, the highest

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Log journeys for mileage and tax records:
 - Optional fuel gauge readings at the start and end of the trip, entered as a percentage of a full tank
 - Where the vehicle has a tank capacity set, the fuel used on the trip is worked out from those readings and shown on the trip list, giving a per-trip view of consumption between fill-ups
 - Reusable templates for journeys you make often, and a business/personal summary report per year
+- The list is ordered by date, most recent first; trips sharing a date are ordered by their odometer reading, so the journey you drove last sits at the top
 
 ### Reminders
 Never miss important dates:

--- a/app/routes/trips.py
+++ b/app/routes/trips.py
@@ -33,7 +33,9 @@ def index():
     if year_filter:
         query = query.filter(db.extract('year', Trip.date) == year_filter)
 
-    trips = query.order_by(Trip.date.desc()).all()
+    # Same-day trips have no time component, so fall back to the odometer
+    # reading to keep them in driving order (most recent first)
+    trips = query.order_by(Trip.date.desc(), Trip.start_odometer.desc()).all()
 
     # Get available years for filter
     years = db.session.query(db.extract('year', Trip.date)).filter(

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.36.1'
+APP_VERSION = '0.37.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_trips.py
+++ b/tests/test_trips.py
@@ -36,6 +36,68 @@ class TestTripIndex:
         assert resp.status_code == 200
         assert b'Client meeting' in resp.data
 
+    def test_index_orders_same_day_trips_by_odometer(self, auth_client, test_user, sample_vehicle):
+        """Trips logged on the same date should be listed by odometer
+        (most recently driven first), not by insertion order (#325)."""
+        earlier = Trip(
+            vehicle_id=sample_vehicle.id,
+            user_id=test_user.id,
+            date=date(2024, 2, 1),
+            start_odometer=10000.0,
+            end_odometer=10050.0,
+            purpose='business',
+            description='Morning trip',
+        )
+        db.session.add(earlier)
+        db.session.commit()
+
+        later = Trip(
+            vehicle_id=sample_vehicle.id,
+            user_id=test_user.id,
+            date=date(2024, 2, 1),
+            start_odometer=10050.0,
+            end_odometer=10120.0,
+            purpose='business',
+            description='Afternoon trip',
+        )
+        db.session.add(later)
+        db.session.commit()
+
+        resp = auth_client.get('/trips/')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        # The trip with the higher (later) odometer reading should be
+        # listed before the earlier same-day trip.
+        assert html.index('Afternoon trip') < html.index('Morning trip')
+
+    def test_index_still_orders_by_date_first(self, auth_client, test_user, sample_vehicle):
+        """The odometer tie-break must not displace the date ordering (#325)."""
+        older = Trip(
+            vehicle_id=sample_vehicle.id,
+            user_id=test_user.id,
+            date=date(2024, 2, 1),
+            start_odometer=20000.0,
+            end_odometer=20100.0,
+            purpose='business',
+            description='Older high-odometer trip',
+        )
+        newer = Trip(
+            vehicle_id=sample_vehicle.id,
+            user_id=test_user.id,
+            date=date(2024, 3, 1),
+            start_odometer=10000.0,
+            end_odometer=10100.0,
+            purpose='business',
+            description='Newer low-odometer trip',
+        )
+        db.session.add_all([older, newer])
+        db.session.commit()
+
+        resp = auth_client.get('/trips/')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert html.index('Newer low-odometer trip') < html.index('Older high-odometer trip')
+
 
 class TestTripNew:
     def test_new_requires_auth(self, client):


### PR DESCRIPTION
## 0.37.0

### Features

- Trips logged on the same date are now listed in odometer order, the highest reading first. A trip's date carries no time of day, so several journeys on one day used to come back in whatever order the database happened to return them, and the reading on the top row was not necessarily the vehicle's latest — easy to miss on a phone. The list is still ordered by date, most recent first. ([#325](https://github.com/dannymcc/may/issues/325))

### Fixes

None in this release.

### Other

- README describes the new ordering in the Trips section.

Thanks to whoever raised [#325](https://github.com/dannymcc/may/issues/325) for spotting it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trips are now listed with the newest dates first.
  * Trips recorded on the same date are sorted by starting odometer reading, highest first.

* **Documentation**
  * Updated trip-ordering guidance to reflect the new sorting behaviour.

* **Chores**
  * Updated the application version to 0.37.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->