### PR TITLE
Release v0.38.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+### Changed
+
+- Charging sessions logged on the same date are now listed in odometer order,
+  the highest reading first, rather than in whatever order the database
+  returned them — the same fix #325 made for trips. A session's date carries no
+  time of day, so several charges on one day could appear out of sequence,
+  which is easy to hit on a plug-in hybrid. The list is still ordered by date,
+  most recent first. A session with no odometer recorded has nothing to order
+  by, so it is left wherever the database puts it within that date.
+  ([#329](https://github.com/dannymcc/may/issues/329))
+
 ## [0.38.1] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ## [Unreleased]
 
+## [0.38.2] - 2026-08-25
+
 ### Changed
 
 - Charging sessions logged on the same date are now listed in odometer order,

--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ Track every fill-up with:
 
 Saving a fuel log returns you to the fuel log list, unless you started from a vehicle page, in which case you go back to that vehicle. Deleting one does the same: from the fuel log list you stay on the list, from a vehicle page you return to that vehicle. Notes behave the same way.
 
+### EV Charging
+Log charging sessions for electric and plug-in hybrid vehicles:
+- Date, optional start and end times, and the odometer reading
+- Energy added in kWh, state of charge at each end, and cost — the total is worked out from the price per kWh where you do not enter it yourself
+- Charger type, location and network, so home and public charging can be told apart
+- The list is ordered by date, most recent first; sessions sharing a date are ordered by their odometer reading, so the most recent charge sits at the top. This matters most on a plug-in hybrid, which may be charged several times in a day
+
 ### Expenses
 Categorize all vehicle-related costs:
 - Maintenance & Repairs

--- a/app/routes/charging.py
+++ b/app/routes/charging.py
@@ -29,7 +29,7 @@ def index():
     if vehicle_filter:
         query = query.filter(ChargingSession.vehicle_id == vehicle_filter)
 
-    sessions = query.order_by(ChargingSession.date.desc()).all()
+    sessions = query.order_by(ChargingSession.date.desc(), ChargingSession.odometer.desc()).all()
 
     # Calculate totals
     total_kwh = sum(s.kwh_added or 0 for s in sessions)

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.38.1'
+APP_VERSION = '0.38.2'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_charging.py
+++ b/tests/test_charging.py
@@ -118,6 +118,65 @@ class TestChargingIndex:
         resp = auth_client.get('/charging/')
         assert resp.status_code == 200
 
+    def test_index_orders_same_day_sessions_by_odometer(self, auth_client, test_user, ev_vehicle):
+        """Charging sessions logged on the same date should be listed by
+        odometer (most recently reached reading first), not by insertion
+        order — same issue as #325 for trips (#329)."""
+        earlier = ChargingSession(
+            vehicle_id=ev_vehicle.id,
+            user_id=test_user.id,
+            date=date(2026, 8, 22),
+            odometer=10000.0,
+            kwh_added=20.0,
+            location='Morning charge',
+        )
+        db.session.add(earlier)
+        db.session.commit()
+
+        later = ChargingSession(
+            vehicle_id=ev_vehicle.id,
+            user_id=test_user.id,
+            date=date(2026, 8, 22),
+            odometer=10200.0,
+            kwh_added=15.0,
+            location='Afternoon charge',
+        )
+        db.session.add(later)
+        db.session.commit()
+
+        resp = auth_client.get('/charging/')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        # The session with the higher (later) odometer reading should be
+        # listed before the earlier same-day session.
+        assert html.index('Afternoon charge') < html.index('Morning charge')
+
+    def test_index_still_orders_by_date_first(self, auth_client, test_user, ev_vehicle):
+        """The odometer tie-break must not displace the date ordering (#329)."""
+        older = ChargingSession(
+            vehicle_id=ev_vehicle.id,
+            user_id=test_user.id,
+            date=date(2026, 8, 1),
+            odometer=20000.0,
+            kwh_added=20.0,
+            location='Older high-odometer charge',
+        )
+        newer = ChargingSession(
+            vehicle_id=ev_vehicle.id,
+            user_id=test_user.id,
+            date=date(2026, 8, 22),
+            odometer=10000.0,
+            kwh_added=15.0,
+            location='Newer low-odometer charge',
+        )
+        db.session.add_all([older, newer])
+        db.session.commit()
+
+        resp = auth_client.get('/charging/')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert html.index('Newer low-odometer charge') < html.index('Older high-odometer charge')
+
 
 class TestChargingNew:
     def test_new_requires_auth(self, client):


### PR DESCRIPTION
## 0.38.2

A small fix to how charging sessions are ordered.

### Fixes

- Charging sessions logged on the same date are now listed in odometer order, the highest reading first, rather than in whatever order the database happened to return them. A session's date carries no time of day, so several charges on one day could appear out of sequence and the reading on the top row was not necessarily the vehicle's latest — easy to hit on a plug-in hybrid. The list is still ordered by date, most recent first. A session with no odometer recorded has nothing to order by, so it stays wherever the database puts it within that date. Thanks to the reporter of [#329](https://github.com/dannymcc/may/issues/329). This is the same fix [#325](https://github.com/dannymcc/may/issues/325) made for trips.

### Other

- README now describes the ordering of the charging list.

Note that the ordering applies to the charging list page. Charging sessions shown on the vehicle timeline and in the charging block on the fuel log page are still ordered by date alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Charging sessions on the same date are now listed by odometer reading, highest first.
  - Date remains the primary sorting criterion, with sessions lacking odometer readings retaining database order.

- **Documentation**
  - Added guidance for recording electric and plug-in hybrid charging sessions, including energy, charge level, costs, charger details and ordering.

- **Release**
  - Updated the application version to 0.38.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->