### PR TITLE
Improve CSV import: Spritmonitor.de support, auto-calc price, duplicate detection

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -3419,14 +3419,19 @@ def create_record(data_type, mapped_row, vehicle_id, user_id, date_format, user_
         odometer = parse_float_value(mapped_row.get('odometer'))
         if odometer is None:
             raise ValueError('Missing or invalid odometer')
+        volume = parse_float_value(mapped_row.get('volume'))
+        price_per_unit = parse_float_value(mapped_row.get('price_per_unit'))
+        total_cost = parse_float_value(mapped_row.get('total_cost'))
+        if price_per_unit is None and volume not in (None, 0) and total_cost is not None:
+            price_per_unit = round(total_cost / volume, 4)
         return FuelLog(
             vehicle_id=vehicle_id,
             user_id=user_id,
             date=date_val,
             odometer=odometer,
-            volume=parse_float_value(mapped_row.get('volume')),
-            price_per_unit=parse_float_value(mapped_row.get('price_per_unit')),
-            total_cost=parse_float_value(mapped_row.get('total_cost')),
+            volume=volume,
+            price_per_unit=price_per_unit,
+            total_cost=total_cost,
             sales_tax=parse_float_value(mapped_row.get('sales_tax')),
             is_full_tank=parse_bool_value(mapped_row.get('is_full_tank')) if mapped_row.get('is_full_tank') else True,
             is_missed=parse_bool_value(mapped_row.get('is_missed')),

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -3231,16 +3231,23 @@ def get_import_fields(data_type):
 
 # Common aliases for auto-suggesting column mappings
 _COLUMN_ALIASES = {
-    'date': ['date', 'fuelup date', 'fill date', 'trip date', 'charge date', 'session date', 'expense date'],
-    'odometer': ['odometer', 'odo', 'mileage', 'miles', 'km', 'kilometers', 'distance'],
-    'volume': ['volume', 'litres', 'liters', 'gallons', 'gal', 'fuel', 'qty', 'quantity'],
+    'date': ['date', 'fuelup date', 'fill date', 'trip date', 'charge date', 'session date', 'expense date',
+             'datum'],
+    'odometer': ['odometer', 'odo', 'mileage', 'miles', 'km', 'kilometers', 'distance',
+                 'km stand', 'kilometerstand', 'tachostand'],
+    'volume': ['volume', 'litres', 'liters', 'gallons', 'gal', 'fuel', 'qty', 'quantity',
+               'spritmenge', 'menge', 'liter', 'tankmenge'],
     'price_per_unit': ['price per unit', 'unit price', 'price/l', 'price/gal', 'price', 'rate'],
-    'total_cost': ['total cost', 'total', 'cost', 'price paid', 'total price'],
+    'total_cost': ['total cost', 'total', 'cost', 'price paid', 'total price',
+                   'kosten', 'gesamtkosten', 'betrag'],
     'sales_tax': ['sales tax', 'sales taxes', 'tax', 'taxes', 'vat', 'gst', 'hst', 'pst', 'qst'],
-    'is_full_tank': ['full tank', 'full', 'complete', 'full fill'],
+    'is_full_tank': ['full tank', 'full', 'complete', 'full fill',
+                     'tankart'],
     'is_missed': ['missed', 'missed fill', 'skipped'],
-    'station': ['station', 'gas station', 'fuel station'],
-    'notes': ['notes', 'note', 'comments', 'comment', 'remarks', 'memo'],
+    'station': ['station', 'gas station', 'fuel station',
+                'tankstelle'],
+    'notes': ['notes', 'note', 'comments', 'comment', 'remarks', 'memo',
+              'bemerkung', 'bemerkungen', 'notiz', 'notizen'],
     'category': ['category', 'type', 'expense type', 'expense category'],
     'description': ['description', 'desc', 'title', 'name', 'item', 'service'],
     'cost': ['cost', 'amount', 'total', 'price', 'expense'],
@@ -3553,7 +3560,15 @@ def csv_import_preview():
 
     try:
         content = file.read().decode('utf-8-sig', errors='ignore')
-        reader = csv.DictReader(io.StringIO(content))
+
+        # Auto-detect delimiter (comma vs semicolon)
+        try:
+            dialect = csv.Sniffer().sniff(content[:2048], delimiters=',;\t')
+            delimiter = dialect.delimiter
+        except csv.Error:
+            delimiter = ','
+
+        reader = csv.DictReader(io.StringIO(content), delimiter=delimiter)
         csv_columns = reader.fieldnames
 
         if not csv_columns:
@@ -3579,6 +3594,7 @@ def csv_import_preview():
         tmp.write(content)
         tmp.close()
         session['csv_import_temp_file'] = tmp.name
+        session['csv_import_delimiter'] = delimiter
 
         target_fields = get_import_fields(data_type)
         suggestions = auto_suggest_mappings(csv_columns, target_fields)
@@ -3610,6 +3626,7 @@ def csv_import_execute():
     vehicle_id = request.form.get('vehicle_id', type=int)
     date_format = request.form.get('date_format', 'auto')
     temp_file = session.pop('csv_import_temp_file', None)
+    delimiter = session.pop('csv_import_delimiter', ',')
 
     if data_type not in DATA_TYPE_LABELS:
         flash(_('Invalid data type.'), 'error')
@@ -3627,7 +3644,7 @@ def csv_import_execute():
     try:
         # Read temp CSV
         with open(temp_file, 'r', encoding='utf-8-sig', errors='ignore') as f:
-            reader = csv.DictReader(f)
+            reader = csv.DictReader(f, delimiter=delimiter)
             csv_columns = reader.fieldnames or []
 
             # Build column mapping from form: mapping_0, mapping_1, etc.

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -3408,6 +3408,41 @@ def _cleanup_temp_file(path):
     except OSError:
         pass
 
+def _is_duplicate(data_type, record, vehicle_id):
+    """Check whether a record with the same key fields already exists."""
+    if data_type == 'fuel_logs':
+        return db.session.query(FuelLog.id).filter_by(
+            vehicle_id=vehicle_id, date=record.date, odometer=record.odometer,
+        ).first() is not None
+    if data_type == 'expenses':
+        filters = dict(
+            vehicle_id=vehicle_id, date=record.date,
+            cost=record.cost, description=record.description,
+        )
+        # Tighten the key with optional fields when mapped, so two
+        # identical toll charges at different odometers aren't dropped.
+        if record.odometer is not None:
+            filters['odometer'] = record.odometer
+        if record.vendor is not None:
+            filters['vendor'] = record.vendor
+        return db.session.query(Expense.id).filter_by(**filters).first() is not None
+    if data_type == 'trips':
+        return db.session.query(Trip.id).filter_by(
+            vehicle_id=vehicle_id, date=record.date,
+            start_odometer=record.start_odometer,
+            end_odometer=record.end_odometer,
+        ).first() is not None
+    if data_type == 'charging_sessions':
+        return db.session.query(ChargingSession.id).filter_by(
+            vehicle_id=vehicle_id, date=record.date,
+            start_time=record.start_time, end_time=record.end_time,
+            odometer=record.odometer,
+            kwh_added=record.kwh_added,
+            total_cost=record.total_cost,
+            location=record.location, network=record.network,
+        ).first() is not None
+    return False
+
 
 def create_record(data_type, mapped_row, vehicle_id, user_id, date_format, user_date_format=None):
     """Create a model instance from a mapped CSV row."""
@@ -3662,6 +3697,7 @@ def csv_import_execute():
             rows = list(reader)
 
         imported = 0
+        skipped = 0
         errors = []
         max_errors = 50
 
@@ -3672,6 +3708,9 @@ def csv_import_execute():
                     mapped_row[field_name] = row.get(csv_col, '')
 
                 record = create_record(data_type, mapped_row, vehicle_id, current_user.id, date_format, current_user.date_format)
+                if _is_duplicate(data_type, record, vehicle_id):
+                    skipped += 1
+                    continue
                 db.session.add(record)
                 imported += 1
             except (ValueError, KeyError) as e:
@@ -3682,6 +3721,9 @@ def csv_import_execute():
 
         label = DATA_TYPE_LABELS.get(data_type, data_type)
         flash(_('CSV import complete: %(count)s %(label)s imported.') % {'count': imported, 'label': label.lower()}, 'success')
+
+        if skipped:
+            flash(_('%(count)s duplicate(s) skipped.') % {'count': skipped}, 'info')
 
         if errors:
             error_summary = f'{len(errors)} row(s) skipped due to errors.'

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,7 +5,7 @@ import sqlite3
 import tempfile
 import pytest
 from app import db as _db_ext
-from app.models import Vehicle, FuelLog
+from app.models import Vehicle, FuelLog, Expense, Trip, ChargingSession
 
 
 # ---------------------------------------------------------------------------
@@ -690,6 +690,7 @@ class TestSpritmonitorCsvImport:
         assert logs[0].odometer == 198042
         assert abs(logs[0].volume - 26.12) < 0.01
         assert abs(logs[0].total_cost - 44.12) < 0.01
+        assert logs[0].price_per_unit == pytest.approx(44.12 / 26.12, abs=0.001)
         assert logs[0].is_full_tank is True
         assert logs[0].notes == 'Testtankung'
 
@@ -715,3 +716,97 @@ class TestSpritmonitorCsvImport:
         # The mapping page should auto-select fields for German column names
         # Check that "date" is pre-selected for "Datum"
         assert 'selected' in html
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection during CSV import
+# ---------------------------------------------------------------------------
+
+class TestCsvImportDuplicateDetection:
+    """Importing the same CSV twice should skip duplicates on the second run."""
+
+    def _preview_and_execute(self, auth_client, vehicle_id, data_type, csv_bytes,
+                             mappings, date_format='auto'):
+        """Run preview→execute and return the final (followed) response."""
+        preview_resp = auth_client.post(
+            '/api/import/csv/preview',
+            data={
+                'data_type': data_type,
+                'vehicle_id': str(vehicle_id),
+                'file': (io.BytesIO(csv_bytes), 'import.csv'),
+            },
+            content_type='multipart/form-data',
+        )
+        assert preview_resp.status_code == 200
+        form = {'data_type': data_type, 'vehicle_id': str(vehicle_id),
+                'date_format': date_format}
+        form.update(mappings)
+        return auth_client.post(
+            '/api/import/csv/execute', data=form,
+            content_type='multipart/form-data',
+            follow_redirects=True,
+        )
+
+    def test_fuel_logs_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,odometer,volume,total_cost\n2024-03-01,20000,35.0,52.50\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'odometer',
+                    'mapping_2': 'volume', 'mapping_3': 'total_cost'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'fuel_logs', csv, mappings)
+        assert FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'fuel_logs', csv, mappings)
+        html = resp.data.decode()
+        assert '0 fuel logs imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+    def test_expenses_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,category,description,cost\n2024-03-01,maintenance,Oil change,75.00\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'category',
+                    'mapping_2': 'description', 'mapping_3': 'cost'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'expenses', csv, mappings)
+        assert Expense.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'expenses', csv, mappings)
+        html = resp.data.decode()
+        assert '0 expenses imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert Expense.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+    def test_trips_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,start_odometer,end_odometer,purpose\n2024-03-01,20000,20050,business\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'start_odometer',
+                    'mapping_2': 'end_odometer', 'mapping_3': 'purpose'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'trips', csv, mappings)
+        assert Trip.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'trips', csv, mappings)
+        html = resp.data.decode()
+        assert '0 trips imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert Trip.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+    def test_charging_sessions_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,kwh_added,total_cost,location\n2024-03-01,40.0,12.00,Home\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'kwh_added',
+                    'mapping_2': 'total_cost', 'mapping_3': 'location'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'charging_sessions', csv, mappings)
+        assert ChargingSession.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'charging_sessions', csv, mappings)
+        html = resp.data.decode()
+        assert '0 charging sessions imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert ChargingSession.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -604,3 +604,114 @@ class TestCsvImportUsDateFormat:
         )
         log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).one()
         assert log.date == date(2026, 1, 12)
+
+
+# ---------------------------------------------------------------------------
+# Spritmonitor CSV import (semicolon-delimited, German format)
+# ---------------------------------------------------------------------------
+
+def make_spritmonitor_csv():
+    """Create a minimal Spritmonitor CSV export."""
+    content = (
+        'Datum;Km-Stand;Teil-Km;Spritmenge;Kosten;W\u00e4hrung;Tankart;Reifen;Strecken;'
+        'Fahrweise;Kraftstoff;Bemerkung;Verbrauch;BC-Verbrauch;BC-Spritmenge;'
+        'BC-Geschwindigkeit;Tankstelle;Land;Gro\u00dfraum;Ort\n'
+        '08.08.2026;199166;525;22,23;46,44;EUR;1;1;14;2;1;;4,23;;;;;D;;\n'
+        '12.07.2026;198641;599;26,93;53,03;EUR;1;1;14;3;1;;4,5;;;;;D;;\n'
+        '24.06.2026;198042;542,5;26,12;44,12;EUR;1;1;14;3;1;Testtankung;4,81;;;;;D;;\n'
+    )
+    return content.encode('utf-8')
+
+
+class TestSpritmonitorCsvImport:
+    """End-to-end import of a Spritmonitor semicolon-delimited CSV."""
+
+    def test_preview_detects_semicolon_delimiter(self, auth_client, sample_vehicle):
+        """Preview step should correctly parse semicolon-delimited CSV."""
+        data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'file': (io.BytesIO(make_spritmonitor_csv()), 'spritmonitor.csv'),
+        }
+        resp = auth_client.post(
+            '/api/import/csv/preview',
+            data=data,
+            content_type='multipart/form-data',
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'Datum' in html
+        assert 'Km-Stand' in html
+        assert 'Spritmenge' in html
+
+    def test_full_import_flow(self, auth_client, sample_vehicle):
+        """Full preview→execute flow imports Spritmonitor records correctly."""
+        from datetime import date
+
+        # Step 1: Preview
+        preview_data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'file': (io.BytesIO(make_spritmonitor_csv()), 'spritmonitor.csv'),
+        }
+        preview_resp = auth_client.post(
+            '/api/import/csv/preview',
+            data=preview_data,
+            content_type='multipart/form-data',
+        )
+        assert preview_resp.status_code == 200
+
+        # Step 2: Execute with Spritmonitor column mappings
+        # Columns: Datum(0), Km-Stand(1), Teil-Km(2), Spritmenge(3), Kosten(4),
+        #          Währung(5), Tankart(6), ..., Bemerkung(11), ...
+        execute_data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'date_format': 'DD/MM/YYYY',
+            'mapping_0': 'date',
+            'mapping_1': 'odometer',
+            'mapping_3': 'volume',
+            'mapping_4': 'total_cost',
+            'mapping_6': 'is_full_tank',
+            'mapping_11': 'notes',
+        }
+        execute_resp = auth_client.post(
+            '/api/import/csv/execute',
+            data=execute_data,
+            content_type='multipart/form-data',
+        )
+        assert execute_resp.status_code == 302
+
+        logs = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).order_by(FuelLog.date).all()
+        assert len(logs) == 3
+
+        # Check first record (oldest: 24.06.2026)
+        assert logs[0].date == date(2026, 6, 24)
+        assert logs[0].odometer == 198042
+        assert abs(logs[0].volume - 26.12) < 0.01
+        assert abs(logs[0].total_cost - 44.12) < 0.01
+        assert logs[0].is_full_tank is True
+        assert logs[0].notes == 'Testtankung'
+
+        # Check last record (newest: 08.08.2026)
+        assert logs[2].date == date(2026, 8, 8)
+        assert logs[2].odometer == 199166
+        assert abs(logs[2].volume - 22.23) < 0.01
+
+    def test_auto_suggest_maps_german_columns(self, auth_client, sample_vehicle):
+        """Auto-suggest should map Spritmonitor German column names."""
+        data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'file': (io.BytesIO(make_spritmonitor_csv()), 'spritmonitor.csv'),
+        }
+        resp = auth_client.post(
+            '/api/import/csv/preview',
+            data=data,
+            content_type='multipart/form-data',
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        # The mapping page should auto-select fields for German column names
+        # Check that "date" is pre-selected for "Datum"
+        assert 'selected' in html


### PR DESCRIPTION
## Summary

Improve the generic CSV import to support [Spritmonitor.de](https://www.spritmonitor.de/) exports and handle common edge cases (missing price-per-unit, duplicate records).

## Changelog

- Added: Spritmonitor.de CSV support — auto-detect semicolon/tab delimiters via csv.Sniffer, German column name aliases (Datum, Km-Stand, Spritmenge, Kosten, Tankstelle, Bemerkung, etc.) for automatic field mapping
- Added: Auto-calculate price_per_unit from total_cost / volume when not provided in the import source
- Added: Duplicate detection during CSV import — records matching by key fields (date + odometer for fuel, date + cost + description for expenses, etc.) are skipped with an info message

## Testing

How were these changes tested?

- [x] Tested locally
- [x] Tested with Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CSV imports now support additional German and alternative column names.
  - Added support for semicolon-delimited files and comma decimal separators.
  - Import previews automatically detect and retain the file delimiter for execution.
  - Fuel imports can calculate unit prices from total cost and quantity when unavailable.

- **Bug Fixes**
  - Prevented duplicate fuel logs, expenses, trips and charging sessions from being imported.
  - Import results now report skipped duplicate records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->