### PR TITLE
Release 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file starts at 0.28.0. Notes for earlier releases are on the
 [GitHub releases page](https://github.com/dannymcc/may/releases).
 
+## [0.42.0] - 2026-08-28
+
+### Added
+
+- Recurring expenses can record a vendor. The column and the copy of it onto
+  each auto-generated expense already existed, but no field on the recurring
+  form ever populated it, so the vendor had to be filled in by hand after the
+  event. The form now carries a vendor input, with the same known-vendor
+  suggestions as the one-off expense form, and both the create and the edit
+  route read it. ([#349](https://github.com/dannymcc/may/issues/349))
+
+### Fixed
+
+- The mobile navigation no longer sits in a lighter grey block in dark mode.
+  Every item in the menu, the hamburger button that opens it and the desktop
+  "More" dropdown carried a stray `dark:bg-gray-600` beside an already-correct
+  `dark:hover:bg-gray-700`. A resting background applies at all times, so the
+  colour meant for hover was painted on permanently, against a darker nav bar.
+  The 28 stray classes are deleted — each had the right hover class beside it,
+  so nothing had to be guessed about the intended colour — and the layout tests
+  gain a nav-scoped invariant that would catch the same slip again.
+  ([#347](https://github.com/dannymcc/may/issues/347))
+- The "Check Now" button on Settings > About now refreshes the Current Version
+  it shows. The check reported update status but left the version as rendered
+  at page load, so after updating the host over SSH the page went on showing
+  the old number until the browser was reloaded. The check-updates response
+  now carries the display version, dev channel's "-dev+sha" suffix intact, and
+  the page updates in place.
+  ([#348](https://github.com/dannymcc/may/issues/348))
+- The Hungarian catalogue addresses the reader informally throughout. Hungarian
+  distinguishes formal from informal address and the shipped catalogue used
+  both: everything predating the bulk fill in #340 was informal, but a handful
+  of the strings that fill added were written formal, and the trip templates
+  strapline managed both registers in one sentence. Twenty-eight msgstrs are
+  rewritten to the informal register the catalogue had already settled on.
+  Register only — no wording otherwise changes.
+  ([#350](https://github.com/dannymcc/may/issues/350))
+- Six further Hungarian corrections, taken from #339 and applied against the
+  catalogue as it now stands: the missing accent on "Kilometres (km)", the
+  "toppic-ot" typo in the ntfy hint, "SMTP Host" translated rather than left
+  as an English loanword, the "/" convention the catalogue already used for
+  "Cost per kWh" extended to its neighbours, and one word for the instrument
+  across the Odometer family — "Last Odometer" had been the mileage covered
+  rather than the reading on the dial. #339's change of the bare msgid
+  "Registration" is deliberately not carried over: since #342 that string
+  carries the registration fee only, not the plate. Credit to burgatshow.
+  ([#352](https://github.com/dannymcc/may/issues/352))
+
+### Changed
+
+- The nine other catalogues filled by #340 (de, fr, es, it, pt, nl, pl, cs and
+  ru) were audited for the same formal/informal break as the Hungarian one and
+  found consistent, so no msgstr needed correcting. Tests now record the
+  register each catalogue settled on and fail if a future bulk fill introduces
+  the other one, checking imperative conjugation as well as address pronouns
+  for the pro-drop languages.
+  ([#351](https://github.com/dannymcc/may/issues/351))
+
 ## [0.41.4] - 2026-08-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file starts at 0.28.0. Notes for earlier releases are on the
 [GitHub releases page](https://github.com/dannymcc/may/releases).
 
-## [0.42.0] - 2026-08-28
+## [0.42.0] - 2026-09-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ### Added
 
+- The CSV importer understands Spritmonitor.de exports. It sniffs the
+  semicolon delimiter those files use, maps their columns onto fuel logs, and
+  where a row gives a total and a volume but no unit price it fills the price
+  in at `total / volume` rather than leaving it blank. Duplicate rows are
+  detected on the fields that actually identify a fill, so re-importing the
+  same export does not double up the history. Credit to LukasLJL.
+  ([#346](https://github.com/dannymcc/may/pull/346))
 - Recurring expenses can record a vendor. The column and the copy of it onto
   each auto-generated expense already existed, but no field on the recurring
   form ever populated it, so the vendor had to be filled in by hand after the
@@ -21,6 +28,16 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ### Fixed
 
+- The vehicle charts respect the currency and date-format settings. The
+  Expense by Category chart drew its value axis (the x axis, the bar being
+  horizontal) as bare numbers with no unit, so it was not obvious the figures
+  were money; those ticks now carry the configured currency symbol. And the
+  Fuel Consumption Trend and Fuel Price Trend charts labelled their date axis
+  straight from the API's ISO strings, ignoring Settings > Date Format; both
+  now format each label to the chosen pattern, reading it from the same source
+  the rest of the page does.
+  ([#359](https://github.com/dannymcc/may/issues/359),
+  [#358](https://github.com/dannymcc/may/issues/358))
 - The mobile navigation no longer sits in a lighter grey block in dark mode.
   Every item in the menu, the hamburger button that opens it and the desktop
   "More" dropdown carried a stray `dark:bg-gray-600` beside an already-correct
@@ -58,6 +75,10 @@ This file starts at 0.28.0. Notes for earlier releases are on the
 
 ### Changed
 
+- Minor corrections to the German catalogue: "Schnelladung" reads "DC
+  Schnelladung", and a few multi-line entries were unwrapped (gettext
+  concatenates the adjacent literals, so the msgids are unchanged). Credit to
+  solluh. ([#361](https://github.com/dannymcc/may/pull/361))
 - The nine other catalogues filled by #340 (de, fr, es, it, pt, nl, pl, cs and
   ru) were audited for the same formal/informal break as the Hungarian one and
   found consistent, so no msgstr needed correcting. Tests now record the

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Track regular payments:
 - Road tax
 - Subscriptions and memberships
 - Custom recurrence patterns (monthly, quarterly, yearly)
+- An optional vendor / service provider, carried on to every expense the
+  schedule creates
 - Automatic calendar integration
 
 ### Documents

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -3231,16 +3231,23 @@ def get_import_fields(data_type):
 
 # Common aliases for auto-suggesting column mappings
 _COLUMN_ALIASES = {
-    'date': ['date', 'fuelup date', 'fill date', 'trip date', 'charge date', 'session date', 'expense date'],
-    'odometer': ['odometer', 'odo', 'mileage', 'miles', 'km', 'kilometers', 'distance'],
-    'volume': ['volume', 'litres', 'liters', 'gallons', 'gal', 'fuel', 'qty', 'quantity'],
+    'date': ['date', 'fuelup date', 'fill date', 'trip date', 'charge date', 'session date', 'expense date',
+             'datum'],
+    'odometer': ['odometer', 'odo', 'mileage', 'miles', 'km', 'kilometers', 'distance',
+                 'km stand', 'kilometerstand', 'tachostand'],
+    'volume': ['volume', 'litres', 'liters', 'gallons', 'gal', 'fuel', 'qty', 'quantity',
+               'spritmenge', 'menge', 'liter', 'tankmenge'],
     'price_per_unit': ['price per unit', 'unit price', 'price/l', 'price/gal', 'price', 'rate'],
-    'total_cost': ['total cost', 'total', 'cost', 'price paid', 'total price'],
+    'total_cost': ['total cost', 'total', 'cost', 'price paid', 'total price',
+                   'kosten', 'gesamtkosten', 'betrag'],
     'sales_tax': ['sales tax', 'sales taxes', 'tax', 'taxes', 'vat', 'gst', 'hst', 'pst', 'qst'],
-    'is_full_tank': ['full tank', 'full', 'complete', 'full fill'],
+    'is_full_tank': ['full tank', 'full', 'complete', 'full fill',
+                     'tankart'],
     'is_missed': ['missed', 'missed fill', 'skipped'],
-    'station': ['station', 'gas station', 'fuel station'],
-    'notes': ['notes', 'note', 'comments', 'comment', 'remarks', 'memo'],
+    'station': ['station', 'gas station', 'fuel station',
+                'tankstelle'],
+    'notes': ['notes', 'note', 'comments', 'comment', 'remarks', 'memo',
+              'bemerkung', 'bemerkungen', 'notiz', 'notizen'],
     'category': ['category', 'type', 'expense type', 'expense category'],
     'description': ['description', 'desc', 'title', 'name', 'item', 'service'],
     'cost': ['cost', 'amount', 'total', 'price', 'expense'],
@@ -3401,6 +3408,41 @@ def _cleanup_temp_file(path):
     except OSError:
         pass
 
+def _is_duplicate(data_type, record, vehicle_id):
+    """Check whether a record with the same key fields already exists."""
+    if data_type == 'fuel_logs':
+        return db.session.query(FuelLog.id).filter_by(
+            vehicle_id=vehicle_id, date=record.date, odometer=record.odometer,
+        ).first() is not None
+    if data_type == 'expenses':
+        filters = dict(
+            vehicle_id=vehicle_id, date=record.date,
+            cost=record.cost, description=record.description,
+        )
+        # Tighten the key with optional fields when mapped, so two
+        # identical toll charges at different odometers aren't dropped.
+        if record.odometer is not None:
+            filters['odometer'] = record.odometer
+        if record.vendor is not None:
+            filters['vendor'] = record.vendor
+        return db.session.query(Expense.id).filter_by(**filters).first() is not None
+    if data_type == 'trips':
+        return db.session.query(Trip.id).filter_by(
+            vehicle_id=vehicle_id, date=record.date,
+            start_odometer=record.start_odometer,
+            end_odometer=record.end_odometer,
+        ).first() is not None
+    if data_type == 'charging_sessions':
+        return db.session.query(ChargingSession.id).filter_by(
+            vehicle_id=vehicle_id, date=record.date,
+            start_time=record.start_time, end_time=record.end_time,
+            odometer=record.odometer,
+            kwh_added=record.kwh_added,
+            total_cost=record.total_cost,
+            location=record.location, network=record.network,
+        ).first() is not None
+    return False
+
 
 def create_record(data_type, mapped_row, vehicle_id, user_id, date_format, user_date_format=None):
     """Create a model instance from a mapped CSV row."""
@@ -3412,14 +3454,19 @@ def create_record(data_type, mapped_row, vehicle_id, user_id, date_format, user_
         odometer = parse_float_value(mapped_row.get('odometer'))
         if odometer is None:
             raise ValueError('Missing or invalid odometer')
+        volume = parse_float_value(mapped_row.get('volume'))
+        price_per_unit = parse_float_value(mapped_row.get('price_per_unit'))
+        total_cost = parse_float_value(mapped_row.get('total_cost'))
+        if price_per_unit is None and volume not in (None, 0) and total_cost is not None:
+            price_per_unit = round(total_cost / volume, 4)
         return FuelLog(
             vehicle_id=vehicle_id,
             user_id=user_id,
             date=date_val,
             odometer=odometer,
-            volume=parse_float_value(mapped_row.get('volume')),
-            price_per_unit=parse_float_value(mapped_row.get('price_per_unit')),
-            total_cost=parse_float_value(mapped_row.get('total_cost')),
+            volume=volume,
+            price_per_unit=price_per_unit,
+            total_cost=total_cost,
             sales_tax=parse_float_value(mapped_row.get('sales_tax')),
             is_full_tank=parse_bool_value(mapped_row.get('is_full_tank')) if mapped_row.get('is_full_tank') else True,
             is_missed=parse_bool_value(mapped_row.get('is_missed')),
@@ -3553,7 +3600,15 @@ def csv_import_preview():
 
     try:
         content = file.read().decode('utf-8-sig', errors='ignore')
-        reader = csv.DictReader(io.StringIO(content))
+
+        # Auto-detect delimiter (comma vs semicolon)
+        try:
+            dialect = csv.Sniffer().sniff(content[:2048], delimiters=',;\t')
+            delimiter = dialect.delimiter
+        except csv.Error:
+            delimiter = ','
+
+        reader = csv.DictReader(io.StringIO(content), delimiter=delimiter)
         csv_columns = reader.fieldnames
 
         if not csv_columns:
@@ -3579,6 +3634,7 @@ def csv_import_preview():
         tmp.write(content)
         tmp.close()
         session['csv_import_temp_file'] = tmp.name
+        session['csv_import_delimiter'] = delimiter
 
         target_fields = get_import_fields(data_type)
         suggestions = auto_suggest_mappings(csv_columns, target_fields)
@@ -3610,6 +3666,7 @@ def csv_import_execute():
     vehicle_id = request.form.get('vehicle_id', type=int)
     date_format = request.form.get('date_format', 'auto')
     temp_file = session.pop('csv_import_temp_file', None)
+    delimiter = session.pop('csv_import_delimiter', ',')
 
     if data_type not in DATA_TYPE_LABELS:
         flash(_('Invalid data type.'), 'error')
@@ -3627,7 +3684,7 @@ def csv_import_execute():
     try:
         # Read temp CSV
         with open(temp_file, 'r', encoding='utf-8-sig', errors='ignore') as f:
-            reader = csv.DictReader(f)
+            reader = csv.DictReader(f, delimiter=delimiter)
             csv_columns = reader.fieldnames or []
 
             # Build column mapping from form: mapping_0, mapping_1, etc.
@@ -3640,6 +3697,7 @@ def csv_import_execute():
             rows = list(reader)
 
         imported = 0
+        skipped = 0
         errors = []
         max_errors = 50
 
@@ -3650,6 +3708,9 @@ def csv_import_execute():
                     mapped_row[field_name] = row.get(csv_col, '')
 
                 record = create_record(data_type, mapped_row, vehicle_id, current_user.id, date_format, current_user.date_format)
+                if _is_duplicate(data_type, record, vehicle_id):
+                    skipped += 1
+                    continue
                 db.session.add(record)
                 imported += 1
             except (ValueError, KeyError) as e:
@@ -3660,6 +3721,9 @@ def csv_import_execute():
 
         label = DATA_TYPE_LABELS.get(data_type, data_type)
         flash(_('CSV import complete: %(count)s %(label)s imported.') % {'count': imported, 'label': label.lower()}, 'success')
+
+        if skipped:
+            flash(_('%(count)s duplicate(s) skipped.') % {'count': skipped}, 'info')
 
         if errors:
             error_summary = f'{len(errors)} row(s) skipped due to errors.'

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -682,6 +682,7 @@ def check_updates():
                 'success': True,
                 'latest_version': latest_version,
                 'current_version': APP_VERSION,
+                'display_version': DISPLAY_VERSION,
                 'update_available': update_available,
                 'release_url': data.get('html_url'),
                 'release_notes': data.get('body', ''),

--- a/app/routes/recurring.py
+++ b/app/routes/recurring.py
@@ -4,6 +4,7 @@ from flask_babel import gettext as _
 from app import db
 from app.utils import parse_decimal
 from app.models import RecurringExpense, Vehicle, EXPENSE_CATEGORIES
+from app.routes.expenses import _known_vendors
 from app.services.recurring_processor import generate_expense_for_period
 from datetime import date
 
@@ -60,6 +61,7 @@ def new():
             category=request.form['category'],
             frequency=request.form['frequency'],
             amount=parse_decimal(request.form['amount']) if request.form.get('amount') else None,
+            vendor=request.form.get('vendor'),
             start_date=start_date,
             next_due=next_due,
             description=request.form.get('description'),
@@ -76,6 +78,7 @@ def new():
     return render_template('recurring/form.html',
                          vehicles=vehicles,
                          categories=EXPENSE_CATEGORIES,
+                         known_vendors=_known_vendors([v.id for v in vehicles]),
                          selected_vehicle=request.args.get('vehicle'))
 
 
@@ -104,6 +107,7 @@ def edit(recurring_id):
         recurring.category = request.form['category']
         recurring.frequency = request.form['frequency']
         recurring.amount = parse_decimal(request.form['amount']) if request.form.get('amount') else None
+        recurring.vendor = request.form.get('vendor')
         recurring.start_date = start_date
         recurring.next_due = next_due
         recurring.description = request.form.get('description')
@@ -118,7 +122,8 @@ def edit(recurring_id):
     return render_template('recurring/form.html',
                          recurring=recurring,
                          vehicles=[recurring.vehicle],
-                         categories=EXPENSE_CATEGORIES)
+                         categories=EXPENSE_CATEGORIES,
+                         known_vendors=_known_vendors(vehicle_ids))
 
 
 @bp.route('/<int:recurring_id>/delete', methods=['POST'])

--- a/app/templates/auth/settings.html
+++ b/app/templates/auth/settings.html
@@ -1778,7 +1778,7 @@
                             <div>
                                 <h3 class="text-sm font-medium text-gray-900 dark:text-white">{{ _('Current Version') }}</h3>
                                 <div class="flex items-center gap-2">
-                                    <p class="text-2xl font-bold text-primary-600">v{{ app_version }}</p>
+                                    <p class="text-2xl font-bold text-primary-600" id="current-version-value">v{{ app_version }}</p>
                                     {% if release_channel and release_channel != 'stable' %}
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
                                         {{ release_channel }}
@@ -2287,6 +2287,7 @@ function checkForUpdates() {
     const upToDateEl = document.getElementById('up-to-date');
     const latestVersionEl = document.getElementById('latest-version');
     const releaseLinkEl = document.getElementById('release-link');
+    const currentVersionEl = document.getElementById('current-version-value');
 
     // Show loading state
     statusEl.textContent = {{ _("Checking...") | tojson }};
@@ -2300,6 +2301,13 @@ function checkForUpdates() {
             spinnerEl.classList.remove('animate-spin');
 
             if (data.success) {
+                // The running version may have changed since this page was rendered
+                // (e.g. the host was updated and restarted), so refresh it in place.
+                const runningVersion = data.display_version || data.current_version;
+                if (currentVersionEl && runningVersion) {
+                    currentVersionEl.textContent = 'v' + runningVersion;
+                }
+
                 if (data.update_available) {
                     statusEl.textContent = {{ _("A newer version is available") | tojson }};
                     latestVersionEl.textContent = 'v' + data.latest_version;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -315,31 +315,31 @@
                                 <div id="more-dropdown" class="hidden absolute right-0 top-full mt-1 w-48 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 z-50">
                                     <div class="py-1">
                                         {% if current_user.show_menu_maintenance is not defined or current_user.show_menu_maintenance %}
-                                        <a href="{{ url_for('maintenance.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Maintenance') }}</a>
+                                        <a href="{{ url_for('maintenance.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Maintenance') }}</a>
                                         {% endif %}
                                         {% if current_user.show_menu_recurring is not defined or current_user.show_menu_recurring %}
-                                        <a href="{{ url_for('recurring.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Recurring') }}</a>
+                                        <a href="{{ url_for('recurring.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Recurring') }}</a>
                                         {% endif %}
                                         {% if current_user.show_menu_documents is not defined or current_user.show_menu_documents %}
-                                        <a href="{{ url_for('documents.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Documents') }}</a>
+                                        <a href="{{ url_for('documents.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Documents') }}</a>
                                         {% endif %}
                                         {% if current_user.show_menu_stations is not defined or current_user.show_menu_stations %}
-                                        <a href="{{ url_for('stations.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Fuel Stations') }}</a>
+                                        <a href="{{ url_for('stations.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Fuel Stations') }}</a>
                                         {% endif %}
                                         {% if current_user.show_menu_charging is not defined or current_user.show_menu_charging %}
-                                        <a href="{{ url_for('charging.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('EV Charging') }}</a>
+                                        <a href="{{ url_for('charging.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('EV Charging') }}</a>
                                         {% endif %}
                                         {% if current_user.show_menu_allowance is not defined or current_user.show_menu_allowance %}
-                                        <a href="{{ url_for('allowance.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Mileage Allowance') }}</a>
+                                        <a href="{{ url_for('allowance.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Mileage Allowance') }}</a>
                                         {% endif %}
                                         {% if current_user.show_menu_tires is not defined or current_user.show_menu_tires %}
-                                        <a href="{{ url_for('tires.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Tires') }}</a>
+                                        <a href="{{ url_for('tires.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Tires') }}</a>
                                         {% endif %}
                                         {% if current_user.show_menu_notes is not defined or current_user.show_menu_notes %}
-                                        <a href="{{ url_for('notes.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Notes') }}</a>
+                                        <a href="{{ url_for('notes.index') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Notes') }}</a>
                                         {% endif %}
                                         {% if can_write('fuel') %}
-                                        <a href="{{ url_for('fuel.quick') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Quick Fuel Entry') }}</a>
+                                        <a href="{{ url_for('fuel.quick') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Quick Fuel Entry') }}</a>
                                         {% endif %}
                                     </div>
                                 </div>
@@ -378,7 +378,7 @@
                         </a>
                     </div>
                     <div class="flex items-center sm:hidden">
-                        <button type="button" onclick="document.getElementById('mobile-menu').classList.toggle('hidden')" class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700 hover:text-gray-500 dark:text-gray-400">
+                        <button type="button" onclick="document.getElementById('mobile-menu').classList.toggle('hidden')" class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-500 dark:text-gray-400">
                             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
                             </svg>
@@ -388,52 +388,52 @@
             </div>
             <div class="sm:hidden hidden" id="mobile-menu">
                 <div class="space-y-1 pb-3 pt-2">
-                    <a href="{{ url_for('main.dashboard') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Dashboard') }}</a>
+                    <a href="{{ url_for('main.dashboard') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Dashboard') }}</a>
                     {% if current_user.show_menu_vehicles is not defined or current_user.show_menu_vehicles %}
-                    <a href="{{ url_for('vehicles.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Vehicles') }}</a>
+                    <a href="{{ url_for('vehicles.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Vehicles') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_fuel is not defined or current_user.show_menu_fuel %}
-                    <a href="{{ url_for('fuel.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Fuel Logs') }}</a>
+                    <a href="{{ url_for('fuel.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Fuel Logs') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_expenses is not defined or current_user.show_menu_expenses %}
-                    <a href="{{ url_for('expenses.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Expenses') }}</a>
+                    <a href="{{ url_for('expenses.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Expenses') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_reminders is not defined or current_user.show_menu_reminders %}
-                    <a href="{{ url_for('reminders.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Reminders') }}</a>
+                    <a href="{{ url_for('reminders.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Reminders') }}</a>
                     {% endif %}
-                    <a href="{{ url_for('search.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Search') }}</a>
+                    <a href="{{ url_for('search.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Search') }}</a>
                     {% if current_user.show_menu_trips is not defined or current_user.show_menu_trips %}
-                    <a href="{{ url_for('trips.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Trips') }}</a>
+                    <a href="{{ url_for('trips.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Trips') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_charging is not defined or current_user.show_menu_charging %}
-                    <a href="{{ url_for('charging.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('EV Charging') }}</a>
+                    <a href="{{ url_for('charging.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('EV Charging') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_maintenance is not defined or current_user.show_menu_maintenance %}
-                    <a href="{{ url_for('maintenance.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Maintenance') }}</a>
+                    <a href="{{ url_for('maintenance.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Maintenance') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_recurring is not defined or current_user.show_menu_recurring %}
-                    <a href="{{ url_for('recurring.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Recurring') }}</a>
+                    <a href="{{ url_for('recurring.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Recurring') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_documents is not defined or current_user.show_menu_documents %}
-                    <a href="{{ url_for('documents.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Documents') }}</a>
+                    <a href="{{ url_for('documents.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Documents') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_stations is not defined or current_user.show_menu_stations %}
-                    <a href="{{ url_for('stations.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Fuel Stations') }}</a>
+                    <a href="{{ url_for('stations.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Fuel Stations') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_allowance is not defined or current_user.show_menu_allowance %}
-                    <a href="{{ url_for('allowance.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Mileage Allowance') }}</a>
+                    <a href="{{ url_for('allowance.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Mileage Allowance') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_tires is not defined or current_user.show_menu_tires %}
-                    <a href="{{ url_for('tires.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Tires') }}</a>
+                    <a href="{{ url_for('tires.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Tires') }}</a>
                     {% endif %}
                     {% if current_user.show_menu_notes is not defined or current_user.show_menu_notes %}
-                    <a href="{{ url_for('notes.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Notes') }}</a>
+                    <a href="{{ url_for('notes.index') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Notes') }}</a>
                     {% endif %}
                     {% if can_write('fuel') %}
-                    <a href="{{ url_for('fuel.quick') }}" class="block px-4 py-2 text-base font-medium text-primary-600 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Quick Fuel Entry') }}</a>
+                    <a href="{{ url_for('fuel.quick') }}" class="block px-4 py-2 text-base font-medium text-primary-600 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Quick Fuel Entry') }}</a>
                     {% endif %}
-                    <a href="{{ url_for('auth.settings') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">{{ _('Settings') }}</a>
-                    <a href="{{ url_for('auth.logout') }}" class="flex items-center gap-2 px-4 py-2 text-base font-medium text-red-500 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700">
+                    <a href="{{ url_for('auth.settings') }}" class="block px-4 py-2 text-base font-medium text-gray-500 dark:text-gray-400 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">{{ _('Settings') }}</a>
+                    <a href="{{ url_for('auth.logout') }}" class="flex items-center gap-2 px-4 py-2 text-base font-medium text-red-500 hover:bg-gray-100 dark:hover:bg-gray-700">
                         <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
                         </svg>

--- a/app/templates/recurring/form.html
+++ b/app/templates/recurring/form.html
@@ -75,6 +75,21 @@
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ _('Leave blank if amount varies') }}</p>
             </div>
 
+            <div>
+                <label for="vendor" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Vendor / Service Provider') }}</label>
+                <input type="text" name="vendor" id="vendor" list="vendor-suggestions"
+                       value="{{ recurring.vendor if recurring and recurring.vendor is not none else '' }}"
+                       placeholder="{{ _('e.g., Local Garage') }}"
+                       class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm">
+                {% if known_vendors %}
+                <datalist id="vendor-suggestions">
+                    {% for v in known_vendors %}
+                    <option value="{{ v }}"></option>
+                    {% endfor %}
+                </datalist>
+                {% endif %}
+            </div>
+
             <div class="grid grid-cols-2 gap-4">
                 <div>
                     <label for="start_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ _('Start Date') }}</label>

--- a/app/templates/vehicles/view.html
+++ b/app/templates/vehicles/view.html
@@ -1144,6 +1144,25 @@ document.addEventListener('DOMContentLoaded', function() {
         restoreChartState('consumption');
         restoreChartState('price');
     }
+
+    // #358: the trend charts plotted the raw ISO date the API returns, so the
+    // x-axis ignored Settings > Date Format. Reformat each label to the user's
+    // chosen pattern, read from the meta tag base.html already exposes.
+    const userDateFormat = (document.querySelector('meta[name="date-format"]') || {}).content || 'DD/MM/YYYY';
+    function formatChartDate(iso) {
+        if (!iso) return iso;
+        const m = String(iso).match(/^(\d{4})-(\d{2})-(\d{2})/);
+        if (!m) return iso;
+        const [, y, mo, d] = m;
+        switch (userDateFormat) {
+            case 'MM/DD/YYYY': return `${mo}/${d}/${y}`;
+            case 'YYYY-MM-DD': return `${y}-${mo}-${d}`;
+            case 'DD.MM.YYYY': return `${d}.${mo}.${y}`;
+            case 'DD/MM/YYYY':
+            default: return `${d}/${mo}/${y}`;
+        }
+    }
+
     fetch('/api/vehicles/{{ vehicle.id }}/stats')
         .then(response => response.json())
         .then(data => {
@@ -1156,7 +1175,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 // them into a single misleading series (#319). Each point
                 // keeps its own slot on the x-axis, so two fills on one date
                 // are still two points.
-                const dates = data.consumption.map(d => d.date);
+                const dates = data.consumption.map(d => formatChartDate(d.date));
                 const typeLabels = {};
                 data.consumption.forEach(d => {
                     typeLabels[d.fuel_type || 'unknown'] = d.fuel_type_label || d.fuel_type || 'unknown';
@@ -1229,7 +1248,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 chartInstances['price'] = new Chart(priceEl.getContext('2d'), {
                     type: 'line',
                     data: {
-                        labels: data.price_per_unit.map(d => d.date),
+                        labels: data.price_per_unit.map(d => formatChartDate(d.date)),
                         datasets: [{
                             label: '{{ _("Price per") }} {{ current_user.volume_unit }} ({{ current_user.currency }})',
                             data: data.price_per_unit.map(d => d.price),
@@ -1273,6 +1292,10 @@ document.addEventListener('DOMContentLoaded', function() {
     restoreChartState('expenses');
     const categoryData = {{ expenses_by_category | tojson }};
     const labels = Object.keys(categoryData);
+    // #359: the value axis (x, because this is a horizontal bar) showed bare
+    // numbers with no unit. Prefix each tick with the configured currency
+    // symbol so it reads as money.
+    const expenseCurrencySymbol = {{ (vehicle.currency_symbol or current_user.currency)|tojson }};
     chartInstances['expenses'] = new Chart(expensesEl.getContext('2d'), {
         type: 'bar',
         data: {
@@ -1298,7 +1321,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 legend: { display: false }
             },
             scales: {
-                x: { beginAtZero: true }
+                x: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return expenseCurrencySymbol + value.toLocaleString();
+                        }
+                    }
+                }
             }
         }
     });

--- a/app/translations/de/LC_MESSAGES/messages.po
+++ b/app/translations/de/LC_MESSAGES/messages.po
@@ -372,7 +372,7 @@ msgstr "Level 2"
 
 #: app/models.py:1534
 msgid "DC Fast Charge"
-msgstr "Schnelladung"
+msgstr "DC Schnelladung"
 
 #: app/models.py:1535
 msgid "Tesla Supercharger"
@@ -564,8 +564,7 @@ msgstr "Zugriff verweigert"
 
 #: app/routes/allowance.py:55 app/routes/allowance.py:90
 msgid "Invalid data submitted. Please check the date and amount fields."
-msgstr ""
-"Es wurden ungültige Daten übermittelt. Bitte überprüfen Sie die Felder für "
+msgstr "Es wurden ungültige Daten übermittelt. Bitte überprüfen Sie die Felder für "
 "Datum und Betrag."
 
 #: app/routes/allowance.py:61
@@ -594,20 +593,16 @@ msgid "The uploaded file is not a valid SQLite database."
 msgstr "Die hochgeladene Datei ist keine gültige SQLite-Datenbank."
 
 #: app/routes/api.py:2689
-msgid ""
-"This does not appear to be a Hammond database — no vehicles, fillups, or "
+msgid "This does not appear to be a Hammond database — no vehicles, fillups, or "
 "expenses tables found."
-msgstr ""
-"Dies scheint keine Hammond-Datenbank zu sein — keine Tabellen für Fahrzeuge,"
+msgstr "Dies scheint keine Hammond-Datenbank zu sein — keine Tabellen für Fahrzeuge,"
 " Tankvorgänge oder Ausgaben gefunden."
 
 #: app/routes/api.py:2838
 #, python-format
-msgid ""
-"Hammond import complete: %(vehicles)s vehicles, %(fuel_logs)s fuel logs, "
+msgid "Hammond import complete: %(vehicles)s vehicles, %(fuel_logs)s fuel logs, "
 "%(expenses)s expenses imported."
-msgstr ""
-"Hammond-Import abgeschlossen: %(vehicles)s Fahrzeuge, %(fuel_logs)s "
+msgstr "Hammond-Import abgeschlossen: %(vehicles)s Fahrzeuge, %(fuel_logs)s "
 "Tankprotokolle, %(expenses)s Ausgaben importiert."
 
 #: app/routes/api.py:2840
@@ -700,8 +695,7 @@ msgstr "Diese Sicherung konnte nicht gelesen werden: %(error)s"
 
 #: app/routes/api.py:3751
 msgid "The uploaded backup has expired. Please upload it again."
-msgstr ""
-"Die hochgeladene Sicherung ist abgelaufen. Bitte laden Sie sie erneut hoch."
+msgstr "Die hochgeladene Sicherung ist abgelaufen. Bitte laden Sie sie erneut hoch."
 
 #: app/routes/api.py:3764
 #, python-format
@@ -821,8 +815,7 @@ msgstr "Registrierungseinstellungen aktualisiert"
 
 #: app/routes/auth.py:530
 msgid "Cannot remove admin status from the last administrator."
-msgstr ""
-"Der Admin-Status kann nicht vom letzten Administrator entfernt werden."
+msgstr "Der Admin-Status kann nicht vom letzten Administrator entfernt werden."
 
 #: app/routes/auth.py:535
 #, python-format
@@ -854,8 +847,7 @@ msgstr "Benutzer %(username)s erfolgreich erstellt"
 
 #: app/routes/charging.py:55
 msgid "No electric vehicles found. Add an EV or hybrid vehicle first."
-msgstr ""
-"Keine Elektrofahrzeuge gefunden. Fügen Sie zuerst ein Elektro- oder "
+msgstr "Keine Elektrofahrzeuge gefunden. Fügen Sie zuerst ein Elektro- oder "
 "Hybridfahrzeug hinzu."
 
 #: app/routes/charging.py:101
@@ -977,8 +969,7 @@ msgstr "Wartungsplan \"%(name)s\" gelöscht"
 
 #: app/routes/notes.py:54 app/routes/notes.py:98
 msgid "Invalid data submitted. Please check the date and odometer fields."
-msgstr ""
-"Es wurden ungültige Daten übermittelt. Bitte überprüfen Sie die Felder für "
+msgstr "Es wurden ungültige Daten übermittelt. Bitte überprüfen Sie die Felder für "
 "Datum und Kilometerstand."
 
 #: app/routes/notes.py:59 app/routes/notes.py:103
@@ -1078,8 +1069,7 @@ msgstr "%(prices)s Live-Preise von %(matched)s Tankstellen aktualisiert"
 
 #: app/routes/stations.py:176
 msgid "No matching forecourts found. Check the station postcodes."
-msgstr ""
-"Keine passenden Tankstellen gefunden. Prüfen Sie die Postleitzahlen der "
+msgstr "Keine passenden Tankstellen gefunden. Prüfen Sie die Postleitzahlen der "
 "Stationen."
 
 #: app/routes/stations.py:182
@@ -1089,8 +1079,7 @@ msgstr "Einige Händler-Feeds konnten nicht gelesen werden: %(errors)s"
 
 #: app/routes/stations.py:193 app/routes/stations.py:209
 msgid "UK fuel prices are not enabled. An admin can turn them on in Settings."
-msgstr ""
-"Britische Kraftstoffpreise sind nicht aktiviert. Ein Administrator kann sie "
+msgstr "Britische Kraftstoffpreise sind nicht aktiviert. Ein Administrator kann sie "
 "in den Einstellungen einschalten."
 
 #: app/routes/stations.py:229
@@ -1107,8 +1096,7 @@ msgstr "Bitte geben Sie dem Reifensatz einen Namen"
 
 #: app/routes/tires.py:105 app/routes/tires.py:141
 msgid "Invalid data submitted. Please check the odometer and cost fields."
-msgstr ""
-"Ungültige Daten übermittelt. Bitte prüfen Sie die Felder für Kilometerstand "
+msgstr "Ungültige Daten übermittelt. Bitte prüfen Sie die Felder für Kilometerstand "
 "und Kosten."
 
 #: app/routes/tires.py:112
@@ -1126,8 +1114,7 @@ msgstr "Dieser Reifensatz ist bereits am Fahrzeug"
 
 #: app/routes/tires.py:174
 msgid "That tire set is retired. Reinstate it before fitting it again."
-msgstr ""
-"Dieser Reifensatz ist ausgemustert. Setzen Sie ihn wieder ein, bevor Sie ihn"
+msgstr "Dieser Reifensatz ist ausgemustert. Setzen Sie ihn wieder ein, bevor Sie ihn"
 " erneut montieren."
 
 #: app/routes/tires.py:188 app/routes/tires.py:227
@@ -1145,10 +1132,8 @@ msgid "That tire set is not on the vehicle"
 msgstr "Dieser Reifensatz ist nicht am Fahrzeug"
 
 #: app/routes/tires.py:220
-msgid ""
-"The odometer reading cannot be lower than the one the set was fitted at"
-msgstr ""
-"Der Kilometerstand darf nicht niedriger sein als bei der Montage des Satzes"
+msgid "The odometer reading cannot be lower than the one the set was fitted at"
+msgstr "Der Kilometerstand darf nicht niedriger sein als bei der Montage des Satzes"
 
 #: app/routes/tires.py:244
 msgid "Fitting record deleted"
@@ -1381,7 +1366,7 @@ msgstr "Notizen"
 #: app/templates/base.html:354 app/templates/base.html:433
 #: app/templates/fuel/quick.html:2 app/templates/fuel/quick.html:7
 msgid "Quick Fuel Entry"
-msgstr "Schnelltanken"
+msgstr "Schneller Tankeintrag"
 
 #: app/templates/base.html:358 app/templates/dashboard.html:392
 #: app/templates/timeline/index.html:114 app/templates/trips/index.html:127
@@ -1414,7 +1399,7 @@ msgstr "Gesamte Kraftstoffkosten"
 
 #: app/templates/dashboard.html:64 app/templates/vehicles/view.html:139
 msgid "Total Charging Cost"
-msgstr "Gesamtkosten"
+msgstr "Gesamte Ladekosten"
 
 #: app/templates/dashboard.html:83 app/templates/vehicles/view.html:145
 msgid "Other Expenses"
@@ -1430,8 +1415,7 @@ msgstr "Gesamtstrecke"
 #: app/templates/trips/report.html:36 app/templates/trips/report.html:40
 #: app/templates/trips/report.html:68 app/templates/trips/report.html:127
 msgid "This total covers vehicles metered in distance and in engine hours."
-msgstr ""
-"Diese Summe umfasst Fahrzeuge, die in Entfernung und in Betriebsstunden "
+msgstr "Diese Summe umfasst Fahrzeuge, die in Entfernung und in Betriebsstunden "
 "erfasst werden."
 
 #: app/templates/dashboard.html:102 app/templates/trips/index.html:41
@@ -1457,7 +1441,7 @@ msgstr "Gesamtkosten"
 
 #: app/templates/dashboard.html:176 app/templates/vehicles/view.html:156
 msgid "Net Cost"
-msgstr "Gesamtkosten"
+msgstr "Nettokosten"
 
 #: app/templates/dashboard.html:189
 msgid "Monthly Spending"
@@ -1476,8 +1460,7 @@ msgstr "Alle anzeigen"
 
 #: app/templates/dashboard.html:223
 msgid "No price data yet. Add fuel stations and log fuel to track prices."
-msgstr ""
-"Noch keine Preisdaten. Fügen Sie Tankstellen hinzu und erfassen Sie "
+msgstr "Noch keine Preisdaten. Fügen Sie Tankstellen hinzu und erfassen Sie "
 "Tankvorgänge, um Preise zu verfolgen."
 
 #: app/templates/dashboard.html:230 app/templates/vehicles/view.html:932
@@ -1700,8 +1683,7 @@ msgstr "Rolle"
 
 #: app/templates/auth/create_user.html:65 app/templates/auth/edit_user.html:52
 msgid "Administrators always have full access, whatever role is set."
-msgstr ""
-"Administratoren haben immer vollen Zugriff, unabhängig von der eingestellten"
+msgstr "Administratoren haben immer vollen Zugriff, unabhängig von der eingestellten"
 " Rolle."
 
 #: app/templates/auth/edit_user.html:2
@@ -1873,7 +1855,7 @@ msgstr "Menge"
 #: app/templates/auth/settings.html:138
 #: app/templates/vehicles/part_form.html:58
 msgid "Liters (L)"
-msgstr "Liter (L)"
+msgstr "Liter (l)"
 
 #: app/templates/auth/settings.html:139
 msgid "UK Gallons (gal)"
@@ -1952,11 +1934,9 @@ msgid "Your account details"
 msgstr "Ihre Kontodetails"
 
 #: app/templates/auth/settings.html:239
-msgid ""
-"Your account can see the data but cannot change it. Ask an administrator if "
+msgid "Your account can see the data but cannot change it. Ask an administrator if "
 "you need more access."
-msgstr ""
-"Ihr Konto kann die Daten sehen, aber nicht ändern. Wenden Sie sich an einen "
+msgstr "Ihr Konto kann die Daten sehen, aber nicht ändern. Wenden Sie sich an einen "
 "Administrator, wenn Sie mehr Zugriff benötigen."
 
 #: app/templates/auth/settings.html:241
@@ -2296,7 +2276,7 @@ msgstr "API-Schlüssel generiert"
 msgid "Copy your API key now. For security, it won't be shown in full again."
 msgstr ""
 "Kopieren Sie jetzt Ihren API-Schlüssel. Aus Sicherheitsgründen wird er nicht"
-" mehr vollständig angezeigt."
+" wieder vollständig angezeigt."
 
 #: app/templates/auth/settings.html:783
 msgid "Done"
@@ -2802,16 +2782,16 @@ msgstr "Gespeicherten Token entfernen"
 #: app/templates/auth/settings.html:1433
 msgid "sends notifications to your devices. Enter your User Key below."
 msgstr ""
-"sendet Benachrichtigungen an Ihre Geräte. Geben Sie Ihren User Key unten "
-"ein."
+"sendet Benachrichtigungen an Ihre Geräte. Geben Sie Ihren Benutzerschlüssel "
+"unten ein."
 
 #: app/templates/auth/settings.html:1436
 msgid "Pushover User Key"
-msgstr "Pushover User Key"
+msgstr "Pushover Benutzerschlüssel"
 
 #: app/templates/auth/settings.html:1441
 msgid "Find your User Key on your Pushover dashboard."
-msgstr "Finden Sie Ihren User Key auf Ihrem Pushover-Dashboard."
+msgstr "Finden Sie Ihren Benutzerschlüssel auf Ihrem Pushover-Dashboard."
 
 #: app/templates/auth/settings.html:1448
 msgid "Notifications will be sent as JSON POST requests to your webhook URL."
@@ -3289,7 +3269,7 @@ msgstr "Vorschau"
 
 #: app/templates/expenses/form.html:2 app/templates/expenses/form.html:11
 msgid "Edit Expense"
-msgstr "Ausgabe hinzufügen"
+msgstr "Ausgabe bearbeiten"
 
 #: app/templates/expenses/form.html:2 app/templates/expenses/form.html:11
 #: app/templates/expenses/form.html:150 app/templates/expenses/index.html:16
@@ -3346,7 +3326,7 @@ msgstr "Belege / Anhänge"
 
 #: app/templates/expenses/form.html:125 app/templates/fuel/form.html:181
 msgid "Delete this attachment?"
-msgstr "Dieses Dokument löschen?"
+msgstr "Diesen Anhang löschen?"
 
 #: app/templates/expenses/form.html:133
 msgid "You can select more than one file"
@@ -3355,7 +3335,7 @@ msgstr "Sie können mehrere Dateien auswählen"
 #: app/templates/expenses/index.html:8
 msgid "Track maintenance, repairs, insurance, and other costs"
 msgstr ""
-"Instandhaltung, Reparaturen, Versicherung und sonstige Kosten überwachen"
+"Instandhaltung, Reparaturen, Versicherungen und sonstige Kosten überwachen"
 
 #: app/templates/expenses/index.html:68 app/templates/vehicles/view.html:1030
 msgid "Delete this expense?"
@@ -3375,11 +3355,11 @@ msgstr "Belege:"
 
 #: app/templates/expenses/index.html:116
 msgid "No expenses"
-msgstr "Ausgaben"
+msgstr "Keine Ausgaben"
 
 #: app/templates/expenses/index.html:117
 msgid "Start tracking your vehicle expenses."
-msgstr "Fügen Sie Ihr erstes Fahrzeug hinzu, um zu beginnen."
+msgstr "Beginnen Sie damit, Ihre Fahrzeugkosten zu erfassen."
 
 #: app/templates/expenses/index.html:136
 msgid "Spend by Vendor"
@@ -3398,7 +3378,7 @@ msgstr "Gesamt"
 
 #: app/templates/fuel/form.html:2 app/templates/fuel/form.html:11
 msgid "Edit Fuel Log"
-msgstr "Tankvorgang hinzufügen"
+msgstr "Tankvorgang bearbeiten"
 
 #: app/templates/fuel/form.html:2 app/templates/fuel/form.html:11
 #: app/templates/fuel/form.html:205 app/templates/fuel/index.html:16
@@ -3413,7 +3393,7 @@ msgstr "Zurück zu den Tankprotokollen"
 #: app/templates/fuel/form.html:39 app/templates/fuel/form.html:213
 #: app/templates/trips/form.html:56 app/templates/trips/form.html:183
 msgid "Last engine hours"
-msgstr "Letzte Betriebsstunden"
+msgstr "Letzte Motorbetriebsstunden"
 
 #: app/templates/fuel/form.html:39 app/templates/fuel/form.html:212
 #: app/templates/trips/form.html:56 app/templates/trips/form.html:182
@@ -3556,7 +3536,7 @@ msgstr ""
 
 #: app/templates/fuel/index.html:135
 msgid "Add Charging Session"
-msgstr "Ladevorgang bearbeiten"
+msgstr "Ladevorgang hinzufügen"
 
 #: app/templates/fuel/index.html:147
 msgid "kWh"
@@ -3665,7 +3645,7 @@ msgid ""
 "change nothing."
 msgstr ""
 "Alles in dieser Sicherung ist bereits in Ihrem Konto. Die Wiederherstellung "
-"ändert nichts."
+"wird nichts ändern."
 
 #: app/templates/import/backup_upload.html:8
 msgid "Restore a May Backup"
@@ -3684,9 +3664,9 @@ msgid ""
 "will see a summary of what will be added before anything is written."
 msgstr ""
 "Die Sicherung wird in Ihr Konto eingefügt. Nichts wird gelöscht oder "
-"überschrieben, und bereits vorhandene Datensätze werden übersprungen statt "
-"dupliziert. Vor dem Schreiben sehen Sie eine Zusammenfassung dessen, was "
-"hinzugefügt wird."
+"überschrieben und bereits vorhandene Datensätze werden übersprungen statt "
+"dupliziert. Vor dem Schreiben in die Datenbank  sehen Sie eine "
+"Zusammenfassung dessen, was hinzugefügt wird."
 
 #: app/templates/import/backup_upload.html:17
 msgid ""
@@ -3767,7 +3747,7 @@ msgid ""
 "This vehicle is metered in engine hours, so its service interval is counted "
 "in hours."
 msgstr ""
-"Dieses Fahrzeug wird in Motorstunden gemessen, daher wird sein "
+"Dieses Fahrzeug wird in Motorbetriebsstunden gemessen, daher wird sein "
 "Wartungsintervall in Stunden gezählt."
 
 #: app/templates/maintenance/form.html:89
@@ -3917,7 +3897,7 @@ msgstr "z.B. DPF-Regeneration"
 
 #: app/templates/notes/form.html:56 app/templates/notes/index.html:30
 msgid "Note"
-msgstr "Notizen"
+msgstr "Notiz"
 
 #: app/templates/notes/form.html:58
 msgid "What happened?"
@@ -3940,7 +3920,7 @@ msgstr "Keine Notizen"
 
 #: app/templates/notes/index.html:84
 msgid "Jot down anything worth remembering about your vehicles."
-msgstr "Konfigurieren Sie, wie Sie Erinnerungen zu Ihren Fahrzeugen erhalten"
+msgstr "Notieren Sie alles Wissenswerte über Ihre Fahrzeuge."
 
 #: app/templates/recurring/form.html:2 app/templates/recurring/form.html:13
 msgid "Edit Recurring Expense"
@@ -4041,7 +4021,7 @@ msgstr ""
 #: app/templates/reminders/_reminder_row.html:67
 #: app/templates/reminders/index.html:116
 msgid "Completed"
-msgstr "Erledigen"
+msgstr "Erledigt"
 
 #: app/templates/reminders/_reminder_row.html:69
 #, python-format
@@ -4097,11 +4077,11 @@ msgstr "Zusätzliche Hinweise zu dieser Erinnerung"
 
 #: app/templates/reminders/form.html:82
 msgid "Recurrence"
-msgstr "Währung"
+msgstr "Wiederholung"
 
 #: app/templates/reminders/form.html:85
 msgid "Every"
-msgstr "Alle (km)"
+msgstr "Alle"
 
 #: app/templates/reminders/form.html:100
 msgid ""
@@ -4114,15 +4094,15 @@ msgstr ""
 
 #: app/templates/reminders/form.html:105
 msgid "Notify me"
-msgstr "Nicht gesetzt"
+msgstr "Erinnere mich"
 
 #: app/templates/reminders/form.html:130
 msgid "Update Reminder"
-msgstr "Erinnerung hinzufügen"
+msgstr "Update-Erinnerung"
 
 #: app/templates/reminders/form.html:130
 msgid "Create Reminder"
-msgstr "Erinnerungen aktivieren"
+msgstr "Erinnerungen erstellen"
 
 #: app/templates/reminders/index.html:8
 msgid "Keep track of important dates for your vehicles"
@@ -4135,15 +4115,15 @@ msgstr "Erinnerung hinzufügen"
 
 #: app/templates/reminders/index.html:38
 msgid "All Types"
-msgstr "Alle Jahre"
+msgstr "Alle Typen"
 
 #: app/templates/reminders/index.html:47
 msgid "Show completed"
-msgstr "Erledigen"
+msgstr "Zeige Erledige"
 
 #: app/templates/reminders/index.html:53
 msgid "Clear filters"
-msgstr "Luftfilter"
+msgstr "Lösche Filter"
 
 #: app/templates/reminders/index.html:65 app/templates/vehicles/view.html:778
 msgid "Overdue"
@@ -4155,15 +4135,15 @@ msgstr "Anstehende Erinnerungen"
 
 #: app/templates/reminders/index.html:99
 msgid "Later"
-msgstr "Filtern"
+msgstr "Später"
 
 #: app/templates/reminders/index.html:132
 msgid "No reminders"
-msgstr "Erinnerungen"
+msgstr "Keine Erinnerungen"
 
 #: app/templates/reminders/index.html:133
 msgid "Get started by adding a reminder for your vehicle."
-msgstr "Fügen Sie Ihr erstes Fahrzeug hinzu, um zu beginnen."
+msgstr "Beginnen Sie damit, eine Erinnerung für Ihr Fahrzeug hinzuzufügen."
 
 #: app/templates/search/index.html:7
 msgid ""
@@ -4409,7 +4389,7 @@ msgstr "Kaufdatum"
 
 #: app/templates/tires/form.html:75 app/templates/tires/form.html:117
 msgid "Engine hours when bought"
-msgstr "Betriebsstunden beim Kauf"
+msgstr "Motorbetriebsstunden beim Kauf"
 
 #: app/templates/tires/form.html:75 app/templates/tires/form.html:116
 #: app/templates/tires/index.html:58
@@ -4421,8 +4401,8 @@ msgid ""
 "Optional. Kept for reference; the distance covered comes from when the set "
 "is on the vehicle."
 msgstr ""
-"Optional. Nur zur Information; die gefahrene Strecke ergibt sich aus der "
-"Zeit am Fahrzeug."
+"Optional. Dient als Referenz; die zurückgelegte Strecke bezieht sich auf den "
+"Zeitraum, in dem der Reifensatz am Fahrzeug montiert war.“
 
 #: app/templates/tires/form.html:93
 msgid "Retired (worn out or sold)"
@@ -4791,7 +4771,7 @@ msgid ""
 "with different odometer units."
 msgstr ""
 "Kilometerstand-Einheit für dieses Fahrzeug überschreiben. Nützlich, wenn Sie"
-" Fahrzeuge mit unterschiedlichen (z.B. Nicht-Landesüblichen) Einheiten "
+" Fahrzeuge mit unterschiedlichen (z.B. nicht-landesüblichen) Einheiten "
 "haben."
 
 #: app/templates/vehicles/form.html:70
@@ -4804,7 +4784,7 @@ msgid ""
 "alongside Diesel."
 msgstr ""
 "Optional. Für Fahrzeuge mit einer weiteren zu erfassenden Flüssigkeit "
-"verwenden, z.B. AdBlueneben Diesel."
+"verwenden, z.B. AdBlue zusätzlich zu Diesel."
 
 #: app/templates/vehicles/form.html:82
 msgid "Make"
@@ -4927,7 +4907,7 @@ msgstr ""
 
 #: app/templates/vehicles/form.html:251
 msgid "Active (show in lists and calculations)"
-msgstr "Aktiv (in Listen und Berechnungen anzeigen)"
+msgstr "Aktiv (wird in Listen und Berechnungen angezeigt)"
 
 #: app/templates/vehicles/form.html:257
 msgid ""
@@ -5341,7 +5321,7 @@ msgstr "im Zeitplan"
 
 #: app/templates/vehicles/view.html:589
 msgid "Over pace"
-msgstr "Im Zeitplan"
+msgstr "Über Zeitplan"
 
 #: app/templates/vehicles/view.html:607 app/templates/vehicles/view.html:614
 msgid "Time elapsed"
@@ -5423,7 +5403,7 @@ msgid ""
 "restore them later."
 msgstr ""
 "Archivierte Fahrzeuge werden nicht in regulären Listen oder Berechnungen "
-"angezeigt. Sie können diese später wiederherstellen."
+"angezeigt. Sie können diese jedoch später wiederherstellen."
 
 #: app/templates/vehicles/view.html:1065
 msgid "Restore this vehicle"

--- a/app/translations/hu/LC_MESSAGES/messages.po
+++ b/app/translations/hu/LC_MESSAGES/messages.po
@@ -63,7 +63,7 @@ msgstr "Motoróra"
 #: app/templates/notes/index.html:31 app/templates/tires/index.html:92
 #: app/templates/tires/index.html:107 app/templates/vehicles/view.html:484
 msgid "Odometer"
-msgstr "kilométeróra"
+msgstr "Kilométeróra"
 
 #: app/models.py:396 app/models.py:1411 app/templates/trips/form.html:189
 msgid "Hours"
@@ -242,7 +242,7 @@ msgstr "Futásteljesítmény (km/mi)"
 
 #: app/models.py:1416 app/templates/auth/settings.html:129
 msgid "Kilometres (km)"
-msgstr "Kilometer (km)"
+msgstr "Kilométer (km)"
 
 #: app/models.py:1417 app/templates/auth/settings.html:130
 msgid "Miles (mi)"
@@ -1426,7 +1426,7 @@ msgstr "vegyes egységek"
 
 #: app/templates/dashboard.html:119 app/templates/vehicles/view.html:201
 msgid "Cost per"
-msgstr "Költség per"
+msgstr "Költség /"
 
 #: app/templates/dashboard.html:119
 msgid "unit"
@@ -2756,7 +2756,7 @@ msgid ""
 "For ntfy.sh, just enter your topic name. For self-hosted, enter the full "
 "URL."
 msgstr ""
-"Az ntfy.sh esetén egyszerűen add meg a toppic-ot. Saját üzemeltetésű szerver"
+"Az ntfy.sh esetén egyszerűen add meg a topic-ot. Saját üzemeltetésű szerver"
 " esetén add meg a teljes URL-t."
 
 #: app/templates/auth/settings.html:1413
@@ -2825,7 +2825,7 @@ msgstr "E-mail (SMTP)"
 
 #: app/templates/auth/settings.html:1519
 msgid "SMTP Host"
-msgstr "SMTP host"
+msgstr "SMTP szerver"
 
 #: app/templates/auth/settings.html:1526
 msgid "SMTP Port"
@@ -3411,11 +3411,11 @@ msgstr "Ennél a járműnél a kilométeróra-állást a Tessie automatikusan k�
 #: app/templates/fuel/form.html:76 app/templates/fuel/quick.html:66
 #: app/templates/vehicles/view.html:1234
 msgid "Price per"
-msgstr "Ár per"
+msgstr "Ár /"
 
 #: app/templates/fuel/form.html:84
 msgid "Discount per"
-msgstr "Kedvezmény per"
+msgstr "Kedvezmény /"
 
 #: app/templates/fuel/form.html:90
 msgid "Optional loyalty discount, subtracted from the price per unit."
@@ -4753,7 +4753,7 @@ msgstr "Üzemóra használata traktorokhoz, hajókhoz stb."
 
 #: app/templates/vehicles/form.html:47
 msgid "Odometer Unit"
-msgstr "Kilométer óra egység"
+msgstr "Kilométeróra egység"
 
 #: app/templates/vehicles/form.html:50
 msgid "Use account default"
@@ -5140,7 +5140,7 @@ msgstr "Rendszám"
 
 #: app/templates/vehicles/view.html:101
 msgid "Last Odometer"
-msgstr "Utolsó futásteljesítmény"
+msgstr "Kilométeróra utolsó állása"
 
 #: app/templates/vehicles/view.html:162
 msgid "Total Hours"

--- a/app/translations/hu/LC_MESSAGES/messages.po
+++ b/app/translations/hu/LC_MESSAGES/messages.po
@@ -522,7 +522,7 @@ msgstr "Izzó"
 
 #: app/permissions.py:128
 msgid "Your account does not have permission to change this data."
-msgstr "A fiókjának nincs jogosultsága ezeknek az adatoknak a módosítására."
+msgstr "A fiókodnak nincs jogosultsága ezeknek az adatoknak a módosítására."
 
 #: app/routes/allowance.py:31 app/routes/expenses.py:155 app/routes/fuel.py:72
 #: app/routes/fuel.py:444 app/routes/notes.py:31 app/routes/reminders.py:64
@@ -696,7 +696,7 @@ msgstr "A biztonsági mentés nem olvasható: %(error)s"
 
 #: app/routes/api.py:3751
 msgid "The uploaded backup has expired. Please upload it again."
-msgstr "A feltöltött biztonsági mentés lejárt. Töltse fel újra."
+msgstr "A feltöltött biztonsági mentés lejárt. Töltsd fel újra."
 
 #: app/routes/api.py:3764
 #, python-format
@@ -720,7 +720,7 @@ msgstr "Hibás felhasználónév vagy jelszó"
 msgid ""
 "Password reset by email is not available. Please contact an administrator."
 msgstr ""
-"Az e-mailes jelszó-visszaállítás nem érhető el. Kérjük, lépj kapcsolatba egy"
+"Az e-mailes jelszó-visszaállítás nem érhető el. Kérlek, lépj kapcsolatba egy"
 " rendszergazdával!"
 
 #: app/routes/auth.py:91
@@ -732,7 +732,7 @@ msgstr ""
 
 #: app/routes/auth.py:104
 msgid "Invalid or expired reset link. Please request a new one."
-msgstr "Érvénytelen vagy lejárt visszaállítási link. Kérjük, kérj újat!"
+msgstr "Érvénytelen vagy lejárt visszaállítási link. Kérlek, kérj újat!"
 
 #: app/routes/auth.py:112 app/routes/auth.py:170 app/routes/auth.py:240
 #: app/routes/auth.py:574 app/routes/auth.py:621
@@ -1068,7 +1068,7 @@ msgstr "%(prices)s élő ár frissítve %(matched)s töltőállomásról"
 #: app/routes/stations.py:176
 msgid "No matching forecourts found. Check the station postcodes."
 msgstr ""
-"Nem található megfelelő töltőállomás. Ellenőrizze az állomások "
+"Nem található megfelelő töltőállomás. Ellenőrizd az állomások "
 "irányítószámait."
 
 #: app/routes/stations.py:182
@@ -1092,11 +1092,11 @@ msgstr "Árbejegyzés törölve"
 
 #: app/routes/tires.py:88 app/routes/tires.py:133
 msgid "Please give the tire set a name"
-msgstr "Adjon nevet a gumiszettnek"
+msgstr "Adj nevet a gumiszettnek"
 
 #: app/routes/tires.py:105 app/routes/tires.py:141
 msgid "Invalid data submitted. Please check the odometer and cost fields."
-msgstr "Érvénytelen adat. Ellenőrizze a kilométeróra és a költség mezőket."
+msgstr "Érvénytelen adat. Ellenőrizd a kilométeróra és a költség mezőket."
 
 #: app/routes/tires.py:112
 #, python-format
@@ -1113,7 +1113,8 @@ msgstr "Ez a gumiszett már a járművön van"
 
 #: app/routes/tires.py:174
 msgid "That tire set is retired. Reinstate it before fitting it again."
-msgstr "Ez a gumiszett ki van vonva. Állítsa vissza, mielőtt újra felszereli."
+msgstr ""
+"Ez a gumiszett ki van vonva. Állítsd vissza, mielőtt újra felszereled."
 
 #: app/routes/tires.py:188 app/routes/tires.py:227
 #, python-format
@@ -1937,7 +1938,7 @@ msgid ""
 "Your account can see the data but cannot change it. Ask an administrator if "
 "you need more access."
 msgstr ""
-"A fiókja látja az adatokat, de nem módosíthatja azokat. Kérjen több "
+"A fiókod látja az adatokat, de nem módosíthatja azokat. Kérj több "
 "jogosultságot egy rendszergazdától."
 
 #: app/templates/auth/settings.html:241
@@ -1945,8 +1946,8 @@ msgid ""
 "Your account can record fuel fill-ups and charging sessions. Ask an "
 "administrator if you need more access."
 msgstr ""
-"A fiókja tankolásokat és töltéseket rögzíthet. Kérjen több jogosultságot egy"
-" rendszergazdától."
+"A fiókod tankolásokat és töltéseket rögzíthet. Kérj több jogosultságot egy "
+"rendszergazdától."
 
 #: app/templates/auth/settings.html:252
 msgid "Member Since"
@@ -2112,7 +2113,7 @@ msgid ""
 "Restore a May backup, or import your data from other fuel tracking "
 "applications"
 msgstr ""
-"Állítson vissza egy May biztonsági mentést, vagy importálja adatait más "
+"Állíts vissza egy May biztonsági mentést, vagy importáld az adataidat más "
 "üzemanyag-nyilvántartó alkalmazásokból"
 
 #: app/templates/auth/settings.html:575
@@ -2600,13 +2601,13 @@ msgid ""
 msgstr ""
 "A brit forgalmazók a kormányzati üzemanyagár-átláthatósági program keretében"
 " közzéteszik a töltőállomási áraikat. A May irányítószám alapján párosítja a"
-" mentett állomásait ezekhez a töltőállomásokhoz, és rögzíti az árakat, így "
-"az árelőzmények és a Legolcsóbb üzemanyag kézi bevitel nélkül is naprakészek"
-" maradnak."
+" mentett állomásaidat ezekhez a töltőállomásokhoz, és rögzíti az árakat, így"
+" az árelőzmények és a Legolcsóbb üzemanyag kézi bevitel nélkül is "
+"naprakészek maradnak."
 
 #: app/templates/auth/settings.html:1278
 msgid "Before you start"
-msgstr "Mielőtt elkezdi"
+msgstr "Mielőtt elkezded"
 
 #: app/templates/auth/settings.html:1280
 msgid "No API key is needed; the feeds are open data"
@@ -2615,7 +2616,7 @@ msgstr "Nincs szükség API kulcsra; az adatforrások nyílt adatok"
 #: app/templates/auth/settings.html:1281
 msgid "Give each station a postcode so it can be matched to a forecourt"
 msgstr ""
-"Adjon meg irányítószámot minden állomáshoz, hogy párosítható legyen egy "
+"Adj meg irányítószámot minden állomáshoz, hogy párosítható legyen egy "
 "töltőállomással"
 
 #: app/templates/auth/settings.html:1282
@@ -2652,7 +2653,7 @@ msgid ""
 "One feed per line. Leave blank to use the built-in list (%(count)s "
 "retailers)."
 msgstr ""
-"Soronként egy adatforrás. Hagyja üresen a beépített lista használatához "
+"Soronként egy adatforrás. Hagyd üresen a beépített lista használatához "
 "(%(count)s forgalmazó)."
 
 #: app/templates/auth/settings.html:1309
@@ -3328,7 +3329,7 @@ msgstr "Biztos, hogy törlöd a csatolmányt?"
 
 #: app/templates/expenses/form.html:133
 msgid "You can select more than one file"
-msgstr "Több fájlt is kiválaszthat"
+msgstr "Több fájlt is kiválaszthatsz"
 
 #: app/templates/expenses/index.html:8
 msgid "Track maintenance, repairs, insurance, and other costs"
@@ -3430,7 +3431,7 @@ msgid ""
 "cost. Add the amounts together where more than one tax applies."
 msgstr ""
 "Nem kötelező. A nyugtán szereplő áfa, amely már benne van a végösszegben. "
-"Több adónem esetén adja össze az összegeket."
+"Több adónem esetén add össze az összegeket."
 
 #: app/templates/fuel/form.html:110 app/templates/fuel/quick.html:94
 msgid "Station"
@@ -3585,7 +3586,7 @@ msgstr "Visszaállítás előnézete"
 #: app/templates/import/backup_preview.html:10
 msgid ""
 "Nothing has been changed yet. This is what will be added to your account."
-msgstr "Még semmi nem változott. Ez kerül majd a fiókjába."
+msgstr "Még semmi nem változott. Ez kerül majd a fiókodba."
 
 #: app/templates/import/backup_preview.html:17
 msgid "Backup type"
@@ -3634,14 +3635,14 @@ msgstr "hozzáadásra kerül"
 
 #: app/templates/import/backup_preview.html:72
 msgid "already in your account — its records will be merged"
-msgstr "már a fiókjában van – a rekordjai összefésülésre kerülnek"
+msgstr "már a fiókodban van – a rekordjai összefésülésre kerülnek"
 
 #: app/templates/import/backup_preview.html:82
 msgid ""
 "Everything in this backup is already in your account. Restoring it will "
 "change nothing."
 msgstr ""
-"A mentés minden eleme már a fiókjában van. A visszaállítás nem változtat "
+"A mentés minden eleme már a fiókodban van. A visszaállítás nem változtat "
 "semmin."
 
 #: app/templates/import/backup_upload.html:8
@@ -3659,9 +3660,9 @@ msgid ""
 "and records that are already here are skipped rather than duplicated. You "
 "will see a summary of what will be added before anything is written."
 msgstr ""
-"A mentés összefésülődik a fiókjával. Semmi nem törlődik és nem íródik felül,"
+"A mentés összefésülődik a fiókoddal. Semmi nem törlődik és nem íródik felül,"
 " a már meglévő rekordok pedig duplikálás helyett kimaradnak. Mielőtt bármi "
-"rögzülne, összefoglalót lát arról, mi kerül hozzáadásra."
+"rögzülne, összefoglalót látsz arról, mi kerül hozzáadásra."
 
 #: app/templates/import/backup_upload.html:17
 msgid ""
@@ -4403,7 +4404,7 @@ msgid ""
 "Track each set of tires on and off the vehicle, and the distance it has "
 "covered"
 msgstr ""
-"Kövesse nyomon a gumiszettek fel- és leszerelését, valamint a megtett távot"
+"Kövesd nyomon a gumiszettek fel- és leszerelését, valamint a megtett távot"
 
 #: app/templates/tires/index.html:34
 msgid "Fitted"
@@ -4464,11 +4465,11 @@ msgstr "Még fent"
 
 #: app/templates/tires/index.html:142
 msgid "Delete this fitting record?"
-msgstr "Törli ezt a felszerelési bejegyzést?"
+msgstr "Törlöd ezt a felszerelési bejegyzést?"
 
 #: app/templates/tires/index.html:160
 msgid "Delete this tire set and its fitting history?"
-msgstr "Törli ezt a gumiszettet és a felszerelési előzményeit?"
+msgstr "Törlöd ezt a gumiszettet és a felszerelési előzményeit?"
 
 #: app/templates/tires/index.html:174
 msgid "No tire sets"
@@ -4477,8 +4478,8 @@ msgstr "Nincsenek gumiszettek"
 #: app/templates/tires/index.html:175
 msgid "Add a set of tires to track when it goes on and off the vehicle."
 msgstr ""
-"Adjon hozzá egy gumiszettet, hogy nyomon követhesse, mikor kerül fel és le a"
-" járműről."
+"Adj hozzá egy gumiszettet, hogy nyomon követhesd, mikor kerül fel és le a "
+"járműről."
 
 #: app/templates/trips/form.html:2 app/templates/trips/form.html:13
 msgid "Edit Trip"
@@ -4692,7 +4693,7 @@ msgstr "Utazási sablonok"
 #: app/templates/trips/templates_index.html:9
 msgid "Save common routes to quickly fill in trip details"
 msgstr ""
-"Mentse el a gyakran használt útvonalakat, hogy gyorsan kitölthesd az út "
+"Mentsd el a gyakran használt útvonalakat, hogy gyorsan kitölthesd az út "
 "adatait"
 
 #: app/templates/trips/templates_index.html:53
@@ -5161,8 +5162,8 @@ msgid ""
 "recorded — the odometer can’t tell petrol from LPG. Add it to your fill-ups."
 msgstr ""
 "A fogyasztás nem számítható ki, amíg nincs rögzítve az egyes üzemanyagokkal "
-"megtett táv – a kilométeróra nem különbözteti meg a benzint az LPG-től. Adja"
-" meg a tankolásoknál."
+"megtett táv – a kilométeróra nem különbözteti meg a benzint az LPG-től. Add "
+"meg a tankolásoknál."
 
 #: app/templates/vehicles/view.html:183
 msgid "Not enough distance or fuel data yet to calculate this."
@@ -5214,7 +5215,7 @@ msgstr "Beállítás főképként"
 
 #: app/templates/vehicles/view.html:335
 msgid "Delete this photo?"
-msgstr "Törli ezt a fényképet?"
+msgstr "Törlöd ezt a fényképet?"
 
 #: app/templates/vehicles/view.html:347
 msgid "No photos yet."

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.41.4'
+APP_VERSION = '0.42.0'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,7 @@
 import pytest
 from app.models import User, AppSettings
 from app import db
+from config import DISPLAY_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -720,3 +721,53 @@ class TestEditUserRoute:
     def test_get_edit_user_unauthenticated_redirects(self, client, test_user):
         response = client.get(f'/auth/users/{test_user.id}/edit')
         assert response.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# About page version refresh (issue #348)
+# ---------------------------------------------------------------------------
+
+class TestAboutPageVersionRefresh:
+    """Issue #348: clicking "Check Now" should refresh the displayed Current Version,
+    not just report update status, without requiring a manual page reload."""
+
+    def test_settings_page_has_targetable_current_version_element(self, auth_client):
+        response = auth_client.get('/auth/settings')
+        assert response.status_code == 200
+        html = response.data.decode('utf-8')
+        # The "Current Version" value needs an id so JS can update it in place.
+        assert 'id="current-version-value"' in html
+
+    def test_check_for_updates_script_refreshes_current_version_display(self, auth_client):
+        response = auth_client.get('/auth/settings')
+        assert response.status_code == 200
+        html = response.data.decode('utf-8')
+        idx = html.index('function checkForUpdates()')
+        script = html[idx:idx + 2000]
+        # The check-updates JSON response already includes current_version;
+        # the handler must use it to refresh the on-page "Current Version" display.
+        assert 'current-version-value' in script
+        assert 'data.current_version' in script
+
+    def test_check_updates_response_carries_display_version(self, auth_client, monkeypatch):
+        """The page renders DISPLAY_VERSION, so the JSON must offer it too, or a dev
+        build's "0.41.4-dev+abc1234" would be overwritten with a bare "0.41.4"."""
+        class FakeResponse:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {
+                    'tag_name': 'v99.0.0',
+                    'html_url': 'https://example.invalid/release',
+                    'body': '',
+                    'published_at': '2026-01-01T00:00:00Z',
+                }
+
+        monkeypatch.setattr('app.routes.auth.requests.get', lambda *a, **kw: FakeResponse())
+
+        response = auth_client.get('/auth/check-updates')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+        assert data['display_version'] == DISPLAY_VERSION

--- a/tests/test_i18n_issue_350.py
+++ b/tests/test_i18n_issue_350.py
@@ -1,0 +1,166 @@
+"""The Hungarian catalogue mixes formal and informal address (#350).
+
+Hungarian distinguishes formal ("magázás", third-person forms addressed to
+the reader: "Ellenőrizze", "a fiókja") from informal ("tegezés", second-person
+forms: "Ellenőrizd", "a fiókod"). Everything the catalogue carried before the
+bulk fill in #340 is informal -- "Kezeld a beállításaidat", "Válassz",
+"Add meg" -- so that is the settled house style; a handful of the strings
+#340 added were written formal instead, and one mixed both registers inside
+a single sentence.
+
+This is cosmetic: nothing was mistranslated. These tests pin the register so
+the next bulk fill cannot quietly reintroduce the drift, and they check the
+tidy-up did not disturb the catalogue itself.
+"""
+import os
+import re
+
+import pytest
+from babel.messages.pofile import read_po
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TRANSLATIONS_DIR = os.path.join(BASE_DIR, 'app', 'translations')
+HU_PO = os.path.join(TRANSLATIONS_DIR, 'hu', 'LC_MESSAGES', 'messages.po')
+
+# Formal address in Hungarian shows up in three shapes. Each entry is
+# (pattern, informal counterpart), so a failure says what to write instead.
+FORMAL_FORMS = [
+    # Formal imperatives (third-person subjunctive used as a polite command).
+    (r'\bEllenőrizze\b', 'Ellenőrizd'),
+    (r'\bAdjon\b', 'Adj'),
+    (r'\bAdja\b', 'Add'),
+    (r'\bÁllítsa\b', 'Állítsd'),
+    (r'\bÁllítson\b', 'Állíts'),
+    (r'\bMentse\b', 'Mentsd'),
+    (r'\bTöltse\b', 'Töltsd'),
+    (r'\bTöltsön\b', 'Tölts'),
+    (r'\bHagyja\b', 'Hagyd'),
+    (r'\bKövesse\b', 'Kövesd'),
+    (r'\bKérjen\b', 'Kérj'),
+    (r'\bVálassza\b', 'Válaszd'),
+    (r'\bVálasszon\b', 'Válassz'),
+    (r'\bKattintson\b', 'Kattints'),
+    (r'\bTörölje\b', 'Töröld'),
+    (r'\bFrissítse\b', 'Frissítsd'),
+    (r'\bMódosítsa\b', 'Módosítsd'),
+    # Polite plural ("we ask you"), which reads as magázás next to tegezés.
+    (r'\bKérjük\b', 'Kérlek'),
+    # Formal second-person possessive: "your account" as a third-person
+    # possessive ("a fiókja") rather than "a fiókod". Only a noun that can
+    # belong to nobody but the reader is safe to match this bluntly: "-ait"
+    # is an ordinary third-person possessive elsewhere ("az út adatait" is
+    # the *trip's* details), so the rest are pinned string by string below
+    # rather than by pattern.
+    (r'\bfiókj\w*\b', 'a fiókod / fiókodban / fiókodba / fiókoddal'),
+    # Formal indicative used to address the reader.
+    (r'\bTörli ezt\b', 'Törlöd ezt'),
+    (r'\bMielőtt elkezdi\b', 'Mielőtt elkezded'),
+]
+
+
+def _hu_catalogue():
+    with open(HU_PO, encoding='utf-8') as handle:
+        return read_po(handle)
+
+
+def _hu_messages():
+    """Every translated (msgid, msgstr) pair in the Hungarian catalogue."""
+    return [
+        (message.id, message.string)
+        for message in _hu_catalogue()
+        if message.id and message.string and isinstance(message.id, str)
+    ]
+
+
+class TestHungarianUsesInformalAddress:
+    """Acceptance criterion: every msgstr in the hu catalogue addresses the
+    reader informally, matching the pre-#340 strings."""
+
+    @pytest.mark.parametrize(
+        'pattern,informal', FORMAL_FORMS, ids=[p for p, _ in FORMAL_FORMS]
+    )
+    def test_no_formal_address(self, pattern, informal):
+        compiled = re.compile(pattern)
+        offenders = [
+            f'{msgid!r} -> {msgstr!r}'
+            for msgid, msgstr in _hu_messages()
+            if compiled.search(msgstr)
+        ]
+        assert offenders == [], (
+            f"Hungarian strings using formal address ({pattern}); the "
+            f"catalogue is informal throughout, so use {informal!r} "
+            f"instead (#350):\n" + '\n'.join(offenders)
+        )
+
+    def test_the_sales_tax_hint_is_informal(self):
+        # The pair the issue quotes: the Sales Tax help text on the fuel
+        # form read "adja össze" while the rest of the catalogue tegez.
+        hint = dict(_hu_messages())[
+            'Optional. Sales tax shown on the receipt, already included in '
+            'the total cost. Add the amounts together where more than one '
+            'tax applies.'
+        ]
+        assert 'add össze' in hint, hint
+        assert 'adja össze' not in hint, hint
+
+    def test_the_trip_templates_strapline_is_not_mixed(self):
+        # trips/templates_index.html:9 managed both registers in one
+        # sentence: a formal "Mentse el" governing an informal
+        # "kitölthesd".
+        strapline = dict(_hu_messages())[
+            'Save common routes to quickly fill in trip details'
+        ]
+        assert strapline.startswith('Mentsd el'), strapline
+        assert 'kitölthesd' in strapline, strapline
+
+    def test_reader_owned_nouns_use_the_informal_possessive(self):
+        # The cases a blanket "-ait" pattern cannot judge: here the thing
+        # possessed belongs to the reader, so it needs "-aid", not "-ait".
+        messages = dict(_hu_messages())
+        restore = messages[
+            'Restore a May backup, or import your data from other fuel '
+            'tracking applications'
+        ]
+        assert 'adataidat' in restore, restore
+        assert 'adatait' not in restore, restore
+
+        forecourts = messages[
+            'UK retailers publish forecourt prices under the government fuel '
+            'price transparency scheme. May matches your saved stations to '
+            'those forecourts by postcode and records the prices, so price '
+            'history and Cheapest Fuel stay up to date without manual entry.'
+        ]
+        assert 'állomásaidat' in forecourts, forecourts
+        assert 'állomásait' not in forecourts, forecourts
+
+
+class TestHungarianCatalogueIsOtherwiseUnchanged:
+    """The tidy-up is register only: it must not drop, add or blank an
+    entry."""
+
+    def test_msgids_still_match_the_template(self):
+        with open(os.path.join(TRANSLATIONS_DIR, 'messages.pot'),
+                  encoding='utf-8') as handle:
+            template = read_po(handle)
+        expected = {message.id for message in template if message.id}
+        actual = {message.id for message in _hu_catalogue() if message.id}
+        assert actual == expected, (
+            f"missing: {sorted(expected - actual)}, "
+            f"unexpected: {sorted(actual - expected)}"
+        )
+
+    def test_no_entry_was_left_untranslated(self):
+        blank = [
+            message.id for message in _hu_catalogue()
+            if message.id and not message.string
+        ]
+        assert blank == [], f"untranslated Hungarian entries: {blank}"
+
+    def test_no_entry_was_left_fuzzy(self):
+        # pybabel compile skips fuzzy entries, so a fuzzy flag ships as
+        # English.
+        fuzzy = [
+            message.id for message in _hu_catalogue()
+            if message.id and message.fuzzy
+        ]
+        assert fuzzy == [], f"fuzzy Hungarian entries: {fuzzy}"

--- a/tests/test_i18n_issue_351.py
+++ b/tests/test_i18n_issue_351.py
@@ -1,0 +1,270 @@
+"""Pin the address register of the other T-V catalogues from #340 (#351).
+
+#350 found that the bulk translation fill in #340 had written a handful of
+formal-register strings into the Hungarian catalogue, which had been
+informal since long before #340. #351 asks whether the same fill did the
+same to the other catalogues whose language draws a T-V distinction.
+
+The audit compared each catalogue's pre-#340 strings (``git show
+2132f12^``) against the strings #340 added, looking at both the address
+pronoun and -- for the pro-drop languages, where the pronoun is usually
+absent and the register is carried by the verb -- the imperative
+conjugation. Every one of the nine is internally consistent, before and
+after the fill:
+
+===  ========  ==================================================
+loc  register  what marks it
+===  ========  ==================================================
+de   formal    Sie / Ihr, and Sie-imperatives ("Prüfen Sie")
+fr   formal    vous / votre / vos
+es   formal    usted / su, and usted-imperatives ("Compruebe")
+nl   formal    u / uw, never je / jouw
+it   informal  tu / tuo, and tu-imperatives ("Aggiungi", "Scegli")
+pt   informal  você-register: seu / sua, "Adicione", never tu-forms
+pl   informal  ty / Ci, with the catalogue's own convention of
+               capitalising the possessive ("Twoje konto")
+cs   formal    váš / vaše, and vy-imperatives ("Zadejte")
+ru   formal    ваш, and вы-imperatives ("Укажите")
+===  ========  ==================================================
+
+So nothing needed correcting: Hungarian looks to have been an isolated
+slip in that batch rather than a systemic fault. These tests exist only so
+that stays true. They record the register each catalogue settled on and
+fail if a future bulk fill introduces the other one, which is how #350 got
+in and sat there until a native speaker noticed.
+
+Two shapes of check per catalogue: no marker of the wrong register
+anywhere, and the settled register still present in quantity, so a fill
+cannot quietly flip the catalogue wholesale either.
+"""
+import os
+import re
+
+import pytest
+from babel.messages.pofile import read_po
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TRANSLATIONS_DIR = os.path.join(BASE_DIR, 'app', 'translations')
+
+# The languages named in #351: those among #340's nineteen catalogues that
+# draw a T-V distinction. Hungarian is handled by test_i18n_issue_350.
+AUDITED = ['de', 'fr', 'es', 'it', 'pt', 'nl', 'pl', 'cs', 'ru']
+
+# Markers of the register the catalogue did *not* choose. Each entry is
+# (pattern, what to write instead), so a failure says what the fix is.
+# Only patterns that cannot fire on the settled register are listed: a
+# blunter net would catch homographs (Italian "sua" is an ordinary
+# third-person possessive, Polish "Proszę" is an impersonal "please" that
+# sits happily beside informal address) and the test would cry wolf.
+WRONG_REGISTER = {
+    'de': [
+        (r'\b[Dd]u\b', 'Sie'),
+        (r'\b[Dd]ein\w*\b', 'Ihr / Ihre / Ihren'),
+        (r'\b[Dd]ich\b', 'Sie'),
+        (r'\b[Dd]ir\b', 'Ihnen'),
+        (r'\b[Ee]uer\b', 'Ihr'),
+        (r'\b[Ee]ure\w*\b', 'Ihre'),
+    ],
+    'fr': [
+        (r'\b[Tt]u\b', 'vous'),
+        (r'\b[Tt]on\b', 'votre'),
+        (r'\b[Tt]es\b', 'vos'),
+        (r'\btoi\b', 'vous'),
+    ],
+    'es': [
+        (r'\b[Tt][uú]\b', 'usted / su'),
+        (r'\b[Tt]us\b', 'sus'),
+        (r'\bti\b', 'usted'),
+        (r'\bcontigo\b', 'con usted'),
+    ],
+    'nl': [
+        (r'\b[Jj]e\b', 'u / uw'),
+        (r'\b[Jj]ij\b', 'u'),
+        (r'\b[Jj]ouw\w*\b', 'uw'),
+    ],
+    # Czech and Russian drop the pronoun, so the register lives in the
+    # imperative ending: informal -ej/-i against formal -ejte/-ите. The
+    # informal counterparts of the verbs these catalogues actually use are
+    # listed rather than a general ending pattern, which would misfire on
+    # ordinary indicatives.
+    'cs': [
+        (r'\b[Tt]v[ůu]j\b', 'váš'),
+        (r'\b[Tt]voj\w+\b', 'vaše / vašeho / vašem'),
+        (r'\b[Tt]vého\b', 'vašeho'),
+        (r'\bMůžeš\b', 'Můžete'),
+        (r'\bpotřebuješ\b', 'potřebujete'),
+        (r'\buvidíš\b', 'uvidíte'),
+        (r'\bZadej\b', 'Zadejte'),
+        (r'\bZkontroluj\b', 'Zkontrolujte'),
+        (r'\bPřidej\b', 'Přidejte'),
+        (r'\bNahraj\b', 'Nahrajte'),
+        (r'\bPonech\b', 'Ponechte'),
+        (r'\bSleduj\b', 'Sledujte'),
+        (r'\bDoplň\b', 'Doplňte'),
+        (r'\bObnov\b', 'Obnovte'),
+    ],
+    'ru': [
+        (r'\b[Тт]вой\b', 'ваш'),
+        (r'\b[Тт]во[яеёию]\w*\b', 'ваша / ваше / вашу'),
+        (r'\b[Тт]ы\b', 'вы'),
+        (r'\bПроверь\b', 'Проверьте'),
+        (r'\bУкажи\b', 'Укажите'),
+        (r'\bЗагрузи\b', 'Загрузите'),
+        (r'\bОставь\b', 'Оставьте'),
+        (r'\bДобавь\b', 'Добавьте'),
+        (r'\bОтслеживай\b', 'Отслеживайте'),
+        (r'\bОбратись\b', 'Обратитесь'),
+        (r'\bсможешь\b', 'сможете'),
+    ],
+    # Italian and Polish went the other way: informal throughout, so it is
+    # the formal forms that must not appear. Italian formal address
+    # capitalises ("Lei", "Suo") to separate itself from the third person,
+    # which is what makes it safe to match here.
+    'it': [
+        (r'\bLei\b', 'tu'),
+        (r'\bSuo\b', 'tuo'),
+        (r'\bSua\b', 'tua'),
+        (r'\bSuoi\b', 'tuoi'),
+        (r'\bSue\b', 'tue'),
+        (r'\bLa preghiamo\b', 'a plain informal imperative'),
+        (r'\bVoglia\b', 'a plain informal imperative'),
+    ],
+    'pl': [
+        # Polish formal address declines, so catch the cases too.
+        (r'\bPan(a|u|em|ie)?\b', 'ty-forms'),
+        (r'\bPani(ą|ę)?\b', 'ty-forms'),
+        (r'\bPaństw\w+\b', 'ty-forms'),
+        (r'\bPańsk\w+\b', 'Twój / Twoje'),
+    ],
+    # Portuguese here is the você register (third-person forms addressed to
+    # the reader), not tu; the tu-conjugated imperatives are the tell.
+    'pt': [
+        (r'\b[Tt]eu\b', 'seu'),
+        (r'\b[Tt]ua\b', 'sua'),
+        (r'\b[Tt]eus\b', 'seus'),
+        (r'\b[Tt]uas\b', 'suas'),
+        (r'\b[Tt]u\b', 'você'),
+        (r'\bcontigo\b', 'com você'),
+        (r'\bAdiciona\b', 'Adicione'),
+        (r'\bEscolhe\b', 'Escolha'),
+        (r'\bVerifica\b', 'Verifique'),
+    ],
+}
+
+# The settled register, and a floor on how many strings carry it. The
+# floors sit at roughly half the present count: loose enough that ordinary
+# translation work does not trip them, tight enough that a bulk fill which
+# flipped the catalogue wholesale would.
+SETTLED_REGISTER = {
+    'de': ('formal (Sie/Ihr)', r'\bSie\b|\bIhre?\w*\b|\bIhnen\b', 60),
+    'fr': ('formal (vous/votre)', r'\b[Vv]ous\b|\b[Vv]otre\b|\b[Vv]os\b', 45),
+    'es': ('formal (usted/su)', r'\busted\b|\b[Ss]us?\b', 35),
+    'nl': ('formal (u/uw)', r'\b[Uu]\b|\b[Uu]w\b', 45),
+    'cs': ('formal (váš, -ejte imperatives)', r'\b[Vv]áš\b|\b[Vv]aš\w+\b', 12),
+    'ru': ('formal (ваш, -ите imperatives)', r'\b[Вв]аш\w*\b|\b[Вв]ы\b', 12),
+    'it': ('informal (tu/tuo)', r'\btuo\b|\btua\b|\btuoi\b|\btue\b|\bPuoi\b|\bti\b', 30),
+    'pl': ('informal (ty/Ci, capitalised possessive)',
+           r'\bTw[oó]j\w*\b|\bTwoj\w+\b|\bMożesz\b|\bCi\b', 8),
+    'pt': ('informal você-register (seu/sua)',
+           r'\bvocê\b|\b[Ss]eus?\b|\b[Ss]uas?\b', 30),
+}
+
+
+def _catalogue(locale):
+    path = os.path.join(TRANSLATIONS_DIR, locale, 'LC_MESSAGES', 'messages.po')
+    with open(path, encoding='utf-8') as handle:
+        return read_po(handle)
+
+
+def _messages(locale):
+    """Every translated (msgid, msgstr) pair in a catalogue."""
+    return [
+        (message.id, message.string)
+        for message in _catalogue(locale)
+        if message.id and message.string and isinstance(message.id, str)
+    ]
+
+
+def _wrong_register_cases():
+    for locale, entries in WRONG_REGISTER.items():
+        for pattern, instead in entries:
+            yield pytest.param(
+                locale, pattern, instead, id=f'{locale}-{pattern}'
+            )
+
+
+class TestTheAuditedCataloguesKeepTheirRegister:
+    """Acceptance criterion: the register #351 recorded for each catalogue
+    is the register it still uses."""
+
+    @pytest.mark.parametrize(
+        'locale,pattern,instead', list(_wrong_register_cases())
+    )
+    def test_no_string_uses_the_other_register(self, locale, pattern,
+                                               instead):
+        compiled = re.compile(pattern)
+        offenders = [
+            f'{msgid!r} -> {msgstr!r}'
+            for msgid, msgstr in _messages(locale)
+            if compiled.search(msgstr)
+        ]
+        settled = SETTLED_REGISTER[locale][0]
+        assert offenders == [], (
+            f"{locale} strings addressing the reader in the wrong register "
+            f"({pattern}); the catalogue is {settled} throughout, so use "
+            f"{instead!r} instead (#351):\n" + '\n'.join(offenders)
+        )
+
+    @pytest.mark.parametrize('locale', AUDITED)
+    def test_the_settled_register_is_still_used_throughout(self, locale):
+        # The mirror of the check above: a fill that translated everything
+        # afresh in the other register would leave no wrong-register marker
+        # to catch, because it would have replaced the right ones too.
+        register, pattern, floor = SETTLED_REGISTER[locale]
+        compiled = re.compile(pattern)
+        carrying = [
+            msgid for msgid, msgstr in _messages(locale)
+            if compiled.search(msgstr)
+        ]
+        assert len(carrying) >= floor, (
+            f"only {len(carrying)} {locale} strings still address the "
+            f"reader as {register}, expected at least {floor}; the "
+            f"catalogue looks to have been rewritten in the other "
+            f"register (#351)"
+        )
+
+
+class TestTheAuditedCataloguesAreComplete:
+    """Acceptance criterion, and the condition under which the register
+    checks above mean anything: a catalogue that has gone blank or fuzzy
+    ships English regardless of what register it was written in."""
+
+    @pytest.mark.parametrize('locale', AUDITED)
+    def test_msgids_still_match_the_template(self, locale):
+        with open(os.path.join(TRANSLATIONS_DIR, 'messages.pot'),
+                  encoding='utf-8') as handle:
+            template = read_po(handle)
+        expected = {message.id for message in template if message.id}
+        actual = {message.id for message in _catalogue(locale) if message.id}
+        assert actual == expected, (
+            f"{locale} missing: {sorted(expected - actual)}, "
+            f"unexpected: {sorted(actual - expected)}"
+        )
+
+    @pytest.mark.parametrize('locale', AUDITED)
+    def test_no_entry_was_left_untranslated(self, locale):
+        blank = [
+            message.id for message in _catalogue(locale)
+            if message.id and not message.string
+        ]
+        assert blank == [], f"untranslated {locale} entries: {blank}"
+
+    @pytest.mark.parametrize('locale', AUDITED)
+    def test_no_entry_was_left_fuzzy(self, locale):
+        # pybabel compile skips fuzzy entries, so a fuzzy flag ships as
+        # English.
+        fuzzy = [
+            message.id for message in _catalogue(locale)
+            if message.id and message.fuzzy
+        ]
+        assert fuzzy == [], f"fuzzy {locale} entries: {fuzzy}"

--- a/tests/test_i18n_issue_352.py
+++ b/tests/test_i18n_issue_352.py
@@ -1,0 +1,142 @@
+"""Re-land the still-valid corrections from #339 against the current
+Hungarian catalogue (#352).
+
+#339 (burgatshow) forked at v0.41.1 and cannot be merged as-is: the bulk
+fill in #340, the register fix in #350 and the pinning tests in #351 have
+rewritten `messages.po` underneath it. But several of the individual fixes
+it made are still genuine and still missing from the catalogue as it
+stands on `dev` -- confirmed here by cross-checking each one against
+translations the catalogue already uses *elsewhere* for the same or an
+analogous English string:
+
+- "Kilometres (km)" is missing its accent: "Kilometer" instead of
+  "Kilométer".
+- The ntfy hint has a doubled-letter typo, "toppic-ot" for "topic-ot".
+- The Odometer family does not agree with itself: "Odometer when bought"
+  says "Kilométeróra", but the bare "Odometer" is lowercase, "Odometer
+  Unit" splits the compound in two ("Kilométer óra"), and "Last Odometer"
+  reaches for a different word altogether ("futásteljesítmény", mileage
+  covered, rather than the reading on the instrument). All four should say
+  "Kilométeróra".
+- "SMTP Host" is left as the untranslated English word "host", while the
+  catalogue uses "szerver" for "server" throughout the same settings
+  section (including two lines above it, in the ntfy hint).
+- "Cost per" / "Price per" / "Discount per" use the English loanword
+  "per", while the same catalogue already renders the near-identical
+  "Cost per kWh" as "Költség / kWh" -- the "/" is the catalogue's own
+  established convention for a per-unit label.
+
+These are corrections #339 made and are still true on `dev`; they are not
+superseded by #340's bulk fill (which only added new msgids) or #350's
+register fix (these strings carry no imperative, so register was never the
+issue). This module pins them so the fix lands and stays landed.
+
+It also guards the trap noted against #339 specifically: the stray „…"
+typographic quotes wrapped around four whole-sentence msgstrs, which must
+not be reintroduced by copying #339's text verbatim.
+
+One correction #339 made is deliberately *not* re-landed: its change of
+the bare msgid "Registration" to "Rendszám" (number plate). That was right
+against #339's base (v0.41.1), where the msgid was shared by the vehicle
+detail page and the expense category, but #342 has since split the plate
+label out into its own msgid, so "Registration" now carries only the
+registration-fee expense category. Applying #339's change today would put
+"number plate" in the expenses dropdown. That msgid is pinned below in the
+sense it actually has instead.
+"""
+import os
+
+from babel.messages.pofile import read_po
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HU_PO = os.path.join(BASE_DIR, 'app', 'translations', 'hu', 'LC_MESSAGES', 'messages.po')
+
+
+def _hu_catalogue():
+    with open(HU_PO, encoding='utf-8') as handle:
+        return read_po(handle)
+
+
+def _hu_messages():
+    return {
+        message.id: message.string
+        for message in _hu_catalogue()
+        if message.id and message.string and isinstance(message.id, str)
+    }
+
+
+class TestStillOutstandingCorrectionsFrom339:
+    """Fixes #339 made that are still missing from the catalogue as it
+    stands on dev, confirmed against how the catalogue already translates
+    the same or an analogous string elsewhere."""
+
+    def test_the_plate_and_the_expense_category_keep_their_own_senses(self):
+        messages = _hu_messages()
+        # The two plate msgids agree with each other, and always did:
+        assert messages['Registration / License Plate'] == 'Rendszám'
+        assert messages['Registration plate'] == 'Rendszám'
+        # The bare "Registration" is *not* one of them. #339 changed it to
+        # "Rendszám" too, which was right against its base (v0.41.1), where
+        # the one msgid was shared by the vehicle detail page and the
+        # expense category. #342 (9676dfe) has since given the plate label
+        # its own string, so `_l('Registration')` now occurs once only, at
+        # models.py:1383 in EXPENSE_CATEGORIES -- the registration/road-tax
+        # fee. Re-landing #339's change here would read "number plate" in
+        # the expenses dropdown, and would part hu from the other
+        # catalogues, which all keep the two senses apart (de
+        # Registrierung/Kennzeichen, fr Immatriculation, cs
+        # Registrace/Registrační značka).
+        assert messages['Registration'] == 'Regisztráció', messages['Registration']
+        assert messages['Registration'] != messages['Registration plate']
+
+    def test_kilometres_km_is_spelt_correctly(self):
+        messages = _hu_messages()
+        assert messages['Kilometres (km)'] == 'Kilométer (km)', messages['Kilometres (km)']
+
+    def test_the_ntfy_hint_has_no_doubled_letter_typo(self):
+        messages = _hu_messages()
+        hint = messages[
+            'For ntfy.sh, just enter your topic name. For self-hosted, enter the full URL.'
+        ]
+        assert 'toppic' not in hint, hint
+
+    def test_the_odometer_family_uses_one_word_for_the_odometer(self):
+        messages = _hu_messages()
+        for msgid in ('Odometer Unit', 'Odometer when bought', 'Last Odometer'):
+            assert 'Kilométeróra' in messages[msgid], (
+                f'{msgid!r} -> {messages[msgid]!r}'
+            )
+        assert messages['Odometer'] == 'Kilométeróra', messages['Odometer']
+
+    def test_smtp_host_is_translated_not_left_in_english(self):
+        messages = _hu_messages()
+        assert messages['SMTP Host'] != 'SMTP host'
+        assert 'host' not in messages['SMTP Host'].lower(), messages['SMTP Host']
+
+    def test_per_unit_labels_use_the_catalogues_own_slash_convention(self):
+        messages = _hu_messages()
+        # The catalogue's own precedent for a per-unit label:
+        assert messages['Cost per kWh'] == 'Költség / kWh'
+        # The generic "per" labels should follow the same convention
+        # rather than the English loanword "per".
+        for msgid in ('Cost per', 'Price per', 'Discount per'):
+            assert 'per' not in messages[msgid].lower().split(), (
+                f'{msgid!r} -> {messages[msgid]!r} still uses the English '
+                f"loanword instead of the catalogue's own \"/\" convention"
+            )
+
+
+class TestNoStrayTypographicQuotes:
+    """#339 review flagged four whole-sentence msgstrs wrapped in stray
+    „…" quotation marks that must not be carried over into the catalogue."""
+
+    def test_no_msgstr_is_wrapped_in_typographic_quotes(self):
+        offenders = [
+            f'{msgid!r} -> {msgstr!r}'
+            for msgid, msgstr in _hu_messages().items()
+            if msgstr.strip().startswith('„') and msgstr.strip().endswith('”')
+        ]
+        assert offenders == [], (
+            'Hungarian msgstrs wrapped in stray „…" quotes (flagged in review '
+            'of #339):\n' + '\n'.join(offenders)
+        )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,7 +5,7 @@ import sqlite3
 import tempfile
 import pytest
 from app import db as _db_ext
-from app.models import Vehicle, FuelLog
+from app.models import Vehicle, FuelLog, Expense, Trip, ChargingSession
 
 
 # ---------------------------------------------------------------------------
@@ -604,3 +604,209 @@ class TestCsvImportUsDateFormat:
         )
         log = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).one()
         assert log.date == date(2026, 1, 12)
+
+
+# ---------------------------------------------------------------------------
+# Spritmonitor CSV import (semicolon-delimited, German format)
+# ---------------------------------------------------------------------------
+
+def make_spritmonitor_csv():
+    """Create a minimal Spritmonitor CSV export."""
+    content = (
+        'Datum;Km-Stand;Teil-Km;Spritmenge;Kosten;W\u00e4hrung;Tankart;Reifen;Strecken;'
+        'Fahrweise;Kraftstoff;Bemerkung;Verbrauch;BC-Verbrauch;BC-Spritmenge;'
+        'BC-Geschwindigkeit;Tankstelle;Land;Gro\u00dfraum;Ort\n'
+        '08.08.2026;199166;525;22,23;46,44;EUR;1;1;14;2;1;;4,23;;;;;D;;\n'
+        '12.07.2026;198641;599;26,93;53,03;EUR;1;1;14;3;1;;4,5;;;;;D;;\n'
+        '24.06.2026;198042;542,5;26,12;44,12;EUR;1;1;14;3;1;Testtankung;4,81;;;;;D;;\n'
+    )
+    return content.encode('utf-8')
+
+
+class TestSpritmonitorCsvImport:
+    """End-to-end import of a Spritmonitor semicolon-delimited CSV."""
+
+    def test_preview_detects_semicolon_delimiter(self, auth_client, sample_vehicle):
+        """Preview step should correctly parse semicolon-delimited CSV."""
+        data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'file': (io.BytesIO(make_spritmonitor_csv()), 'spritmonitor.csv'),
+        }
+        resp = auth_client.post(
+            '/api/import/csv/preview',
+            data=data,
+            content_type='multipart/form-data',
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'Datum' in html
+        assert 'Km-Stand' in html
+        assert 'Spritmenge' in html
+
+    def test_full_import_flow(self, auth_client, sample_vehicle):
+        """Full preview→execute flow imports Spritmonitor records correctly."""
+        from datetime import date
+
+        # Step 1: Preview
+        preview_data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'file': (io.BytesIO(make_spritmonitor_csv()), 'spritmonitor.csv'),
+        }
+        preview_resp = auth_client.post(
+            '/api/import/csv/preview',
+            data=preview_data,
+            content_type='multipart/form-data',
+        )
+        assert preview_resp.status_code == 200
+
+        # Step 2: Execute with Spritmonitor column mappings
+        # Columns: Datum(0), Km-Stand(1), Teil-Km(2), Spritmenge(3), Kosten(4),
+        #          Währung(5), Tankart(6), ..., Bemerkung(11), ...
+        execute_data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'date_format': 'DD/MM/YYYY',
+            'mapping_0': 'date',
+            'mapping_1': 'odometer',
+            'mapping_3': 'volume',
+            'mapping_4': 'total_cost',
+            'mapping_6': 'is_full_tank',
+            'mapping_11': 'notes',
+        }
+        execute_resp = auth_client.post(
+            '/api/import/csv/execute',
+            data=execute_data,
+            content_type='multipart/form-data',
+        )
+        assert execute_resp.status_code == 302
+
+        logs = FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).order_by(FuelLog.date).all()
+        assert len(logs) == 3
+
+        # Check first record (oldest: 24.06.2026)
+        assert logs[0].date == date(2026, 6, 24)
+        assert logs[0].odometer == 198042
+        assert abs(logs[0].volume - 26.12) < 0.01
+        assert abs(logs[0].total_cost - 44.12) < 0.01
+        assert logs[0].price_per_unit == pytest.approx(44.12 / 26.12, abs=0.001)
+        assert logs[0].is_full_tank is True
+        assert logs[0].notes == 'Testtankung'
+
+        # Check last record (newest: 08.08.2026)
+        assert logs[2].date == date(2026, 8, 8)
+        assert logs[2].odometer == 199166
+        assert abs(logs[2].volume - 22.23) < 0.01
+
+    def test_auto_suggest_maps_german_columns(self, auth_client, sample_vehicle):
+        """Auto-suggest should map Spritmonitor German column names."""
+        data = {
+            'data_type': 'fuel_logs',
+            'vehicle_id': str(sample_vehicle.id),
+            'file': (io.BytesIO(make_spritmonitor_csv()), 'spritmonitor.csv'),
+        }
+        resp = auth_client.post(
+            '/api/import/csv/preview',
+            data=data,
+            content_type='multipart/form-data',
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        # The mapping page should auto-select fields for German column names
+        # Check that "date" is pre-selected for "Datum"
+        assert 'selected' in html
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection during CSV import
+# ---------------------------------------------------------------------------
+
+class TestCsvImportDuplicateDetection:
+    """Importing the same CSV twice should skip duplicates on the second run."""
+
+    def _preview_and_execute(self, auth_client, vehicle_id, data_type, csv_bytes,
+                             mappings, date_format='auto'):
+        """Run preview→execute and return the final (followed) response."""
+        preview_resp = auth_client.post(
+            '/api/import/csv/preview',
+            data={
+                'data_type': data_type,
+                'vehicle_id': str(vehicle_id),
+                'file': (io.BytesIO(csv_bytes), 'import.csv'),
+            },
+            content_type='multipart/form-data',
+        )
+        assert preview_resp.status_code == 200
+        form = {'data_type': data_type, 'vehicle_id': str(vehicle_id),
+                'date_format': date_format}
+        form.update(mappings)
+        return auth_client.post(
+            '/api/import/csv/execute', data=form,
+            content_type='multipart/form-data',
+            follow_redirects=True,
+        )
+
+    def test_fuel_logs_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,odometer,volume,total_cost\n2024-03-01,20000,35.0,52.50\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'odometer',
+                    'mapping_2': 'volume', 'mapping_3': 'total_cost'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'fuel_logs', csv, mappings)
+        assert FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'fuel_logs', csv, mappings)
+        html = resp.data.decode()
+        assert '0 fuel logs imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert FuelLog.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+    def test_expenses_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,category,description,cost\n2024-03-01,maintenance,Oil change,75.00\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'category',
+                    'mapping_2': 'description', 'mapping_3': 'cost'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'expenses', csv, mappings)
+        assert Expense.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'expenses', csv, mappings)
+        html = resp.data.decode()
+        assert '0 expenses imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert Expense.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+    def test_trips_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,start_odometer,end_odometer,purpose\n2024-03-01,20000,20050,business\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'start_odometer',
+                    'mapping_2': 'end_odometer', 'mapping_3': 'purpose'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'trips', csv, mappings)
+        assert Trip.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'trips', csv, mappings)
+        html = resp.data.decode()
+        assert '0 trips imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert Trip.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+    def test_charging_sessions_skips_duplicates(self, auth_client, sample_vehicle):
+        csv = b'date,kwh_added,total_cost,location\n2024-03-01,40.0,12.00,Home\n'
+        mappings = {'mapping_0': 'date', 'mapping_1': 'kwh_added',
+                    'mapping_2': 'total_cost', 'mapping_3': 'location'}
+
+        self._preview_and_execute(auth_client, sample_vehicle.id,
+                                  'charging_sessions', csv, mappings)
+        assert ChargingSession.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1
+
+        resp = self._preview_and_execute(auth_client, sample_vehicle.id,
+                                         'charging_sessions', csv, mappings)
+        html = resp.data.decode()
+        assert '0 charging sessions imported' in html.lower()
+        assert '1 duplicate' in html.lower()
+        assert ChargingSession.query.filter_by(vehicle_id=sample_vehicle.id).count() == 1

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -14,6 +14,15 @@ two structural invariants that caused it:
 
 Elements hidden at phone width (``hidden`` with a breakpoint prefix to reveal
 them, such as the desktop nav bar) are ignored — they are not on screen.
+
+Issue #347 added a third invariant, covering the navigation only:
+
+3. No element in the nav paints a dark-mode background it never asked for.
+   ``dark:bg-*`` applies at all times, so writing it where ``dark:hover:bg-*``
+   was meant leaves the colour on permanently. An element that sets a hover
+   background but no resting one wants nothing behind it until it is hovered,
+   in dark mode as much as in light, so a resting ``dark:bg-*`` on it is
+   always a mistake.
 """
 
 import re
@@ -131,6 +140,51 @@ def scan(html):
     return scanner
 
 
+class NavBackgroundScanner(HTMLParser):
+    """Collects nav elements carrying a resting dark background they never asked for.
+
+    The mobile menu lives inside ``<nav>``, so scanning the nav subtree covers
+    it on every page without needing to find the menu itself.
+    """
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._depth = 0
+        self.offenders = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'nav':
+            self._depth += 1
+            return
+        if not self._depth:
+            return
+
+        classes = _classes(attrs)
+        resting_dark = {c for c in classes if c.startswith('dark:bg-')}
+        # A hover colour with no resting one: the element is transparent until
+        # hovered, so it must be transparent in dark mode too.
+        if not resting_dark:
+            return
+        if not any(c.startswith('hover:bg-') for c in classes):
+            return
+        if any(c.startswith('bg-') for c in classes):
+            return
+        self.offenders.append(' '.join(sorted(resting_dark)))
+
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs)
+
+    def handle_endtag(self, tag):
+        if tag == 'nav' and self._depth:
+            self._depth -= 1
+
+
+def scan_nav(html):
+    scanner = NavBackgroundScanner()
+    scanner.feed(html)
+    return scanner
+
+
 @pytest.fixture
 def populated(app, test_user, sample_vehicle, sample_fuel_log, sample_expense,
               sample_trip, sample_charging_session):
@@ -231,6 +285,50 @@ def test_admin_user_table_can_scroll_sideways(admin_client):
     response = admin_client.get('/auth/users')
     assert response.status_code == 200
     assert not scan(response.get_data(as_text=True)).unscrollable_tables
+
+
+def test_nav_has_no_unasked_for_dark_background(auth_client, populated):
+    """The mobile menu must not sit behind a permanent grey block in dark mode.
+
+    Issue #347: every item in the mobile menu, and the hamburger that opens it,
+    carried a stray ``dark:bg-gray-600`` next to an already-correct
+    ``dark:hover:bg-gray-700``. In dark mode that painted each item a lighter
+    grey than the ``dark:bg-gray-800`` nav around it, at rest rather than on
+    hover, on every page of the app.
+    """
+    offenders = {}
+    for path in _pages(populated):
+        response = auth_client.get(path)
+        assert response.status_code == 200, path
+        rows = scan_nav(response.get_data(as_text=True)).offenders
+        if rows:
+            offenders[path] = rows
+    assert not offenders, f'nav elements with a resting dark background: {offenders}'
+
+
+def test_nav_scanner_spots_a_stray_dark_background():
+    """The scanner itself: only a resting dark background on a hover-only element."""
+    item = '<nav><a class="{cls}">Fuel</a></nav>'
+
+    # The #347 bug: dark:bg-* where dark:hover:bg-* was meant.
+    assert scan_nav(item.format(
+        cls='block px-4 hover:bg-gray-100 dark:bg-gray-600 dark:hover:bg-gray-700'
+    )).offenders
+
+    # Fixed: the hover colour is the only background, in both modes.
+    assert not scan_nav(item.format(
+        cls='block px-4 hover:bg-gray-100 dark:hover:bg-gray-700'
+    )).offenders
+
+    # An element with a resting background in both modes is meant to have one.
+    assert not scan_nav(item.format(
+        cls='block px-4 bg-white dark:bg-gray-800 hover:bg-gray-50'
+    )).offenders
+
+    # Outside the nav this scanner says nothing.
+    assert not scan_nav(
+        '<div><a class="hover:bg-gray-100 dark:bg-gray-600">Fuel</a></div>'
+    ).offenders
 
 
 def test_scanner_spots_a_bare_table():

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -1,6 +1,6 @@
 import pytest
 from app import db
-from app.models import RecurringExpense
+from app.models import Expense, RecurringExpense
 from datetime import date
 
 
@@ -63,6 +63,50 @@ class TestRecurringNew:
         assert recurring.user_id == test_user.id
         assert recurring.frequency == 'yearly'
 
+    def test_create_recurring_saves_vendor(self, auth_client, sample_vehicle, test_user):
+        """#349: the recurring expense form should capture a vendor so that
+        auto-generated expenses are allocated to it, the same way the
+        one-off expense form does."""
+        resp = auth_client.post('/recurring/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'name': 'Car Insurance',
+            'category': 'insurance',
+            'frequency': 'yearly',
+            'amount': '250.00',
+            'start_date': '2024-01-01',
+            'vendor': 'Acme Insurance Co',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        recurring = RecurringExpense.query.filter_by(name='Car Insurance').first()
+        assert recurring is not None
+        assert recurring.vendor == 'Acme Insurance Co'
+
+    def test_new_form_offers_vendor_field(self, auth_client, sample_vehicle):
+        resp = auth_client.get('/recurring/new')
+        assert resp.status_code == 200
+        assert b'name="vendor"' in resp.data
+
+    def test_generated_expense_gets_the_vendor(self, auth_client, sample_vehicle):
+        """#349: the point of the field — the expense created from the
+        schedule is allocated to the vendor."""
+        auth_client.post('/recurring/new', data={
+            'vehicle_id': str(sample_vehicle.id),
+            'name': 'Breakdown Cover',
+            'category': 'insurance',
+            'frequency': 'yearly',
+            'amount': '90.00',
+            'start_date': '2024-01-01',
+            'vendor': 'Acme Recovery',
+        }, follow_redirects=True)
+        recurring = RecurringExpense.query.filter_by(name='Breakdown Cover').first()
+
+        resp = auth_client.post(f'/recurring/{recurring.id}/generate', follow_redirects=True)
+        assert resp.status_code == 200
+
+        expense = Expense.query.filter_by(vehicle_id=sample_vehicle.id).first()
+        assert expense is not None
+        assert expense.vendor == 'Acme Recovery'
+
 
 class TestRecurringEdit:
     def test_edit_requires_auth(self, client, sample_recurring):
@@ -88,6 +132,30 @@ class TestRecurringEdit:
         db.session.refresh(sample_recurring)
         assert sample_recurring.name == 'Updated Insurance'
         assert sample_recurring.frequency == 'quarterly'
+
+    def test_edit_recurring_saves_vendor(self, auth_client, sample_recurring):
+        """#349: editing a recurring expense should let you set the vendor
+        so it flows through to auto-generated expenses."""
+        resp = auth_client.post(f'/recurring/{sample_recurring.id}/edit', data={
+            'name': sample_recurring.name,
+            'category': sample_recurring.category,
+            'frequency': sample_recurring.frequency,
+            'amount': '100.00',
+            'start_date': '2024-01-01',
+            'next_due': '2024-02-01',
+            'remind_days_before': '7',
+            'vendor': 'Acme Insurance Co',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        db.session.refresh(sample_recurring)
+        assert sample_recurring.vendor == 'Acme Insurance Co'
+
+    def test_edit_form_prefills_vendor(self, auth_client, sample_recurring):
+        sample_recurring.vendor = 'Acme Insurance Co'
+        db.session.commit()
+        resp = auth_client.get(f'/recurring/{sample_recurring.id}/edit')
+        assert resp.status_code == 200
+        assert b'Acme Insurance Co' in resp.data
 
 
 class TestRecurringDelete:

--- a/tests/test_release_0_42_0.py
+++ b/tests/test_release_0_42_0.py
@@ -17,6 +17,9 @@ import config
 BASE_DIR = Path(__file__).resolve().parent.parent
 CHANGELOG = BASE_DIR / 'CHANGELOG.md'
 
+# The day 0.42.0 goes out on the weekly auto-release (#356).
+RELEASE_DATE = '2026-09-02'
+
 
 def _changelog_text():
     return CHANGELOG.read_text(encoding='utf-8')
@@ -34,10 +37,20 @@ def test_app_version_is_bumped_to_0_42_0():
     assert config.APP_VERSION == '0.42.0'
 
 
-def test_changelog_has_a_dated_0_42_0_section():
+def test_changelog_dates_0_42_0_to_the_release_date():
+    # The date is the day 0.42.0 ships on the weekly auto-release, not the day
+    # the section was written (#356). Asserting the exact date rather than the
+    # YYYY-MM-DD shape is deliberate: a pattern check let a wrong date through
+    # once already. If the release slips, this failing is the cue to re-date
+    # the heading before cutting.
     assert re.search(
-        r'^## \[0\.42\.0\] - \d{4}-\d{2}-\d{2}$', _changelog_text(), re.MULTILINE
-    ), "CHANGELOG.md has no dated '## [0.42.0] - YYYY-MM-DD' heading"
+        rf'^## \[0\.42\.0\] - {re.escape(RELEASE_DATE)}$',
+        _changelog_text(),
+        re.MULTILINE,
+    ), (
+        f"CHANGELOG.md's 0.42.0 heading must read "
+        f"'## [0.42.0] - {RELEASE_DATE}', the date the release ships"
+    )
 
 
 def test_0_42_0_section_sits_above_0_41_4():

--- a/tests/test_release_0_42_0.py
+++ b/tests/test_release_0_42_0.py
@@ -1,0 +1,72 @@
+"""Release prep for 0.42.0: version bump and changelog (#354).
+
+Six fixes queued for release (#347-#352) are on dev and verified there, but
+dev still reports the previous release: APP_VERSION in config.py and
+CHANGELOG.md's newest section both still say 0.41.4. The weekly auto-release
+would otherwise ship these commits as an unlabelled continuation of 0.41.4.
+
+This pins CLAUDE.md's "Creating a Release" steps 1-2 only: the version bump
+and the changelog section. It does not touch tagging, main, or gh -- those
+remain out of scope.
+"""
+import re
+from pathlib import Path
+
+import config
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CHANGELOG = BASE_DIR / 'CHANGELOG.md'
+
+
+def _changelog_text():
+    return CHANGELOG.read_text(encoding='utf-8')
+
+
+def _section_0_42_0():
+    text = _changelog_text()
+    start = text.find('## [0.42.0]')
+    assert start != -1, "CHANGELOG.md has no ## [0.42.0] section"
+    end = text.find('\n## [', start + 1)
+    return text[start:end if end != -1 else len(text)]
+
+
+def test_app_version_is_bumped_to_0_42_0():
+    assert config.APP_VERSION == '0.42.0'
+
+
+def test_changelog_has_a_dated_0_42_0_section():
+    assert re.search(
+        r'^## \[0\.42\.0\] - \d{4}-\d{2}-\d{2}$', _changelog_text(), re.MULTILINE
+    ), "CHANGELOG.md has no dated '## [0.42.0] - YYYY-MM-DD' heading"
+
+
+def test_0_42_0_section_sits_above_0_41_4():
+    text = _changelog_text()
+    new_pos = text.find('## [0.42.0]')
+    old_pos = text.find('## [0.41.4]')
+    assert new_pos != -1 and old_pos != -1 and new_pos < old_pos, (
+        "the 0.42.0 section must be added above the existing 0.41.4 section"
+    )
+
+
+def test_0_42_0_section_references_all_six_issues():
+    section = _section_0_42_0()
+    missing = [n for n in (347, 348, 349, 350, 351, 352) if f'#{n}' not in section]
+    assert not missing, f"0.42.0 section does not reference: {missing}"
+
+
+def test_vendor_field_issue_is_not_filed_under_fixed():
+    # #349 adds a new vendor field to the recurring-expense form -- a new
+    # capability, not a fix -- so it must not appear under ### Fixed.
+    section = _section_0_42_0()
+    fixed_start = section.find('### Fixed')
+    if fixed_start == -1:
+        return
+    next_heading = re.search(r'\n### ', section[fixed_start + 1:])
+    fixed_end = (
+        fixed_start + 1 + next_heading.start() if next_heading else len(section)
+    )
+    assert '#349' not in section[fixed_start:fixed_end], (
+        "#349 (recurring-expense vendor field) is filed under ### Fixed; "
+        "it is a new capability and belongs under Added/Changed instead"
+    )

--- a/tests/test_vehicle_charts.py
+++ b/tests/test_vehicle_charts.py
@@ -1,0 +1,65 @@
+"""Vehicle-view chart presentation.
+
+Covers two reported faults on /vehicles/<id>:
+
+- #359: the Expense-by-Category chart's value axis (the x axis, because the bar
+  is horizontal) showed bare numbers with no currency unit.
+- #358: the Fuel Consumption Trend and Fuel Price Trend charts rendered their
+  date labels straight from the API's ISO strings, ignoring Settings > Date
+  Format.
+"""
+
+from app import db
+
+
+class TestExpenseChartCurrency:
+    def test_expense_chart_x_axis_prefixes_currency(self, auth_client, sample_vehicle, sample_expense):
+        """#359: the expense bar chart's x ticks carry the configured currency."""
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        # The symbol is resolved server-side (£ for GBP, escaped as \u00a3 in the
+        # JS string literal by tojson) and used in a ticks callback.
+        assert r'const expenseCurrencySymbol = "\u00a3";' in body
+        assert 'expenseCurrencySymbol + value.toLocaleString()' in body
+
+    def test_expense_chart_currency_is_escaped(self, app, auth_client, sample_vehicle, test_user):
+        """A custom currency is free text, so it must not break out of the JS."""
+        import json
+
+        test_user.currency = 'X"Y'
+        db.session.commit()
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert 'const expenseCurrencySymbol = %s;' % json.dumps('X"Y') in body
+        assert 'const expenseCurrencySymbol = "X"Y";' not in body
+
+
+class TestTrendChartDateFormat:
+    def test_trend_charts_reformat_dates_to_setting(self, auth_client, sample_vehicle):
+        """#358: both trend charts route their ISO labels through the formatter."""
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        # A single formatter is defined once and applied to both series.
+        assert 'function formatChartDate(iso)' in body
+        assert body.count('formatChartDate(d.date)') == 2
+        # It reads the format from the meta tag base.html already exposes,
+        # rather than inventing a second source of truth.
+        assert 'meta[name="date-format"]' in body
+
+    def test_formatter_covers_every_configured_format(self, auth_client, sample_vehicle):
+        """Each of the four Settings date formats has a branch in the formatter."""
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+        body = resp.get_data(as_text=True)
+        for fmt in ('MM/DD/YYYY', 'YYYY-MM-DD', 'DD.MM.YYYY', 'DD/MM/YYYY'):
+            assert "case '%s'" % fmt in body
+
+    def test_date_format_meta_tag_reflects_user_setting(self, auth_client, sample_vehicle, test_user):
+        """The meta tag the formatter reads must carry the user's chosen format."""
+        test_user.date_format = 'DD.MM.YYYY'
+        db.session.commit()
+        resp = auth_client.get(f'/vehicles/{sample_vehicle.id}')
+        body = resp.get_data(as_text=True)
+        assert '<meta name="date-format" content="DD.MM.YYYY">' in body


### PR DESCRIPTION
Release 0.42.0.

Comprehensive changelog:

## [0.42.0] - 2026-09-02

### Added

- The CSV importer understands Spritmonitor.de exports. It sniffs the
  semicolon delimiter those files use, maps their columns onto fuel logs, and
  where a row gives a total and a volume but no unit price it fills the price
  in at `total / volume` rather than leaving it blank. Duplicate rows are
  detected on the fields that actually identify a fill, so re-importing the
  same export does not double up the history. Credit to LukasLJL.
  ([#346](https://github.com/dannymcc/may/pull/346))
- Recurring expenses can record a vendor. The column and the copy of it onto
  each auto-generated expense already existed, but no field on the recurring
  form ever populated it, so the vendor had to be filled in by hand after the
  event. The form now carries a vendor input, with the same known-vendor
  suggestions as the one-off expense form, and both the create and the edit
  route read it. ([#349](https://github.com/dannymcc/may/issues/349))

### Fixed

- The vehicle charts respect the currency and date-format settings. The
  Expense by Category chart drew its value axis (the x axis, the bar being
  horizontal) as bare numbers with no unit, so it was not obvious the figures
  were money; those ticks now carry the configured currency symbol. And the
  Fuel Consumption Trend and Fuel Price Trend charts labelled their date axis
  straight from the API's ISO strings, ignoring Settings > Date Format; both
  now format each label to the chosen pattern, reading it from the same source
  the rest of the page does.
  ([#359](https://github.com/dannymcc/may/issues/359),
  [#358](https://github.com/dannymcc/may/issues/358))
- The mobile navigation no longer sits in a lighter grey block in dark mode.
  Every item in the menu, the hamburger button that opens it and the desktop
  "More" dropdown carried a stray `dark:bg-gray-600` beside an already-correct
  `dark:hover:bg-gray-700`. A resting background applies at all times, so the
  colour meant for hover was painted on permanently, against a darker nav bar.
  The 28 stray classes are deleted — each had the right hover class beside it,
  so nothing had to be guessed about the intended colour — and the layout tests
  gain a nav-scoped invariant that would catch the same slip again.
  ([#347](https://github.com/dannymcc/may/issues/347))
- The "Check Now" button on Settings > About now refreshes the Current Version
  it shows. The check reported update status but left the version as rendered
  at page load, so after updating the host over SSH the page went on showing
  the old number until the browser was reloaded. The check-updates response
  now carries the display version, dev channel's "-dev+sha" suffix intact, and
  the page updates in place.
  ([#348](https://github.com/dannymcc/may/issues/348))
- The Hungarian catalogue addresses the reader informally throughout. Hungarian
  distinguishes formal from informal address and the shipped catalogue used
  both: everything predating the bulk fill in #340 was informal, but a handful
  of the strings that fill added were written formal, and the trip templates
  strapline managed both registers in one sentence. Twenty-eight msgstrs are
  rewritten to the informal register the catalogue had already settled on.
  Register only — no wording otherwise changes.
  ([#350](https://github.com/dannymcc/may/issues/350))
- Six further Hungarian corrections, taken from #339 and applied against the
  catalogue as it now stands: the missing accent on "Kilometres (km)", the
  "toppic-ot" typo in the ntfy hint, "SMTP Host" translated rather than left
  as an English loanword, the "/" convention the catalogue already used for
  "Cost per kWh" extended to its neighbours, and one word for the instrument
  across the Odometer family — "Last Odometer" had been the mileage covered
  rather than the reading on the dial. #339's change of the bare msgid
  "Registration" is deliberately not carried over: since #342 that string
  carries the registration fee only, not the plate. Credit to burgatshow.
  ([#352](https://github.com/dannymcc/may/issues/352))

### Changed

- Minor corrections to the German catalogue: "Schnelladung" reads "DC
  Schnelladung", and a few multi-line entries were unwrapped (gettext
  concatenates the adjacent literals, so the msgids are unchanged). Credit to
  solluh. ([#361](https://github.com/dannymcc/may/pull/361))
- The nine other catalogues filled by #340 (de, fr, es, it, pt, nl, pl, cs and
  ru) were audited for the same formal/informal break as the Hungarian one and
  found consistent, so no msgstr needed correcting. Tests now record the
  register each catalogue settled on and fail if a future bulk fill introduces
  the other one, checking imperative conjugation as well as address pronouns
  for the pro-drop languages.
  ([#351](https://github.com/dannymcc/may/issues/351))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import Spritmonitor.de CSV files with automatic delimiter and column detection.
  * Prevent duplicate imports and report skipped records.
  * Add optional vendor/service provider details to recurring expenses, with autocomplete suggestions.
* **Bug Fixes**
  * Correct vehicle chart date and currency formatting.
  * Improve mobile navigation dark-mode styling.
  * Refresh the displayed application version after update checks.
  * Correct Hungarian catalogue translations and consistency issues.
* **Documentation**
  * Updated the changelog and recurring-expenses documentation for version 0.42.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->