### PR TITLE
Release 0.42.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This file starts at 0.28.0. Notes for earlier releases are on the
 [GitHub releases page](https://github.com/dannymcc/may/releases).
 
+## [0.42.1] - 2026-09-02
+
+### Fixed
+
+- Mobile list rows no longer crush the name to a single letter. On the
+  Recurring Expenses list and the Upcoming Reminders row, the name sat in a
+  flex row beside a right-hand cluster of metadata and action buttons that
+  could not be told not to shrink, so on a phone-width screen the browser
+  shrank both sides to fit and the name's ellipsis collapsed it to the first
+  letter — "R..." for "Roadside Assistance", half a letter on a reminder
+  title. The right-hand cluster is now pinned at its natural width, and the
+  name column truncates gracefully with room rather than vanishing.
+  ([#347](https://github.com/dannymcc/may/issues/347))
+
 ## [0.42.0] - 2026-09-02
 
 ### Added

--- a/app/templates/recurring/index.html
+++ b/app/templates/recurring/index.html
@@ -55,7 +55,7 @@
                         </p>
                     </div>
                 </div>
-                <div class="ml-4 flex items-center gap-4">
+                <div class="ml-4 flex flex-shrink-0 items-center gap-4">
                     {% if item.amount %}
                     <div class="text-right">
                         <p class="text-sm font-medium text-gray-900 dark:text-white">{{ item.vehicle.currency_symbol }}{{ item.amount|money }}</p>

--- a/app/templates/reminders/_reminder_row.html
+++ b/app/templates/reminders/_reminder_row.html
@@ -1,6 +1,6 @@
 <div class="p-4 hover:bg-gray-50 dark:bg-gray-700">
     <div class="flex items-center justify-between">
-        <div class="flex items-center space-x-4">
+        <div class="flex items-center space-x-4 min-w-0">
             <!-- Complete checkbox / status -->
             {% if not reminder.is_completed %}
             {% if can_write('reminders') %}
@@ -27,7 +27,7 @@
 
             <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2">
-                    <h3 class="text-sm font-medium text-gray-900 dark:text-white {% if reminder.is_completed %}line-through text-gray-500 dark:text-gray-400{% endif %}">
+                    <h3 class="text-sm font-medium text-gray-900 dark:text-white truncate {% if reminder.is_completed %}line-through text-gray-500 dark:text-gray-400{% endif %}">
                         {{ reminder.title }}
                     </h3>
                     <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
@@ -56,7 +56,7 @@
             </div>
         </div>
 
-        <div class="flex items-center space-x-4">
+        <div class="flex flex-shrink-0 items-center space-x-4">
             <!-- Due date -->
             <div class="text-right">
                 <p class="text-sm {% if reminder.is_overdue() %}text-red-600 font-medium{% elif reminder.is_upcoming(7) %}text-amber-600{% else %}text-gray-900 dark:text-white{% endif %}">

--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ basedir = Path(__file__).parent.absolute()
 load_dotenv(basedir / '.env')
 
 
-APP_VERSION = '0.42.0'
+APP_VERSION = '0.42.1'
 RELEASE_CHANNEL = os.environ.get('RELEASE_CHANNEL', 'stable')
 GIT_SHA = os.environ.get('GIT_SHA', '')[:7]  # Short SHA
 GITHUB_REPO = 'dannymcc/may'

--- a/tests/test_mobile_row_truncation.py
+++ b/tests/test_mobile_row_truncation.py
@@ -1,0 +1,71 @@
+"""Mobile list rows must not crush the name column to a single letter (#347).
+
+Both the Recurring Expenses list (`recurring/index.html`) and the Upcoming
+Reminders row (`reminders/_reminder_row.html`) lay each entry out as a flex row:
+a name/title block on the left and a cluster of metadata plus action buttons on
+the right. The right cluster had no `flex-shrink-0`, so on a narrow (mobile)
+viewport flexbox shrank *both* sides to fit, and the `truncate` on the name then
+collapsed it to the first letter ("R..." for "Roadside Assistance").
+
+The fix pins the right cluster with `flex-shrink-0` and gives the name column a
+`min-w-0` ancestor so it truncates gracefully with room, rather than vanishing.
+These tests assert that structure survives, and that the full name is still in
+the DOM (truncation is visual only, so nothing is actually lost).
+"""
+
+from datetime import date
+
+from app import db
+from app.models import RecurringExpense, Reminder
+
+
+LONG_NAME = 'Roadside Assistance And Breakdown Cover Premium Plan'
+
+
+class TestRecurringRowLayout:
+    def _make(self, test_user, sample_vehicle):
+        rec = RecurringExpense(
+            vehicle_id=sample_vehicle.id, user_id=test_user.id,
+            name=LONG_NAME, category='insurance', frequency='monthly',
+            amount=12.50, start_date=date(2024, 1, 1), next_due=date(2024, 2, 1),
+            is_active=True,
+        )
+        db.session.add(rec)
+        db.session.commit()
+        return rec
+
+    def test_recurring_row_protects_the_name_column(self, auth_client, test_user, sample_vehicle):
+        self._make(test_user, sample_vehicle)
+        resp = auth_client.get('/recurring/')
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        # The full name survives in the DOM — truncation is CSS-only.
+        assert LONG_NAME in body
+        # The action/metadata cluster must not shrink and steal the name's width.
+        assert 'flex flex-shrink-0 items-center gap-4' in body
+        # The name still truncates gracefully when there genuinely isn't room.
+        assert 'truncate' in body
+
+
+class TestReminderRowLayout:
+    def _make(self, test_user, sample_vehicle):
+        rem = Reminder(
+            vehicle_id=sample_vehicle.id, user_id=test_user.id,
+            title=LONG_NAME, reminder_type='insurance',
+            due_date=date(2024, 6, 1), recurrence='none',
+        )
+        db.session.add(rem)
+        db.session.commit()
+        return rem
+
+    def test_reminder_row_protects_the_title_column(self, auth_client, test_user, sample_vehicle):
+        self._make(test_user, sample_vehicle)
+        resp = auth_client.get('/reminders/')
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert LONG_NAME in body
+        # Right cluster (due date + actions) pinned so it can't crush the title.
+        assert 'flex flex-shrink-0 items-center space-x-4' in body
+        # Left block carries min-w-0 so the truncate on the title actually engages.
+        assert 'flex items-center space-x-4 min-w-0' in body
+        assert 'truncate' in body

--- a/tests/test_release_0_42_0.py
+++ b/tests/test_release_0_42_0.py
@@ -33,8 +33,11 @@ def _section_0_42_0():
     return text[start:end if end != -1 else len(text)]
 
 
-def test_app_version_is_bumped_to_0_42_0():
-    assert config.APP_VERSION == '0.42.0'
+def test_app_version_is_bumped_to_current_release():
+    # Bumped to 0.42.1 for the mobile-row-truncation patch (#347). The 0.42.0
+    # changelog assertions below stay pinned — that section is history and must
+    # not be rewritten by a later release.
+    assert config.APP_VERSION == '0.42.1'
 
 
 def test_changelog_dates_0_42_0_to_the_release_date():


### PR DESCRIPTION
Release 0.42.1 — patch.

Carries the mobile list-row name truncation fix (#347).

Changelog:

## [0.42.1] - 2026-09-02

### Fixed

- Mobile list rows no longer crush the name to a single letter. On the
  Recurring Expenses list and the Upcoming Reminders row, the name sat in a
  flex row beside a right-hand cluster of metadata and action buttons that
  could not be told not to shrink, so on a phone-width screen the browser
  shrank both sides to fit and the name's ellipsis collapsed it to the first
  letter — "R..." for "Roadside Assistance", half a letter on a reminder
  title. The right-hand cluster is now pinned at its natural width, and the
  name column truncates gracefully with room rather than vanishing.
  ([#347](https://github.com/dannymcc/may/issues/347))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile layouts for recurring expenses and upcoming reminders.
  * Long names now truncate gracefully while dates, amounts, and action buttons remain fully visible.

* **Documentation**
  * Added release notes for version 0.42.1, including the mobile layout fix.

* **Tests**
  * Added regression coverage for mobile row truncation and layout stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->