### PR TITLE
Add support for MySQL/MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ SECRET_KEY=your-secure-random-string
 # Database location (optional, defaults to SQLite in the app's data folder)
 # Note the slashes: sqlite:///path is relative, sqlite:////path is absolute.
 DATABASE_URL=sqlite:////srv/may/data/may.db
-# PostgreSQL is also supported:
+# PostgreSQL, MySQL, and MariaDB are also supported:
 # DATABASE_URL=postgresql://user:password@host:5432/may
+# DATABASE_URL=mysql+pymysql://user:password@host:3306/may
 
 # Upload folder for attachments (optional)
 UPLOAD_FOLDER=/srv/may/data/uploads

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ weasyprint>=69.0
 requests>=2.34.2
 python-dateutil>=2.9.0.post0
 psycopg2-binary>=2.9.12
+pymysql>=1.2.0
 pytest>=9.1.1
 pytest-cov>=7.1.0
 coverage>=7.15.4


### PR DESCRIPTION
## Summary

Added support for using MySQL/MariaDB databases

## Changelog

- Added:
  - MySQL/MariaDB support

## Testing

How were these changes tested?

- [x] Tested locally
- [x] Tested with Docker image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration guidance to list MySQL and MariaDB as supported database options alongside PostgreSQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->